### PR TITLE
[#135] Remove hardcoded genre from discover page

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -61,7 +61,7 @@ export default async function DiscoverPage({
 
       <div className="mt-6 space-y-3">
         {storylines.map((s) => (
-          <StoryCard key={s.id} storyline={s} genre="fiction" />
+          <StoryCard key={s.id} storyline={s} />
         ))}
         {storylines.length === 0 && (
           <p className="text-muted py-8 text-center text-sm">


### PR DESCRIPTION
Removes hardcoded genre="fiction" prop from StoryCard in discover page. StoryCard already handles undefined genre gracefully (conditionally renders). Fixes #135