### PR TITLE
[#132] Add .plotlinkrc key-loading warning

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -87,6 +87,9 @@ function loadRcFile(): RcData {
     if (existsSync(filepath)) {
       try {
         const raw = readFileSync(filepath, "utf-8");
+        console.warn(
+          "WARNING: Loading keys from .plotlinkrc — ensure this file is in .gitignore and never committed.",
+        );
         return JSON.parse(raw) as RcData;
       } catch {
         // Ignore malformed rc files


### PR DESCRIPTION
## Summary
- Adds a stderr warning when CLI loads keys from `.plotlinkrc`: `WARNING: Loading keys from .plotlinkrc — ensure this file is in .gitignore and never committed.`

Fixes #132

## Test plan
- [ ] Run CLI with `.plotlinkrc` present — verify warning appears on stderr
- [ ] Run CLI with env vars only — verify no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)