### PR TITLE
[#158] Show donation stats prominently, clarify deadline wording

### DIFF
--- a/src/app/dashboard/writer/page.tsx
+++ b/src/app/dashboard/writer/page.tsx
@@ -2,6 +2,7 @@
 
 import { useAccount } from "wagmi";
 import { useQuery } from "@tanstack/react-query";
+import { formatUnits } from "viem";
 import { supabase, type Storyline } from "../../../../lib/supabase";
 import { DeadlineCountdown } from "../../../components/DeadlineCountdown";
 import { ClaimRoyalties } from "../../../components/ClaimRoyalties";
@@ -119,11 +120,9 @@ function StorylineDetail({ storyline, writerAddress }: { storyline: Storyline; w
         </div>
         <div>
           <span className="block text-[10px] uppercase tracking-wider">
-            Deadline
+            Donations
           </span>
-          <span className="text-foreground">
-            {storyline.has_deadline ? "72h" : "none"}
-          </span>
+          <DonationCount storylineId={storyline.storyline_id} />
         </div>
       </div>
 
@@ -144,5 +143,34 @@ function StorylineDetail({ storyline, writerAddress }: { storyline: Storyline; w
         </>
       )}
     </div>
+  );
+}
+
+function DonationCount({ storylineId }: { storylineId: number }) {
+  const { data } = useQuery({
+    queryKey: ["donation-count", storylineId],
+    queryFn: async () => {
+      if (!supabase) return { total: BigInt(0), count: 0 };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: rows } = await (supabase.from("donations") as any)
+        .select("amount")
+        .eq("storyline_id", storylineId);
+      if (!rows) return { total: BigInt(0), count: 0 };
+      const total = (rows as { amount: string }[]).reduce(
+        (sum, d) => sum + BigInt(d.amount),
+        BigInt(0),
+      );
+      return { total, count: rows.length };
+    },
+  });
+
+  if (!data || data.count === 0) {
+    return <span className="text-foreground">—</span>;
+  }
+
+  return (
+    <span className="text-foreground">
+      {formatUnits(data.total, 18)} <span className="text-muted">({data.count})</span>
+    </span>
   );
 }

--- a/src/app/dashboard/writer/page.tsx
+++ b/src/app/dashboard/writer/page.tsx
@@ -4,6 +4,7 @@ import { useAccount } from "wagmi";
 import { useQuery } from "@tanstack/react-query";
 import { formatUnits } from "viem";
 import { supabase, type Storyline } from "../../../../lib/supabase";
+import { getTokenTVL } from "../../../../lib/price";
 import { DeadlineCountdown } from "../../../components/DeadlineCountdown";
 import { ClaimRoyalties } from "../../../components/ClaimRoyalties";
 import { WriterTradingStats } from "../../../components/WriterTradingStats";
