### PR TITLE
[#116] Extract truncateAddress to shared utility

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,3 @@
+export function truncateAddress(address: string): string {
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -8,12 +8,9 @@ import { RatingSummary } from "../../../components/RatingSummary";
 import { getTokenPrice, type TokenPriceInfo } from "../../../../lib/price";
 import { IS_TESTNET } from "../../../../lib/contracts/constants";
 import { type Address } from "viem";
+import { truncateAddress } from "../../../../lib/utils";
 
 type Params = Promise<{ storylineId: string }>;
-
-function truncateAddress(address: string): string {
-  return `${address.slice(0, 6)}...${address.slice(-4)}`;
-}
 
 export default async function StoryPage({ params }: { params: Params }) {
   const { storylineId } = await params;

--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -2,10 +2,7 @@
 
 import { useAccount, useConnect, useDisconnect } from "wagmi";
 import { injected } from "wagmi/connectors";
-
-function truncateAddress(address: string): string {
-  return `${address.slice(0, 6)}...${address.slice(-4)}`;
-}
+import { truncateAddress } from "../../lib/utils";
 
 export function ConnectWallet() {
   const { address, isConnected } = useAccount();

--- a/src/components/RatingWidget.tsx
+++ b/src/components/RatingWidget.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { publicClient } from "../../lib/rpc";
 import { erc20Abi } from "../../lib/price";
 import type { Address } from "viem";
+import { truncateAddress } from "../../lib/utils";
 
 interface RatingData {
   id: number;
@@ -27,10 +28,6 @@ interface RatingsResponse {
 interface RatingWidgetProps {
   storylineId: number;
   tokenAddress: string;
-}
-
-function truncateAddress(address: string): string {
-  return `${address.slice(0, 6)}...${address.slice(-4)}`;
 }
 
 function StarDisplay({ rating, size = "sm" }: { rating: number; size?: "sm" | "lg" }) {

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -1,9 +1,6 @@
 import Link from "next/link";
 import type { Storyline } from "../../lib/supabase";
-
-function truncateAddress(address: string): string {
-  return `${address.slice(0, 6)}...${address.slice(-4)}`;
-}
+import { truncateAddress } from "../../lib/utils";
 
 export function StoryCard({
   storyline,


### PR DESCRIPTION
## Summary
- Extracted `truncateAddress()` from 4 files (`ConnectWallet.tsx`, `StoryCard.tsx`, `RatingWidget.tsx`, `story/[storylineId]/page.tsx`) into `lib/utils.ts`
- All 4 components now import from the shared location
- No logic changes — function body is identical

Fixes #116

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] Wallet address displays correctly in header (ConnectWallet)
- [ ] Writer address displays correctly on story cards
- [ ] Writer address displays correctly on story detail page
- [ ] Rater addresses display correctly in RatingWidget

🤖 Generated with [Claude Code](https://claude.com/claude-code)