### PR TITLE
[#117] Fix min-h-screen double-nesting causing 44px overflow

### DIFF
--- a/src/app/chain/page.tsx
+++ b/src/app/chain/page.tsx
@@ -56,7 +56,7 @@ export default function ChainPlotPage() {
 
   if (!isConnected) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-6">
+      <div className="flex min-h-[calc(100vh-2.75rem)] flex-col items-center justify-center gap-4 px-6">
         <p className="text-muted text-sm">
           Connect your wallet to chain a plot.
         </p>
@@ -66,7 +66,7 @@ export default function ChainPlotPage() {
 
   if (state === "published") {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-6 px-6">
+      <div className="flex min-h-[calc(100vh-2.75rem)] flex-col items-center justify-center gap-6 px-6">
         <h1 className="text-accent text-2xl font-bold">Plot chained!</h1>
         <div className="flex gap-3">
           {storylineId && (

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -38,7 +38,7 @@ export default function CreateStorylinePage() {
 
   if (!isConnected) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-6">
+      <div className="flex min-h-[calc(100vh-2.75rem)] flex-col items-center justify-center gap-4 px-6">
         <p className="text-muted text-sm">
           Connect your wallet to create a storyline.
         </p>
@@ -48,7 +48,7 @@ export default function CreateStorylinePage() {
 
   if (state === "published") {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-6 px-6">
+      <div className="flex min-h-[calc(100vh-2.75rem)] flex-col items-center justify-center gap-6 px-6">
         <h1 className="text-accent text-2xl font-bold">Storyline created!</h1>
         <div className="flex gap-3">
           <Link

--- a/src/app/dashboard/reader/page.tsx
+++ b/src/app/dashboard/reader/page.tsx
@@ -52,7 +52,7 @@ export default function ReaderDashboard() {
 
   if (!isConnected) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-6">
+      <div className="flex min-h-[calc(100vh-2.75rem)] flex-col items-center justify-center gap-4 px-6">
         <p className="text-muted text-sm">
           Connect your wallet to view your dashboard.
         </p>

--- a/src/app/dashboard/writer/page.tsx
+++ b/src/app/dashboard/writer/page.tsx
@@ -35,7 +35,7 @@ export default function WriterDashboard() {
 
   if (!isConnected) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-6">
+      <div className="flex min-h-[calc(100vh-2.75rem)] flex-col items-center justify-center gap-4 px-6">
         <p className="text-muted text-sm">
           Connect your wallet to view your dashboard.
         </p>

--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -21,7 +21,7 @@ export default async function DiscoverPage({
   const supabase = createServerClient();
   if (!supabase) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex min-h-[calc(100vh-2.75rem)] items-center justify-center">
         <p className="text-muted text-sm">Database unavailable</p>
       </div>
     );

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -189,7 +189,7 @@ function PlotEntry({ plot }: { plot: Plot }) {
 
 function NotFound({ message }: { message: string }) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center px-6">
+    <div className="flex min-h-[calc(100vh-2.75rem)] flex-col items-center justify-center px-6">
       <p className="text-muted text-sm">{message}</p>
     </div>
   );


### PR DESCRIPTION
Fixes #117

## Summary
- Root layout applies `min-h-screen` + `pt-11` (44px nav offset) to the children wrapper
- Five pages also used `min-h-screen` on their own wrapper divs, causing a 44px scroll overflow
- Replaced `min-h-screen` with `min-h-[calc(100vh-2.75rem)]` on each affected page wrapper to account for the nav height

## Files changed
- `src/app/create/page.tsx` — 2 wrapper divs (not-connected + published states)
- `src/app/chain/page.tsx` — 2 wrapper divs (not-connected + published states)
- `src/app/dashboard/reader/page.tsx` — 1 wrapper div (not-connected state)
- `src/app/dashboard/writer/page.tsx` — 1 wrapper div (not-connected state)
- `src/app/discover/page.tsx` — 1 wrapper div (database-unavailable state)

## Test plan
- [ ] Verify no vertical scrollbar on each affected page when content fits viewport
- [ ] Verify empty/error states remain vertically centered
- [ ] Verify normal content pages (with form content) still scroll naturally when content exceeds viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)