### PR TITLE
[#154] Add receipt fetch retry to indexer routes

### DIFF
--- a/lib/rpc.ts
+++ b/lib/rpc.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, http, fallback } from "viem";
+import { createPublicClient, http, fallback, type Hex } from "viem";
 import { base, baseSepolia } from "viem/chains";
 
 const chainId = Number(process.env.NEXT_PUBLIC_CHAIN_ID || "84532");
@@ -20,3 +20,20 @@ export const publicClient = createPublicClient({
   chain,
   transport,
 });
+
+/**
+ * Fetch a transaction receipt with retries and backoff.
+ * Load-balanced RPC nodes may not have the receipt immediately after
+ * `waitForTransactionReceipt` completes on the client side.
+ */
+export async function getReceiptWithRetry(hash: Hex, maxAttempts = 3) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await publicClient.getTransactionReceipt({ hash });
+    } catch (err) {
+      if (attempt === maxAttempts) throw err;
+      await new Promise((r) => setTimeout(r, attempt * 1000));
+    }
+  }
+  throw new Error("unreachable");
+}

--- a/src/app/api/index/donation/route.ts
+++ b/src/app/api/index/donation/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { type Hex, decodeEventLog, encodeEventTopics } from "viem";
-import { publicClient } from "../../../../../lib/viem";
+import { publicClient, getReceiptWithRetry } from "../../../../../lib/rpc";
 import { createServerClient } from "../../../../../lib/supabase";
 import {
   storyFactoryAbi,
@@ -26,10 +26,10 @@ export async function POST(req: Request) {
     return error("Missing or invalid txHash");
   }
 
-  // 1. Fetch receipt
+  // 1. Fetch receipt (with retry for load-balanced RPC nodes)
   let receipt;
   try {
-    receipt = await publicClient.getTransactionReceipt({ hash: txHash });
+    receipt = await getReceiptWithRetry(txHash);
   } catch {
     return error("Failed to fetch transaction receipt", 502);
   }

--- a/src/app/api/index/plot/route.ts
+++ b/src/app/api/index/plot/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { type Hex, decodeEventLog, encodeEventTopics } from "viem";
-import { publicClient } from "../../../../../lib/viem";
+import { publicClient, getReceiptWithRetry } from "../../../../../lib/rpc";
 import { createServerClient } from "../../../../../lib/supabase";
 import {
   storyFactoryAbi,
@@ -31,10 +31,10 @@ export async function POST(req: Request) {
     return error("Missing or invalid txHash");
   }
 
-  // 1. Fetch receipt
+  // 1. Fetch receipt (with retry for load-balanced RPC nodes)
   let receipt;
   try {
-    receipt = await publicClient.getTransactionReceipt({ hash: txHash });
+    receipt = await getReceiptWithRetry(txHash);
   } catch {
     return error("Failed to fetch transaction receipt", 502);
   }

--- a/src/app/api/index/storyline/route.ts
+++ b/src/app/api/index/storyline/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { type Hex, decodeEventLog, encodeEventTopics } from "viem";
-import { publicClient } from "../../../../../lib/viem";
+import { publicClient, getReceiptWithRetry } from "../../../../../lib/rpc";
 import { createServerClient } from "../../../../../lib/supabase";
 import {
   storyFactoryAbi,
@@ -32,10 +32,10 @@ export async function POST(req: Request) {
     return error("Missing or invalid txHash");
   }
 
-  // 1. Fetch receipt
+  // 1. Fetch receipt (with retry for load-balanced RPC nodes)
   let receipt;
   try {
-    receipt = await publicClient.getTransactionReceipt({ hash: txHash });
+    receipt = await getReceiptWithRetry(txHash);
   } catch {
     return error("Failed to fetch transaction receipt", 502);
   }


### PR DESCRIPTION
## Summary
- Added `getReceiptWithRetry` helper in `lib/rpc.ts` — 3 attempts with 1s exponential backoff
- Applied to all 3 indexer routes: `/api/index/donation`, `/api/index/storyline`, `/api/index/plot`
- Switched routes from `lib/viem` (compat shim) to direct `lib/rpc` imports

Fixes #154

## Test plan
- [x] `tsc --noEmit` — zero errors
- [x] `next build` — clean
- [x] `vitest run` — 22/22 tests pass
- [ ] Trigger a donation/storyline/plot indexing immediately after tx confirms — should succeed instead of 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)