### PR TITLE
[#155] Fix DeadlineCountdown hydration mismatch

### DIFF
--- a/src/components/DeadlineCountdown.tsx
+++ b/src/components/DeadlineCountdown.tsx
@@ -5,11 +5,11 @@ import { useState, useEffect } from "react";
 const DEADLINE_HOURS = 72;
 
 export function DeadlineCountdown({ lastPlotTime }: { lastPlotTime: string }) {
-  const [remaining, setRemaining] = useState<number | null>(() =>
-    typeof window === "undefined" ? null : calcRemaining(lastPlotTime),
-  );
+  const [remaining, setRemaining] = useState<number | null>(null);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial sync needed for SSR hydration safety
+    setRemaining(calcRemaining(lastPlotTime));
     const interval = setInterval(() => {
       setRemaining(calcRemaining(lastPlotTime));
     }, 1000);


### PR DESCRIPTION
## Summary
- Always initialize `remaining` state as `null` so server and client both render `--:--:--` during hydration
- Set the calculated value only inside `useEffect` after mount
- Lint rule `react-hooks/set-state-in-effect` suppressed with inline comment since this is the standard SSR hydration pattern

Fixes #155

## Test plan
- [x] `eslint` — passes (lint rule suppressed)
- [x] `tsc --noEmit` — zero errors
- [x] `next build` — clean
- [ ] Load a story page with deadline — no hydration mismatch error in console
- [ ] Countdown starts after mount, placeholder `--:--:--` shows briefly during SSR

🤖 Generated with [Claude Code](https://claude.com/claude-code)