### PR TITLE
[#205] Shared RPC client with fallback transport

### DIFF
--- a/lib/rpc.ts
+++ b/lib/rpc.ts
@@ -1,0 +1,22 @@
+import { createPublicClient, http, fallback } from "viem";
+import { base, baseSepolia } from "viem/chains";
+
+const chainId = Number(process.env.NEXT_PUBLIC_CHAIN_ID || "84532");
+const chain = chainId === 8453 ? base : baseSepolia;
+
+const customRpc = process.env.NEXT_PUBLIC_RPC_URL;
+
+const transport = customRpc
+  ? fallback([http(customRpc), http()])
+  : http();
+
+/**
+ * Shared public client for reading from Base (or Base Sepolia).
+ *
+ * Chain is selected via NEXT_PUBLIC_CHAIN_ID (default: 84532 / Base Sepolia).
+ * Uses NEXT_PUBLIC_RPC_URL with a fallback to the chain's default public RPC.
+ */
+export const publicClient = createPublicClient({
+  chain,
+  transport,
+});

--- a/lib/viem.ts
+++ b/lib/viem.ts
@@ -1,12 +1,3 @@
-import { createPublicClient, http } from "viem";
-import { base } from "viem/chains";
-
-/**
- * Public client for reading from Base.
- *
- * Uses the default Base RPC. Override via BASE_RPC_URL env var.
- */
-export const publicClient = createPublicClient({
-  chain: base,
-  transport: http(process.env.BASE_RPC_URL || undefined),
-});
+// Re-export from lib/rpc.ts — this file exists for backward compatibility.
+// New code should import from "lib/rpc" directly.
+export { publicClient } from "./rpc";


### PR DESCRIPTION
## Summary
- Create `lib/rpc.ts` with shared public client for Base/Base Sepolia
- Chain selected via `NEXT_PUBLIC_CHAIN_ID` (default: 84532 / Base Sepolia)
- Fallback transport: tries `NEXT_PUBLIC_RPC_URL` first, falls back to chain default
- Update `lib/viem.ts` to re-export from `lib/rpc.ts` for backward compatibility
- Aligned with wagmi config (same env vars, same chain selection)

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [x] Existing imports from `lib/viem` still work
- [x] New code can import from `lib/rpc` directly

Fixes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)