### PR TITLE
[#89] Add ISR caching to discover page

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -3,6 +3,8 @@ import { getTrendingStorylines, getRisingStorylines } from "../../../lib/ranking
 import { StoryCard } from "../../components/StoryCard";
 import { TabNav } from "../../components/TabNav";
 
+export const revalidate = 120; // ISR: regenerate at most every 2 minutes
+
 type SearchParams = Promise<{ tab?: string }>;
 
 const TABS = ["new", "trending", "rising", "completed"] as const;


### PR DESCRIPTION
## Summary

Fixes #89

- Added `export const revalidate = 120` to the discover page server component
- Next.js ISR regenerates the page at most every 2 minutes, so the ~200 RPC calls for trending/rising tabs are cached between requests
- Multicall batching for `enrichWithOnChain` not added — the ISR cache eliminates the per-request cost which is the primary issue. Multicall could be a follow-up optimization if needed.

## Test plan
- [ ] Discover page loads normally on all tabs (new, trending, rising, completed)
- [ ] Subsequent loads within 2 minutes are served from cache (faster response)
- [ ] After 2 minutes, page revalidates with fresh data

🤖 Generated with [Claude Code](https://claude.com/claude-code)