### PR TITLE
[#114] Fix footer copyright text WCAG AA contrast

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -25,7 +25,7 @@ export function Footer() {
             built on <span className="text-accent-dim">Base</span>
           </span>
         </div>
-        <div className="text-muted/60 text-[10px]">
+        <div className="text-muted text-xs">
           <span className="text-accent-dim">$</span> PlotLink &copy; {new Date().getFullYear()}
         </div>
       </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -25,7 +25,7 @@ export function Footer() {
             built on <span className="text-accent-dim">Base</span>
           </span>
         </div>
-        <div className="text-muted text-xs">
+        <div className="text-neutral-400 text-xs">
           <span className="text-accent-dim">$</span> PlotLink &copy; {new Date().getFullYear()}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Changed footer copyright `text-[10px]` to `text-xs` (12px) for minimum readable size
- Removed `/60` opacity modifier from `text-muted/60` to improve contrast ratio to WCAG AA compliance

Fixes #114

## Test plan
- [ ] Verify footer copyright text is visually larger (12px vs 10px)
- [ ] Run contrast checker on `text-muted` against dark background (#0a0a0a) — should pass WCAG AA (4.5:1)
- [ ] Confirm no layout shift from the size change

🤖 Generated with [Claude Code](https://claude.com/claude-code)