### PR TITLE
[#115] Add aria-expanded and aria-hidden to mobile nav toggle

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -59,8 +59,9 @@ export function NavBar() {
             onClick={() => setMobileOpen(!mobileOpen)}
             className="text-muted hover:text-foreground p-1 text-sm transition-colors md:hidden"
             aria-label="Toggle menu"
+            aria-expanded={mobileOpen}
           >
-            {mobileOpen ? "[x]" : "[=]"}
+            <span aria-hidden="true">{mobileOpen ? "[x]" : "[=]"}</span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Adds `aria-expanded={mobileOpen}` to the hamburger button so screen readers announce the toggle state
- Wraps the `[=]`/`[x]` decorative text in `<span aria-hidden="true">` to hide it from assistive technology

Fixes #115

## Test plan
- [ ] Verify mobile nav toggle announces expanded/collapsed state with a screen reader (VoiceOver/NVDA)
- [ ] Confirm `[=]`/`[x]` text is not read aloud by assistive technology
- [ ] Verify no visual regressions on mobile breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)