### PR TITLE
[#78] Ratings schema + RLS policy

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -189,7 +189,7 @@ export interface Database {
           id?: never;
           storyline_id?: number;
           rater_address?: string;
-          score?: number;
+          rating?: number;
           comment?: string | null;
           created_at?: string;
           updated_at?: string;

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -171,7 +171,7 @@ export interface Database {
           id: number;
           storyline_id: number;
           rater_address: string;
-          score: number;
+          rating: number;
           comment: string | null;
           created_at: string;
           updated_at: string;
@@ -180,7 +180,7 @@ export interface Database {
           id?: never;
           storyline_id: number;
           rater_address: string;
-          score: number;
+          rating: number;
           comment?: string | null;
           created_at?: string;
           updated_at?: string;

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -166,6 +166,35 @@ export interface Database {
           indexed_at?: string;
         };
       };
+      ratings: {
+        Row: {
+          id: number;
+          storyline_id: number;
+          rater_address: string;
+          score: number;
+          comment: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: never;
+          storyline_id: number;
+          rater_address: string;
+          score: number;
+          comment?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: never;
+          storyline_id?: number;
+          rater_address?: string;
+          score?: number;
+          comment?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
     };
   };
 }
@@ -174,3 +203,4 @@ export interface Database {
 export type Storyline = Database["public"]["Tables"]["storylines"]["Row"];
 export type Plot = Database["public"]["Tables"]["plots"]["Row"];
 export type Donation = Database["public"]["Tables"]["donations"]["Row"];
+export type Rating = Database["public"]["Tables"]["ratings"]["Row"];

--- a/supabase/migrations/00005_ratings.sql
+++ b/supabase/migrations/00005_ratings.sql
@@ -3,7 +3,7 @@
 
 CREATE TABLE ratings (
   id          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-  storyline_id BIGINT NOT NULL REFERENCES storylines(id),
+  storyline_id BIGINT NOT NULL REFERENCES storylines(storyline_id),
   rater_address TEXT NOT NULL,
   score       SMALLINT NOT NULL CHECK (score >= 1 AND score <= 5),
   comment     TEXT,
@@ -11,6 +11,8 @@ CREATE TABLE ratings (
   updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
   UNIQUE (storyline_id, rater_address)
 );
+
+CREATE INDEX idx_ratings_storyline ON ratings (storyline_id);
 
 ALTER TABLE ratings ENABLE ROW LEVEL SECURITY;
 

--- a/supabase/migrations/00005_ratings.sql
+++ b/supabase/migrations/00005_ratings.sql
@@ -5,7 +5,7 @@ CREATE TABLE ratings (
   id          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
   storyline_id BIGINT NOT NULL REFERENCES storylines(storyline_id),
   rater_address TEXT NOT NULL,
-  score       SMALLINT NOT NULL CHECK (score >= 1 AND score <= 5),
+  rating      SMALLINT NOT NULL CHECK (rating >= 1 AND rating <= 5),
   comment     TEXT,
   created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),

--- a/supabase/migrations/00005_ratings.sql
+++ b/supabase/migrations/00005_ratings.sql
@@ -1,0 +1,17 @@
+-- Ratings table: one rating per user per storyline (upsert pattern)
+-- Public read, no public write (writes via service role only)
+
+CREATE TABLE ratings (
+  id          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  storyline_id BIGINT NOT NULL REFERENCES storylines(id),
+  rater_address TEXT NOT NULL,
+  score       SMALLINT NOT NULL CHECK (score >= 1 AND score <= 5),
+  comment     TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (storyline_id, rater_address)
+);
+
+ALTER TABLE ratings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read" ON ratings FOR SELECT USING (true);


### PR DESCRIPTION
## Summary
- Added migration `00005_ratings.sql`: creates `ratings` table with score (1-5), comment, unique constraint on `(storyline_id, rater_address)` for upsert
- RLS enabled with public read policy (`FOR SELECT USING (true)`), no public write (writes via service role only)
- Updated `Database` type in `lib/supabase.ts` with `ratings` Row/Insert/Update types
- Added `Rating` convenience type alias

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] Migration creates table with correct columns and constraints
- [ ] RLS allows anonymous SELECT but blocks INSERT/UPDATE/DELETE via anon key

Fixes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)