### PR TITLE
[#107] Add terminal-style footer component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist_Mono } from "next/font/google";
 import { Providers } from "./providers";
 import { NavBar } from "../components/NavBar";
+import { Footer } from "../components/Footer";
 import "./globals.css";
 
 const geistMono = Geist_Mono({
@@ -24,7 +25,8 @@ export default function RootLayout({
       <body className={`${geistMono.variable} antialiased`}>
         <Providers>
           <NavBar />
-          <div className="pt-11">{children}</div>
+          <div className="pt-11 min-h-screen">{children}</div>
+          <Footer />
         </Providers>
       </body>
     </html>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+
+export function Footer() {
+  return (
+    <footer className="border-t border-[var(--border)] bg-[var(--bg)] px-4 py-6 mt-16">
+      <div className="mx-auto max-w-5xl flex flex-col gap-4 text-xs">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-4 text-muted">
+            <Link href="/discover" className="hover:text-foreground transition-colors">
+              discover
+            </Link>
+            <Link href="/create" className="hover:text-foreground transition-colors">
+              create
+            </Link>
+            <a
+              href="https://github.com/realproject7/plotlink"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-foreground transition-colors"
+            >
+              github
+            </a>
+          </div>
+          <span className="text-muted">
+            built on <span className="text-accent-dim">Base</span>
+          </span>
+        </div>
+        <div className="text-muted/60 text-[10px]">
+          <span className="text-accent-dim">$</span> PlotLink &copy; {new Date().getFullYear()}
+        </div>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #107

- **Footer component** (`src/components/Footer.tsx`): Minimal terminal aesthetic with discover/create/github links, "built on Base" badge, `$ PlotLink © 2026` copyright
- Added to root `layout.tsx` below `{children}` with `min-h-screen` on content to push footer down
- Uses existing design tokens from `globals.css`

## Test plan
- [ ] Footer visible on all pages below content
- [ ] Links navigate correctly (discover, create open internally; github opens in new tab)
- [ ] "Built on Base" text visible with accent-dim styling
- [ ] Footer stays at bottom even on short-content pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)