### PR TITLE
[#112] Add inline ConnectWallet CTA to wallet-gated pages

### DIFF
--- a/src/app/chain/page.tsx
+++ b/src/app/chain/page.tsx
@@ -12,6 +12,7 @@ import { supabase, type Storyline } from "../../../lib/supabase";
 import { useChainPlot } from "../../hooks/useChainPlot";
 import type { PublishState } from "../../hooks/usePublish";
 import Link from "next/link";
+import { ConnectWallet } from "../../components/ConnectWallet";
 
 const STATE_LABELS: Record<PublishState, string> = {
   idle: "",
@@ -60,6 +61,7 @@ export default function ChainPlotPage() {
         <p className="text-muted text-sm">
           Connect your wallet to chain a plot.
         </p>
+        <ConnectWallet />
       </div>
     );
   }

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -11,6 +11,7 @@ import { usePublish, type PublishState } from "../../hooks/usePublish";
 import { storyFactoryAbi } from "../../../lib/contracts/abi";
 import { STORY_FACTORY } from "../../../lib/contracts/constants";
 import Link from "next/link";
+import { ConnectWallet } from "../../components/ConnectWallet";
 
 const STATE_LABELS: Record<PublishState, string> = {
   idle: "",
@@ -42,6 +43,7 @@ export default function CreateStorylinePage() {
         <p className="text-muted text-sm">
           Connect your wallet to create a storyline.
         </p>
+        <ConnectWallet />
       </div>
     );
   }

--- a/src/app/dashboard/reader/page.tsx
+++ b/src/app/dashboard/reader/page.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { supabase, type Donation } from "../../../../lib/supabase";
 import { ReaderPortfolio } from "../../../components/ReaderPortfolio";
 import { formatUnits } from "viem";
+import { ConnectWallet } from "../../../components/ConnectWallet";
 
 const PAGE_SIZE = 50;
 
@@ -56,6 +57,7 @@ export default function ReaderDashboard() {
         <p className="text-muted text-sm">
           Connect your wallet to view your dashboard.
         </p>
+        <ConnectWallet />
       </div>
     );
   }

--- a/src/app/dashboard/writer/page.tsx
+++ b/src/app/dashboard/writer/page.tsx
@@ -7,6 +7,7 @@ import { DeadlineCountdown } from "../../../components/DeadlineCountdown";
 import { ClaimRoyalties } from "../../../components/ClaimRoyalties";
 import { WriterTradingStats } from "../../../components/WriterTradingStats";
 import Link from "next/link";
+import { ConnectWallet } from "../../../components/ConnectWallet";
 import { type Address } from "viem";
 
 async function fetchWriterStorylines(
@@ -39,6 +40,7 @@ export default function WriterDashboard() {
         <p className="text-muted text-sm">
           Connect your wallet to view your dashboard.
         </p>
+        <ConnectWallet />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Added `<ConnectWallet />` button inline below the "Connect your wallet to..." prompt on 4 wallet-gated pages: `/create`, `/chain`, `/dashboard/reader`, `/dashboard/writer`
- Users now have a clear CTA instead of a dead-end text prompt

Fixes #112

## Test plan
- [ ] Visit `/create`, `/chain`, `/dashboard/reader`, `/dashboard/writer` while disconnected — each should show the connect wallet button below the prompt text
- [ ] Click the connect button on each page — wallet connection flow should trigger
- [ ] After connecting, each page should render its normal content

🤖 Generated with [Claude Code](https://claude.com/claude-code)