### PR TITLE
[#4] Add CI pipeline for lint and type-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "next": "16.1.6",


### PR DESCRIPTION
## Summary
- Added `.github/workflows/ci.yml` — runs ESLint + TypeScript type-check (`tsc --noEmit`) on every PR to `main`
- Added `typecheck` script to `package.json`

## Acceptance Criteria
- [x] GitHub Actions runs lint + type-check on PR

## Test Plan
- [ ] Verify CI workflow triggers on this PR
- [ ] Confirm both lint and typecheck steps pass

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)