### PR TITLE
[#197] Update descriptions: single-author model, not collaborative

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # PlotLink
 
-Collaborative on-chain storytelling platform. Users co-author narratives where plot decisions are recorded on-chain, and story artifacts are stored on IPFS via Filebase. The app is mobile-first with a terminal/monospace design aesthetic.
+On-chain storytelling platform. Writers create storylines and link plots on-chain, with story artifacts stored on IPFS via Filebase. The app is mobile-first with a terminal/monospace design aesthetic.
 
 ## Tech Stack
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: "PlotLink",
-  description: "Collaborative on-chain storytelling",
+  description: "On-chain storytelling platform. Create your story, link your plots, build your audience.",
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,7 +35,7 @@ export default async function Home() {
           PlotLink
         </h1>
         <p className="text-muted mt-1 text-sm">
-          Collaborative on-chain storytelling. Write the next chapter.
+          On-chain storytelling. Create your story, link your plots, build your audience.
         </p>
       </header>
 

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -52,7 +52,7 @@ export async function generateMetadata({
   const priceSuffix = priceInfo
     ? ` — Price: ${priceInfo.pricePerToken} ${reserveLabel}`
     : "";
-  const description = `A collaborative on-chain story by ${truncateAddress(sl.writer_address)} — ${sl.plot_count} ${sl.plot_count === 1 ? "plot" : "plots"}${priceSuffix}`;
+  const description = `An on-chain story by ${truncateAddress(sl.writer_address)} — ${sl.plot_count} ${sl.plot_count === 1 ? "plot" : "plots"}${priceSuffix}`;
 
   const fcEmbed = JSON.stringify({
     version: "1",


### PR DESCRIPTION
## Summary
- CLAUDE.md: updated project description
- Home page hero: "On-chain storytelling. Create your story, link your plots, build your audience."
- Layout OG meta: same new description
- Story page meta: "An on-chain story by..." (was "A collaborative on-chain story by...")
- No "collaborative" references remain in source code

Fixes #197

## Test plan
- [x] `tsc --noEmit` — zero errors
- [x] `next build` — clean
- [x] `grep -ri "collaborative" src/` — no matches
- [ ] Home page shows updated hero text

🤖 Generated with [Claude Code](https://claude.com/claude-code)