### PR TITLE
[#92] Bind comment to signed rating message

### DIFF
--- a/src/app/api/ratings/route.ts
+++ b/src/app/api/ratings/route.ts
@@ -78,8 +78,9 @@ export async function POST(req: NextRequest) {
     return error("Missing address, signature, or message");
   }
 
-  // Validate signed message binds to this specific action
-  const expectedMessage = `Rate storyline ${storylineId} with rating ${rating}`;
+  // Validate signed message binds to this specific action (including comment)
+  const boundComment = comment ?? "";
+  const expectedMessage = `Rate storyline ${storylineId} with rating ${rating} comment:${boundComment}`;
   if (message !== expectedMessage) {
     return error(
       `Signed message must be exactly: "${expectedMessage}"`,

--- a/src/components/RatingWidget.tsx
+++ b/src/components/RatingWidget.tsx
@@ -111,7 +111,7 @@ export function RatingWidget({ storylineId, tokenAddress }: RatingWidgetProps) {
       setSuccess(false);
       setSubmitting(true);
 
-      const message = `Rate storyline ${storylineId} with rating ${selectedRating}`;
+      const message = `Rate storyline ${storylineId} with rating ${selectedRating} comment:${comment || ""}`;
       const signature = await signMessageAsync({ message });
 
       const res = await fetch("/api/ratings", {


### PR DESCRIPTION
## Summary

Fixes #92

- Signed message now includes the comment: `Rate storyline {id} with rating {n} comment:{text}`
- Empty comments use an empty string (`comment:`) so the message format is consistent
- Updated both API (`route.ts`) and client (`RatingWidget.tsx`) to use the new format
- Prevents signature replay with a different comment value

## Test plan
- [ ] Submit rating with a comment — signature should bind to that comment
- [ ] Submit rating without a comment — should use `comment:` (empty) in signed message
- [ ] Attempt to replay a signature with a modified comment — should fail verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)