### PR TITLE
[#169] Add token symbol to donation stat on writer dashboard

### DIFF
--- a/src/app/dashboard/writer/page.tsx
+++ b/src/app/dashboard/writer/page.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { formatUnits } from "viem";
 import { supabase, type Storyline } from "../../../../lib/supabase";
 import { getTokenTVL } from "../../../../lib/price";
+import { RESERVE_LABEL } from "../../../../lib/contracts/constants";
 import { DeadlineCountdown } from "../../../components/DeadlineCountdown";
 import { ClaimRoyalties } from "../../../components/ClaimRoyalties";
 import { WriterTradingStats } from "../../../components/WriterTradingStats";
@@ -180,7 +181,7 @@ function DonationCount({ storylineId, tokenAddress }: { storylineId: number; tok
 
   return (
     <span className="text-foreground">
-      {formatUnits(data.total, data.decimals)} <span className="text-muted">({data.count})</span>
+      {formatUnits(data.total, data.decimals)} {RESERVE_LABEL} <span className="text-muted">({data.count})</span>
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- Display `RESERVE_LABEL` (WETH on testnet / $PLOT on mainnet) next to donation amount in writer dashboard
- Now reads "0.001 WETH (1)" instead of "0.001 (1)"

Fixes #169

## Test plan
- [x] `tsc --noEmit` — zero errors
- [x] `next build` — clean
- [ ] Writer dashboard donation stat shows token symbol

🤖 Generated with [Claude Code](https://claude.com/claude-code)