@@ -122,7 +123,10 @@ function StorylineDetail({ storyline, writerAddress }: { storyline: Storyline; w
           <span className="block text-[10px] uppercase tracking-wider">
             Donations
           </span>
-          <DonationCount storylineId={storyline.storyline_id} />
+          {storyline.token_address
+            ? <DonationCount storylineId={storyline.storyline_id} tokenAddress={storyline.token_address} />
+            : <span className="text-foreground">—</span>
+          }
         </div>
       </div>
 
@@ -146,21 +150,27 @@ function StorylineDetail({ storyline, writerAddress }: { storyline: Storyline; w
   );
 }
 
-function DonationCount({ storylineId }: { storylineId: number }) {
+function DonationCount({ storylineId, tokenAddress }: { storylineId: number; tokenAddress: string }) {
   const { data } = useQuery({
-    queryKey: ["donation-count", storylineId],
+    queryKey: ["donation-count", storylineId, tokenAddress],
     queryFn: async () => {
-      if (!supabase) return { total: BigInt(0), count: 0 };
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data: rows } = await (supabase.from("donations") as any)
-        .select("amount")
-        .eq("storyline_id", storylineId);
-      if (!rows) return { total: BigInt(0), count: 0 };
+      const [tvlData, rows] = await Promise.all([
+        getTokenTVL(tokenAddress as Address),
+        supabase
+          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (supabase.from("donations") as any)
+              .select("amount")
+              .eq("storyline_id", storylineId)
+              .then((r: { data: { amount: string }[] | null }) => r.data)
+          : null,
+      ]);
+      const decimals = tvlData?.decimals ?? 18;
+      if (!rows || rows.length === 0) return { total: BigInt(0), count: 0, decimals };
       const total = (rows as { amount: string }[]).reduce(
         (sum, d) => sum + BigInt(d.amount),
         BigInt(0),
       );
-      return { total, count: rows.length };
+      return { total, count: rows.length, decimals };
     },
   });
 
@@ -170,7 +180,7 @@ function DonationCount({ storylineId }: { storylineId: number }) {
 
   return (
     <span className="text-foreground">
-      {formatUnits(data.total, 18)} <span className="text-muted">({data.count})</span>
+      {formatUnits(data.total, data.decimals)} <span className="text-muted">({data.count})</span>
     </span>
   );
 }

--- a/src/components/DeadlineCountdown.tsx
+++ b/src/components/DeadlineCountdown.tsx
@@ -19,9 +19,8 @@ export function DeadlineCountdown({ lastPlotTime }: { lastPlotTime: string }) {
   if (remaining === null) {
     return (
       <div className="border-border bg-surface mt-4 rounded border px-3 py-2 text-xs">
-        <span className="text-muted">Deadline: </span>
+        <span className="text-muted">Next plot due in </span>
         <span className="text-accent font-medium">--:--:--</span>
-        <span className="text-muted ml-1">remaining</span>
       </div>
     );
   }
@@ -40,12 +39,11 @@ export function DeadlineCountdown({ lastPlotTime }: { lastPlotTime: string }) {
 
   return (
     <div className="border-border bg-surface mt-4 rounded border px-3 py-2 text-xs">
-      <span className="text-muted">Deadline: </span>
+      <span className="text-muted">Next plot due in </span>
       <span className="text-accent font-medium">
         {String(hours).padStart(2, "0")}:{String(minutes).padStart(2, "0")}:
         {String(seconds).padStart(2, "0")}
       </span>
-      <span className="text-muted ml-1">remaining</span>
     </div>
   );
 }

--- a/src/components/WriterTradingStats.tsx
+++ b/src/components/WriterTradingStats.tsx
@@ -100,8 +100,7 @@ export function WriterTradingStats({ storyline }: WriterTradingStatsProps) {
             : "—"}
         </span>
         <span className="text-muted block text-[10px]">
-          {donationsTotal !== undefined && decimals !== undefined && `D: ${formatUnits(donationsTotal, decimals)}`}
-          {royaltyData && decimals !== undefined && ` R: ${formatUnits(royaltyData.unclaimed, decimals)}`}
+          {royaltyData && decimals !== undefined && `Royalties: ${formatUnits(royaltyData.unclaimed, decimals)}`}
         </span>
       </div>
       <div>


### PR DESCRIPTION
## Summary
- Replaced redundant "Deadline 72h" static column with donation total + count in writer dashboard
- Changed deadline wording from "Deadline: XX:XX:XX remaining" to "Next plot due in XX:XX:XX"
- Replaced cryptic "D:" / "R:" labels with clearer "Royalties:" in earnings breakdown

Fixes #158

## Test plan
- [x] `tsc --noEmit` — zero errors
- [x] `next build` — clean
- [x] `vitest run` — 22/22 tests pass
- [ ] Writer dashboard shows donation total + count instead of "Deadline 72h"
- [ ] Deadline countdown reads "Next plot due in HH:MM:SS"

🤖 Generated with [Claude Code](https://claude.com/claude-code)