### PR TITLE
[#95] Add DB-level lowercase CHECK on rater_address

### DIFF
--- a/supabase/migrations/00006_ratings_address_check.sql
+++ b/supabase/migrations/00006_ratings_address_check.sql
@@ -1,0 +1,4 @@
+-- Enforce lowercase hex addresses at the DB level to prevent dedup issues.
+ALTER TABLE ratings
+  ADD CONSTRAINT ratings_rater_address_lowercase
+  CHECK (rater_address = lower(rater_address));


### PR DESCRIPTION
## Summary

Fixes #95

- Added migration `00006_ratings_address_check.sql` with CHECK constraint: `rater_address = lower(rater_address)`
- Defense-in-depth: prevents mixed-case addresses from breaking the UNIQUE dedup if writes bypass the API

## Test plan
- [ ] Migration applies cleanly on a fresh DB
- [ ] Migration applies cleanly on existing DB (all existing addresses are already lowercase via API)
- [ ] Inserting a mixed-case address directly via SQL is rejected
- [ ] Normal API flow (which lowercases) continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)