### PR TITLE
[#90] Use actual reserve token decimals in dashboard

### DIFF
--- a/src/components/WriterTradingStats.tsx
+++ b/src/components/WriterTradingStats.tsx
@@ -67,6 +67,7 @@ export function WriterTradingStats({ storyline }: WriterTradingStatsProps) {
     },
   });
 
+  const decimals = tvlData?.decimals;
   const earnings =
     donationsTotal !== undefined && royaltyData
       ? donationsTotal + royaltyData.unclaimed
@@ -79,13 +80,13 @@ export function WriterTradingStats({ storyline }: WriterTradingStatsProps) {
           Earnings
         </span>
         <span className="text-accent font-medium">
-          {earnings !== undefined
-            ? `${formatUnits(earnings, 18)} ${reserveLabel}`
+          {earnings !== undefined && decimals !== undefined
+            ? `${formatUnits(earnings, decimals)} ${reserveLabel}`
             : "—"}
         </span>
         <span className="text-muted block text-[10px]">
-          {donationsTotal !== undefined && `D: ${formatUnits(donationsTotal, 18)}`}
-          {royaltyData && ` R: ${formatUnits(royaltyData.unclaimed, 18)}`}
+          {donationsTotal !== undefined && decimals !== undefined && `D: ${formatUnits(donationsTotal, decimals)}`}
+          {royaltyData && decimals !== undefined && ` R: ${formatUnits(royaltyData.unclaimed, decimals)}`}
         </span>
       </div>
       <div>
@@ -93,7 +94,7 @@ export function WriterTradingStats({ storyline }: WriterTradingStatsProps) {
           Token Price
         </span>
         <span className="text-foreground">
-          {price !== undefined ? `${formatUnits(BigInt(price), 18)} ${reserveLabel}` : "—"}
+          {price !== undefined && decimals !== undefined ? `${formatUnits(BigInt(price), decimals)} ${reserveLabel}` : "—"}
         </span>
       </div>
       <div>


### PR DESCRIPTION
## Summary

Fixes #90

- **WriterTradingStats**: Replaced hardcoded `formatUnits(..., 18)` with `formatUnits(..., decimals)` using decimals from `getTokenTVL()` which reads `reserveToken.decimals()` on-chain
- **ReaderPortfolio**: Already uses `tvlResult?.decimals` correctly (no changes needed)
- Earnings, donations, royalties, and token price all now use actual reserve token decimals

## Test plan
- [ ] Verify earnings/price display with 18-decimal reserve token (WETH) — should be unchanged
- [ ] Verify display with 6-decimal reserve token (USDC) — values should now be correct
- [ ] Values show "—" until TVL data (with decimals) is loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)