### PR TITLE
[#113] Reorder widgets above story content on mobile

### DIFF
--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -70,7 +70,7 @@ export default async function StoryPage({ params }: { params: Params }) {
         </main>
 
         {/* Sidebar — engagement widgets */}
-        <aside className="space-y-4">
+        <aside className="order-first space-y-4 lg:order-none">
           {sl.token_address && priceInfo && (
             <PriceChart
               tokenAddress={sl.token_address as Address}


### PR DESCRIPTION
## Summary
- Adds `order-first lg:order-none` to the sidebar `<aside>` on the story page so engagement widgets (trading, price chart, ratings, donations) render **above** story content on mobile viewports
- Desktop two-column layout is completely unchanged — the ordering classes only take effect below the `lg` breakpoint
- Single-line Tailwind class change; no structural or behavioral changes

Fixes #113

## Test plan
- [ ] Open a story page on a mobile viewport (< 1024px) — widgets should appear before story text
- [ ] Open the same page on desktop (>= 1024px) — layout should be identical to before (story left, widgets right)
- [ ] Verify no visual regressions on the story page at various breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)