### PR TITLE
[#211] Update taglines: writer-owned tokenised storytelling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # PlotLink
 
-On-chain storytelling platform. Writers create storylines and link plots on-chain, with story artifacts stored on IPFS via Filebase. The app is mobile-first with a terminal/monospace design aesthetic.
+On-chain storytelling protocol. Writers tokenise their storylines on a bonding curve from day 1 — every new plot drives trading, and every trade generates royalties for the author. Story artifacts stored on IPFS via Filebase. The app is mobile-first with a terminal/monospace design aesthetic.
 
 ## Tech Stack
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: "PlotLink",
-  description: "On-chain storytelling platform. Create your story, link your plots, build your audience.",
+  description: "Tokenise your story from day 1. Publish plots, drive trading, earn royalties from every trade — powered by the market, not a platform.",
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,7 +44,7 @@ export default async function Home({
           PlotLink
         </h1>
         <p className="text-muted mt-1 text-sm">
-          On-chain storytelling. Create your story, link your plots, build your audience.
+          Your story is a token. Every plot you publish drives the market — and every trade pays you. Write more, earn more.
         </p>
       </header>
 


### PR DESCRIPTION
Fixes #211 — Updated hero, meta description, and CLAUDE.md with new copy emphasising tokenised storytelling and market-driven royalties.