### PR TITLE
[#144] Use reserve token for royalty decimals/symbol

### DIFF
--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { type Address, erc20Abi, formatUnits, isAddress } from "viem";
+import { MCV2_BOND_ADDRESS, mcv2BondAbi } from "@plotlink/sdk";
 import { buildClient } from "../sdk.js";
 
 export function registerClaim(program: Command): void {
@@ -19,20 +20,37 @@ export function registerClaim(program: Command): void {
         console.log("Checking royalties...");
         const info = await client.getRoyaltyInfo(tokenAddress);
 
-        // Fetch reserve token decimals dynamically
+        // Fetch reserve token address via tokenBond(), then read its decimals
         let decimals = 18;
+        let symbol = "TOKEN";
         try {
-          decimals = await client.publicClient.readContract({
-            address: tokenAddress,
-            abi: erc20Abi,
-            functionName: "decimals",
+          const bond = await client.publicClient.readContract({
+            address: MCV2_BOND_ADDRESS,
+            abi: mcv2BondAbi,
+            functionName: "tokenBond",
+            args: [tokenAddress],
           });
+          const reserveToken = (bond as readonly unknown[])[4] as Address;
+          const [dec, sym] = await Promise.all([
+            client.publicClient.readContract({
+              address: reserveToken,
+              abi: erc20Abi,
+              functionName: "decimals",
+            }),
+            client.publicClient.readContract({
+              address: reserveToken,
+              abi: erc20Abi,
+              functionName: "symbol",
+            }),
+          ]);
+          decimals = dec;
+          symbol = sym;
         } catch {
-          // Default to 18 if decimals() call fails
+          // Default to 18/TOKEN if calls fail
         }
 
         const formatted = formatUnits(info.unclaimed, decimals);
-        console.log(`  Unclaimed:    ${formatted}`);
+        console.log(`  Unclaimed:    ${formatted} ${symbol}`);
         console.log(`  Beneficiary:  ${info.beneficiary}`);
 
         if (info.unclaimed === 0n) {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { createClient } from "@supabase/supabase-js";
 import { type Address, erc20Abi, formatUnits } from "viem";
+import { MCV2_BOND_ADDRESS, mcv2BondAbi } from "@plotlink/sdk";
 import { buildClient } from "../sdk.js";
 import { loadConfig } from "../config.js";
 
@@ -49,19 +50,26 @@ export function registerStatus(program: Command): void {
         }
 
         // -----------------------------------------------------------------
-        // 3. Reserve token metadata (symbol + decimals)
+        // 3. Reserve token metadata (symbol + decimals via tokenBond)
         // -----------------------------------------------------------------
         let tokenSymbol = "TOKEN";
         let tokenDecimals = 18;
         try {
+          const bond = await client.publicClient.readContract({
+            address: MCV2_BOND_ADDRESS,
+            abi: mcv2BondAbi,
+            functionName: "tokenBond",
+            args: [info.tokenAddress],
+          });
+          const reserveToken = (bond as readonly unknown[])[4] as Address;
           const [sym, dec] = await Promise.all([
             client.publicClient.readContract({
-              address: info.tokenAddress,
+              address: reserveToken,
               abi: erc20Abi,
               functionName: "symbol",
             }),
             client.publicClient.readContract({
-              address: info.tokenAddress,
+              address: reserveToken,
               abi: erc20Abi,
               functionName: "decimals",
             }),
@@ -69,7 +77,7 @@ export function registerStatus(program: Command): void {
           tokenSymbol = sym;
           tokenDecimals = dec;
         } catch {
-          // Fall back to defaults if token doesn't support ERC-20 metadata
+          // Fall back to defaults if calls fail
         }
 
         // -----------------------------------------------------------------

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -41,3 +41,6 @@ export {
   BASE_SEPOLIA_CHAIN_ID,
   BASE_MAINNET_CHAIN_ID,
 } from "./constants";
+
+// Re-export ABIs for direct contract reads
+export { mcv2BondAbi } from "./abi";


### PR DESCRIPTION
Fixes royalty formatting to use reserve token (via tokenBond()) instead of storyline token for decimals() and symbol(). Applied to both claim.ts and status.ts. Also exports mcv2BondAbi from SDK. Fixes #144