### PR TITLE
[#176] DonateWidget: show author address instead of story #ID

### DIFF
--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -151,7 +151,7 @@ export default async function StoryPage({ params }: { params: Params }) {
           {sl.token_address && (
             <TradingWidget tokenAddress={sl.token_address as Address} />
           )}
-          <DonateWidget storylineId={id} />
+          <DonateWidget storylineId={id} writerAddress={sl.writer_address} />
           {sl.token_address && (
             <RatingWidget storylineId={id} tokenAddress={sl.token_address} />
           )}

--- a/src/components/DonateWidget.tsx
+++ b/src/components/DonateWidget.tsx
@@ -8,14 +8,16 @@ import { publicClient } from "../../lib/rpc";
 import { erc20Abi } from "../../lib/price";
 import { storyFactoryAbi } from "../../lib/contracts/abi";
 import { STORY_FACTORY, PLOT_TOKEN, IS_TESTNET, EXPLORER_URL } from "../../lib/contracts/constants";
+import { truncateAddress } from "../../lib/utils";
 
 type TxState = "idle" | "approving" | "confirming" | "pending" | "indexing" | "done" | "error";
 
 interface DonateWidgetProps {
   storylineId: number;
+  writerAddress?: string;
 }
 
-export function DonateWidget({ storylineId }: DonateWidgetProps) {
+export function DonateWidget({ storylineId, writerAddress }: DonateWidgetProps) {
   const { address, isConnected } = useAccount();
   const [amount, setAmount] = useState("");
   const [txState, setTxState] = useState<TxState>("idle");
@@ -167,7 +169,7 @@ export function DonateWidget({ storylineId }: DonateWidgetProps) {
           <span className="text-foreground">
             {formatUnits(parsedAmount, 18)} {reserveLabel}
           </span>{" "}
-          to story #{storylineId}
+          to {writerAddress ? truncateAddress(writerAddress) : `story #${storylineId}`}
         </p>
       )}
 


### PR DESCRIPTION
## Summary
- DonateWidget accepts optional `writerAddress` prop
- Confirmation text shows truncated author address (e.g., "0x0175...4dBf") instead of "story #2"
- Falls back to story ID if writer address unavailable
- Story page passes `writer_address` from storyline data

Fixes #176

## Test plan
- [x] `tsc --noEmit` — zero errors
- [x] `next build` — clean
- [ ] Donation confirmation shows author address instead of story #ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)