### PR TITLE
[#133] Add isAddress() validation before Address casts

### DIFF
--- a/packages/cli/src/commands/agent-register.ts
+++ b/packages/cli/src/commands/agent-register.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import type { Address } from "viem";
+import { isAddress } from "viem";
 import { buildClient } from "../sdk.js";
 
 export function registerAgentRegister(program: Command): void {
@@ -26,9 +27,13 @@ export function registerAgentRegister(program: Command): void {
         skipWallet?: boolean;
       }) => {
         try {
-          // Resolve wallet key from env BEFORE spending gas on registration
+          // Validate wallet address and key BEFORE spending gas on registration
           let walletKey: string | undefined;
           if (opts.wallet && !opts.skipWallet) {
+            if (!isAddress(opts.wallet)) {
+              console.error(`Invalid address: ${opts.wallet}`);
+              process.exit(1);
+            }
             walletKey = process.env.PLOTLINK_AGENT_WALLET_KEY;
             if (!walletKey) {
               console.error(

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import type { Address } from "viem";
+import { isAddress } from "viem";
 import { buildClient } from "../sdk.js";
 
 export function registerClaim(program: Command): void {
@@ -9,6 +10,10 @@ export function registerClaim(program: Command): void {
     .requiredOption("-a, --address <tokenAddress>", "Storyline ERC-20 token address")
     .action(async (opts: { address: string }) => {
       try {
+        if (!isAddress(opts.address)) {
+          console.error(`Invalid address: ${opts.address}`);
+          process.exit(1);
+        }
         const tokenAddress = opts.address as Address;
         const client = buildClient({ ipfs: false });
 


### PR DESCRIPTION
Adds viem isAddress() validation before all Address casts in claim.ts and agent-register.ts. Shows clear error message. Validates before gas-spending calls. Fixes #133