### PR TITLE
[#193] Deadline countdown in days/hours/minutes/seconds format

### DIFF
--- a/src/components/DeadlineCountdown.tsx
+++ b/src/components/DeadlineCountdown.tsx
@@ -20,7 +20,7 @@ export function DeadlineCountdown({ lastPlotTime }: { lastPlotTime: string }) {
     return (
       <div className="border-border bg-surface mt-4 rounded border px-3 py-2 text-xs">
         <span className="text-muted">Next plot due in </span>
-        <span className="text-accent font-medium">--:--:--</span>
+        <span className="text-accent font-medium">--</span>
       </div>
     );
   }
@@ -33,17 +33,24 @@ export function DeadlineCountdown({ lastPlotTime }: { lastPlotTime: string }) {
     );
   }
 
-  const hours = Math.floor(remaining / 3600);
+  const days = Math.floor(remaining / 86400);
+  const hours = Math.floor((remaining % 86400) / 3600);
   const minutes = Math.floor((remaining % 3600) / 60);
   const seconds = remaining % 60;
+
+  let formatted: string;
+  if (days > 0) {
+    formatted = `${days}d ${hours}h ${minutes}m ${seconds}s`;
+  } else if (hours > 0) {
+    formatted = `${hours}h ${minutes}m ${seconds}s`;
+  } else {
+    formatted = `${minutes}m ${seconds}s`;
+  }
 
   return (
     <div className="border-border bg-surface mt-4 rounded border px-3 py-2 text-xs">
       <span className="text-muted">Next plot due in </span>
-      <span className="text-accent font-medium">
-        {String(hours).padStart(2, "0")}:{String(minutes).padStart(2, "0")}:
-        {String(seconds).padStart(2, "0")}
-      </span>
+      <span className="text-accent font-medium">{formatted}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace raw hours format (`161:48:23`) with human-readable: `6d 23h 13m 21s`
- Progressive format: shows only relevant units (days when 1+, hours when <24h, minutes when <1h)

Fixes #193

## Test plan
- [x] `tsc --noEmit` — zero errors
- [x] `next build` — clean
- [ ] Countdown shows "Xd Xh Xm Xs" format

🤖 Generated with [Claude Code](https://claude.com/claude-code)