### PR TITLE
[#68] Add error state rendering to dashboards

### DIFF
--- a/src/app/dashboard/reader/page.tsx
+++ b/src/app/dashboard/reader/page.tsx
@@ -111,7 +111,7 @@ export default function ReaderDashboard() {
           {donations.map((d) => (
             <DonationRow key={d.id} donation={d} />
           ))}
-          {!isLoading && donations.length === 0 && (
+          {!isLoading && !error && donations.length === 0 && (
             <p className="text-muted py-6 text-center text-sm">
               No donations yet.
             </p>

--- a/src/app/dashboard/reader/page.tsx
+++ b/src/app/dashboard/reader/page.tsx
@@ -21,13 +21,14 @@ async function fetchDonationPage(
   if (!supabase) return { rows: [], totalCount: 0 };
   const from = page * PAGE_SIZE;
   const to = from + PAGE_SIZE - 1;
-  const { data, count } = await supabase
+  const { data, count, error } = await supabase
     .from("donations")
     .select("*", { count: "exact" })
     .eq("donor_address", address.toLowerCase())
     .order("block_timestamp", { ascending: false })
     .range(from, to)
     .returns<Donation[]>();
+  if (error) throw error;
   return { rows: data ?? [], totalCount: count ?? 0 };
 }
 
@@ -40,7 +41,7 @@ export default function ReaderDashboard() {
     setPage(0);
   }, [address]);
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: ["reader-donations", address, page],
     queryFn: () => fetchDonationPage(address!, page),
     enabled: isConnected && !!address,
@@ -99,6 +100,12 @@ export default function ReaderDashboard() {
         </p>
 
         {isLoading && <p className="text-muted mt-4 text-sm">Loading...</p>}
+
+        {error && (
+          <p className="mt-4 text-sm text-red-400">
+            Failed to load donations. Please try again.
+          </p>
+        )}
 
         <div className="mt-4 space-y-2">
           {donations.map((d) => (

--- a/src/app/dashboard/writer/page.tsx
+++ b/src/app/dashboard/writer/page.tsx
@@ -11,20 +11,21 @@ async function fetchWriterStorylines(
   address: string,
 ): Promise<Storyline[]> {
   if (!supabase) return [];
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("storylines")
     .select("*")
     .eq("writer_address", address.toLowerCase())
     .eq("hidden", false)
     .order("block_timestamp", { ascending: false })
     .returns<Storyline[]>();
+  if (error) throw error;
   return data ?? [];
 }
 
 export default function WriterDashboard() {
   const { address, isConnected } = useAccount();
 
-  const { data: storylines = [], isLoading } = useQuery({
+  const { data: storylines = [], isLoading, error } = useQuery({
     queryKey: ["writer-storylines", address],
     queryFn: () => fetchWriterStorylines(address!),
     enabled: isConnected && !!address,
@@ -52,6 +53,12 @@ export default function WriterDashboard() {
       </p>
 
       {isLoading && <p className="text-muted mt-8 text-sm">Loading...</p>}
+
+      {error && (
+        <p className="mt-8 text-sm text-red-400">
+          Failed to load storylines. Please try again.
+        </p>
+      )}
 
       <div className="mt-8 space-y-4">
         {storylines.map((s) => (

--- a/src/app/dashboard/writer/page.tsx
+++ b/src/app/dashboard/writer/page.tsx
@@ -64,7 +64,7 @@ export default function WriterDashboard() {
         {storylines.map((s) => (
           <StorylineDetail key={s.id} storyline={s} />
         ))}
-        {!isLoading && storylines.length === 0 && (
+        {!isLoading && !error && storylines.length === 0 && (
           <p className="text-muted py-8 text-center text-sm">
             No storylines yet.
           </p>


### PR DESCRIPTION
## Summary
- Surface Supabase query errors by throwing from fetch functions so `useQuery` captures them
- Render user-visible error messages ("Failed to load storylines/donations. Please try again.") in both writer and reader dashboards
- Previously, failed queries silently showed the empty state with no indication of failure

Fixes #68

## Test plan
- [ ] Simulate Supabase failure (e.g. invalid anon key) and verify error message appears on both dashboards
- [ ] Verify normal operation unchanged (successful queries render data as before)
- [ ] `npm run lint` and `npm run typecheck` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)