### PR TITLE
[#152] Link tx hashes to block explorer

### DIFF
--- a/lib/contracts/constants.ts
+++ b/lib/contracts/constants.ts
@@ -15,6 +15,11 @@ const chainId = Number(process.env.NEXT_PUBLIC_CHAIN_ID || "84532");
 export const IS_TESTNET = chainId === 84532;
 export const BASE_CHAIN_ID = chainId;
 
+/** Block explorer base URL (no trailing slash) */
+export const EXPLORER_URL = IS_TESTNET
+  ? "https://sepolia.basescan.org"
+  : "https://basescan.org";
+
 // ---------------------------------------------------------------------------
 // PlotLink contracts
 // ---------------------------------------------------------------------------

--- a/src/app/register-agent/page.tsx
+++ b/src/app/register-agent/page.tsx
@@ -6,7 +6,7 @@ import { decodeEventLog, type Hex } from "viem";
 import { useRouter } from "next/navigation";
 import { publicClient } from "../../../lib/rpc";
 import { erc8004Abi } from "../../../lib/contracts/erc8004";
-import { ERC8004_REGISTRY, BASE_CHAIN_ID } from "../../../lib/contracts/constants";
+import { ERC8004_REGISTRY, BASE_CHAIN_ID, EXPLORER_URL } from "../../../lib/contracts/constants";
 import { ConnectWallet } from "../../components/ConnectWallet";
 
 // ---------------------------------------------------------------------------
@@ -439,7 +439,15 @@ export default function RegisterAgentPage() {
 
           {regTxHash && (
             <div className="border-border text-muted rounded border px-3 py-2 text-xs">
-              Tx: {regTxHash.slice(0, 10)}...{regTxHash.slice(-8)}
+              Tx:{" "}
+              <a
+                href={`${EXPLORER_URL}/tx/${regTxHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent hover:underline"
+              >
+                {regTxHash.slice(0, 10)}...{regTxHash.slice(-8)}
+              </a>
             </div>
           )}
 
@@ -670,7 +678,15 @@ export default function RegisterAgentPage() {
 
           {bindTxHash && (
             <div className="border-border text-muted rounded border px-3 py-2 text-xs">
-              Tx: {bindTxHash.slice(0, 10)}...{bindTxHash.slice(-8)}
+              Tx:{" "}
+              <a
+                href={`${EXPLORER_URL}/tx/${bindTxHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent hover:underline"
+              >
+                {bindTxHash.slice(0, 10)}...{bindTxHash.slice(-8)}
+              </a>
             </div>
           )}
 

--- a/src/components/ClaimRoyalties.tsx
+++ b/src/components/ClaimRoyalties.tsx
@@ -6,7 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { formatUnits, type Address } from "viem";
 import { publicClient } from "../../lib/rpc";
 import { mcv2BondAbi } from "../../lib/price";
-import { MCV2_BOND, IS_TESTNET } from "../../lib/contracts/constants";
+import { MCV2_BOND, IS_TESTNET, EXPLORER_URL } from "../../lib/contracts/constants";
 
 type TxState = "idle" | "confirming" | "pending" | "done" | "error";
 
@@ -20,6 +20,7 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary }: ClaimRo
   const [txState, setTxState] = useState<TxState>("idle");
   const [error, setError] = useState<string | null>(null);
   const [claimedAmount, setClaimedAmount] = useState<bigint>(BigInt(0));
+  const [txHash, setTxHash] = useState<string | null>(null);
 
   const { writeContractAsync } = useWriteContract();
 
@@ -55,6 +56,7 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary }: ClaimRo
         functionName: "claimRoyalties",
         args: [tokenAddress],
       });
+      setTxHash(hash);
 
       setTxState("pending");
       await publicClient.waitForTransactionReceipt({ hash });
@@ -107,6 +109,19 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary }: ClaimRo
           </span>
         )}
       </div>
+      {txHash && txState === "done" && (
+        <p className="text-muted mt-1 text-[10px]">
+          Tx:{" "}
+          <a
+            href={`${EXPLORER_URL}/tx/${txHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            {txHash.slice(0, 10)}...{txHash.slice(-8)}
+          </a>
+        </p>
+      )}
       {error && <p className="mt-1 text-[10px] text-red-400">{error}</p>}
     </div>
   );

--- a/src/components/DonateWidget.tsx
+++ b/src/components/DonateWidget.tsx
@@ -7,7 +7,7 @@ import { parseUnits, formatUnits } from "viem";
 import { publicClient } from "../../lib/rpc";
 import { erc20Abi } from "../../lib/price";
 import { storyFactoryAbi } from "../../lib/contracts/abi";
-import { STORY_FACTORY, PLOT_TOKEN, IS_TESTNET } from "../../lib/contracts/constants";
+import { STORY_FACTORY, PLOT_TOKEN, IS_TESTNET, EXPLORER_URL } from "../../lib/contracts/constants";
 
 type TxState = "idle" | "approving" | "confirming" | "pending" | "indexing" | "done" | "error";
 
@@ -190,7 +190,15 @@ export function DonateWidget({ storylineId }: DonateWidgetProps) {
       {error && <p className="mt-2 text-xs text-red-400">{error}</p>}
       {txHash && txState === "done" && (
         <p className="text-muted mt-2 text-xs">
-          Tx: {txHash.slice(0, 10)}...{txHash.slice(-8)}
+          Tx:{" "}
+          <a
+            href={`${EXPLORER_URL}/tx/${txHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            {txHash.slice(0, 10)}...{txHash.slice(-8)}
+          </a>
         </p>
       )}
     </section>

--- a/src/components/TradingWidget.tsx
+++ b/src/components/TradingWidget.tsx
@@ -6,7 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { parseUnits, formatUnits, type Address } from "viem";
 import { publicClient } from "../../lib/rpc";
 import { mcv2BondAbi, erc20Abi } from "../../lib/price";
-import { MCV2_BOND, PLOT_TOKEN, IS_TESTNET } from "../../lib/contracts/constants";
+import { MCV2_BOND, PLOT_TOKEN, IS_TESTNET, EXPLORER_URL } from "../../lib/contracts/constants";
 
 type Tab = "buy" | "sell";
 type TxState = "idle" | "approving" | "confirming" | "pending" | "done" | "error";
@@ -269,7 +269,15 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
       {error && <p className="mt-2 text-xs text-red-400">{error}</p>}
       {txHash && txState === "done" && (
         <p className="text-muted mt-2 text-xs">
-          Tx: {txHash.slice(0, 10)}...{txHash.slice(-8)}
+          Tx:{" "}
+          <a
+            href={`${EXPLORER_URL}/tx/${txHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            {txHash.slice(0, 10)}...{txHash.slice(-8)}
+          </a>
         </p>
       )}
     </section>


### PR DESCRIPTION
## Summary
- Added `EXPLORER_URL` constant to `lib/contracts/constants.ts` — testnet: `sepolia.basescan.org`, mainnet: `basescan.org`
- Replaced all 4 plain-text tx hash displays with clickable `<a>` links to BaseScan
- Updated: `TradingWidget`, `DonateWidget`, `register-agent` page (reg + bind tx hashes)

Fixes #152

## Test plan
- [x] `tsc --noEmit` — zero errors
- [x] `next build` — clean
- [ ] Complete a trade → tx hash is a clickable link opening BaseScan in new tab
- [ ] Complete a donation → same
- [ ] Register agent / bind wallet → same

🤖 Generated with [Claude Code](https://claude.com/claude-code)