### PR TITLE
Fix gas estimation failures and hydration mismatch

### DIFF
--- a/src/components/DeadlineCountdown.tsx
+++ b/src/components/DeadlineCountdown.tsx
@@ -5,10 +5,11 @@ import { useState, useEffect } from "react";
 const DEADLINE_HOURS = 72;
 
 export function DeadlineCountdown({ lastPlotTime }: { lastPlotTime: string }) {
-  const [remaining, setRemaining] = useState<number | null>(null);
+  const [remaining, setRemaining] = useState<number | null>(() =>
+    typeof window === "undefined" ? null : calcRemaining(lastPlotTime),
+  );
 
   useEffect(() => {
-    setRemaining(calcRemaining(lastPlotTime));
     const interval = setInterval(() => {
       setRemaining(calcRemaining(lastPlotTime));
     }, 1000);

--- a/src/components/DeadlineCountdown.tsx
+++ b/src/components/DeadlineCountdown.tsx
@@ -5,14 +5,25 @@ import { useState, useEffect } from "react";
 const DEADLINE_HOURS = 72;
 
 export function DeadlineCountdown({ lastPlotTime }: { lastPlotTime: string }) {
-  const [remaining, setRemaining] = useState(() => calcRemaining(lastPlotTime));
+  const [remaining, setRemaining] = useState<number | null>(null);
 
   useEffect(() => {
+    setRemaining(calcRemaining(lastPlotTime));
     const interval = setInterval(() => {
       setRemaining(calcRemaining(lastPlotTime));
     }, 1000);
     return () => clearInterval(interval);
   }, [lastPlotTime]);
+
+  if (remaining === null) {
+    return (
+      <div className="border-border bg-surface mt-4 rounded border px-3 py-2 text-xs">
+        <span className="text-muted">Deadline: </span>
+        <span className="text-accent font-medium">--:--:--</span>
+        <span className="text-muted ml-1">remaining</span>
+      </div>
+    );
+  }
 
   if (remaining <= 0) {
     return (

--- a/src/components/DonateWidget.tsx
+++ b/src/components/DonateWidget.tsx
@@ -62,6 +62,7 @@ export function DonateWidget({ storylineId }: DonateWidgetProps) {
         abi: storyFactoryAbi,
         functionName: "donate",
         args: [BigInt(storylineId), parsedAmount],
+        gas: BigInt(150_000),
       });
       setTxHash(hash);
 

--- a/src/components/TradingWidget.tsx
+++ b/src/components/TradingWidget.tsx
@@ -92,6 +92,7 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
           abi: mcv2BondAbi,
           functionName: "mint",
           args: [tokenAddress, parsedAmount, maxCost, address],
+          gas: BigInt(2_000_000),
         });
         setTxHash(hash);
         setTxState("pending");
@@ -125,6 +126,7 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
           abi: mcv2BondAbi,
           functionName: "burn",
           args: [tokenAddress, parsedAmount, minRefund, address],
+          gas: BigInt(2_000_000),
         });
         setTxHash(hash);
         setTxState("pending");


### PR DESCRIPTION
## Summary
- **Gas estimation**: Set explicit gas limits on donate (150k), mint/burn (2M) to bypass MetaMask's broken estimation on Base Sepolia
- **Hydration**: DeadlineCountdown renders `--:--:--` on server, starts countdown after client mount

## Test plan
- [ ] `npm run typecheck` passes
- [ ] Donate/Buy/Sell flows work without gas errors
- [ ] `/story/[id]` loads without hydration error in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)