### PR TITLE
[#3] Add CLAUDE.md project documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# PlotLink
+
+Collaborative on-chain storytelling platform. Users co-author narratives where plot decisions are recorded on-chain, and story artifacts are stored on IPFS via Filebase. The app is mobile-first with a terminal/monospace design aesthetic.
+
+## Tech Stack
+
+- **Framework**: Next.js 16 (App Router)
+- **Language**: TypeScript
+- **Styling**: Tailwind CSS v4
+- **Auth & Database**: Supabase
+- **Storage**: Filebase (IPFS)
+- **Chain**: EVM-compatible (RPC + contract interaction)
+
+## Repo Structure
+
+```
+src/
+  app/          # Next.js App Router pages and layouts
+    globals.css # Design tokens (CSS custom properties)
+    layout.tsx  # Root layout (monospace font)
+    page.tsx    # Home page
+.github/
+  workflows/
+    ci.yml      # Lint + type-check on PRs
+```
+
+## Commands
+
+```sh
+npm run dev        # Start dev server
+npm run build      # Production build
+npm run lint       # ESLint
+npm run typecheck  # TypeScript type-check (tsc --noEmit)
+```
+
+## Design System
+
+Terminal aesthetic: dark background (`#0a0a0a`), monospace font (Geist Mono), green accent (`#00ff88`), outline-based UI. CSS custom properties defined in `src/app/globals.css`.
+
+## Proposal
+
+See [`docs/PROPOSAL-plotlink.md`](docs/PROPOSAL-plotlink.md) for the full project proposal.
+
+## Environment Variables
+
+See [`.env.example`](.env.example) for all required environment variables.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Terminal aesthetic: dark background (`#0a0a0a`), monospace font (Geist Mono), gr
 
 ## Proposal
 
-See [`docs/PROPOSAL-plotlink.md`](docs/PROPOSAL-plotlink.md) for the full project proposal.
+The full project proposal will be added at `docs/PROPOSAL-plotlink.md` in a future ticket.
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary
- Created `CLAUDE.md` with project purpose, tech stack, repo structure, build/test commands, design system notes, and links to proposal and env vars

## Acceptance Criteria
- [x] `CLAUDE.md` exists with project context

## Test Plan
- [ ] Verify `CLAUDE.md` is present and covers required sections

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)