### PR TITLE
[#184] Add title to chainPlot + fix 168h deadline

### DIFF
--- a/lib/contracts/abi.ts
+++ b/lib/contracts/abi.ts
@@ -16,6 +16,7 @@ export const plotChainedEvent = {
     { name: "storylineId", type: "uint256", indexed: true },
     { name: "plotIndex", type: "uint256", indexed: true },
     { name: "writer", type: "address", indexed: true },
+    { name: "title", type: "string", indexed: false },
     { name: "contentCID", type: "string", indexed: false },
     { name: "contentHash", type: "bytes32", indexed: false },
   ],
@@ -68,6 +69,7 @@ export const chainPlotFunction = {
   stateMutability: "nonpayable",
   inputs: [
     { name: "storylineId", type: "uint256" },
+    { name: "title", type: "string" },
     { name: "contentCID", type: "string" },
     { name: "contentHash", type: "bytes32" },
   ],

--- a/lib/contracts/constants.ts
+++ b/lib/contracts/constants.ts
@@ -27,7 +27,7 @@ export const EXPLORER_URL = IS_TESTNET
 /** StoryFactory — storyline + plot management */
 export const STORY_FACTORY = (process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ??
   (IS_TESTNET
-    ? "0x05C4d59529807316D6fA09cdaA509adDfe85b474"
+    ? "0x6B8d38af1773dd162Ebc6f4A8eb923F3c669605d"
     : "0x0000000000000000000000000000000000000000")) as `0x${string}`;
 
 /** ZapPlotLinkMCV2 — one-click buy (ETH/USDC/HUNT -> storyline token) */

--- a/packages/cli/src/commands/chain.ts
+++ b/packages/cli/src/commands/chain.ts
@@ -8,14 +8,15 @@ export function registerChain(program: Command): void {
     .description("Chain a new plot onto an existing storyline")
     .requiredOption("-s, --storyline <id>", "Storyline ID")
     .requiredOption("-f, --file <path>", "Path to content file (plain text)")
-    .action(async (opts: { storyline: string; file: string }) => {
+    .option("-t, --title <title>", "Chapter title", "")
+    .action(async (opts: { storyline: string; file: string; title: string }) => {
       try {
         const content = readFileSync(opts.file, "utf-8");
         const storylineId = BigInt(opts.storyline);
         const client = buildClient({ ipfs: true });
 
         console.log(`Chaining plot onto storyline ${storylineId}...`);
-        const result = await client.chainPlot(storylineId, content);
+        const result = await client.chainPlot(storylineId, content, opts.title);
 
         console.log("Plot chained!");
         console.log(`  TX:   ${result.txHash}`);

--- a/packages/sdk/src/abi.ts
+++ b/packages/sdk/src/abi.ts
@@ -18,6 +18,7 @@ export const storyFactoryAbi = [
       { name: "storylineId", type: "uint256", indexed: true },
       { name: "plotIndex", type: "uint256", indexed: true },
       { name: "writer", type: "address", indexed: true },
+      { name: "title", type: "string", indexed: false },
       { name: "contentCID", type: "string", indexed: false },
       { name: "contentHash", type: "bytes32", indexed: false },
     ],
@@ -63,6 +64,7 @@ export const storyFactoryAbi = [
     stateMutability: "nonpayable",
     inputs: [
       { name: "storylineId", type: "uint256" },
+      { name: "title", type: "string" },
       { name: "contentCID", type: "string" },
       { name: "contentHash", type: "bytes32" },
     ],

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -254,11 +254,13 @@ export class PlotLink {
    *
    * @param storylineId - The storyline to chain onto
    * @param content - Plot content (plain text)
+   * @param title - Optional chapter title (defaults to empty string)
    * @returns Transaction hash and IPFS CID
    */
   async chainPlot(
     storylineId: bigint,
     content: string,
+    title = "",
   ): Promise<ChainPlotResult> {
     this.requireFilebase();
     validateNonEmpty("content", content);
@@ -272,7 +274,7 @@ export class PlotLink {
       address: this.storyFactory,
       abi: storyFactoryAbi,
       functionName: "chainPlot",
-      args: [storylineId, contentCid, contentHash],
+      args: [storylineId, title, contentCid, contentHash],
     });
 
     const txHash = await this.walletClient.writeContract(request);

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -31,7 +31,7 @@ export const SUPPORTED_CHAIN_IDS = new Set([BASE_SEPOLIA_CHAIN_ID, BASE_MAINNET_
 
 /** StoryFactory — storyline + plot management. */
 export const STORY_FACTORY_ADDRESS =
-  "0x05C4d59529807316D6fA09cdaA509adDfe85b474" as const;
+  "0x6B8d38af1773dd162Ebc6f4A8eb923F3c669605d" as const;
 
 /** MCV2_Bond — bonding curve trading, token creation, royalty distribution. */
 export const MCV2_BOND_ADDRESS =

--- a/src/app/chain/page.tsx
+++ b/src/app/chain/page.tsx
@@ -41,6 +41,7 @@ async function fetchWriterStorylines(address: string): Promise<Storyline[]> {
 export default function ChainPlotPage() {
   const { address, isConnected } = useAccount();
   const [storylineId, setStorylineId] = useState<number | null>(null);
+  const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
 
   const { data: storylines = [], isLoading: loadingStorylines } = useQuery({
@@ -103,7 +104,7 @@ export default function ChainPlotPage() {
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          if (canSubmit) chainPlot(storylineId, content);
+          if (canSubmit) chainPlot(storylineId, content, title);
         }}
         className="mt-8 space-y-6"
       >
@@ -133,6 +134,23 @@ export default function ChainPlotPage() {
               }))}
             />
           )}
+        </div>
+
+        {/* Chapter title */}
+        <div>
+          <label className="text-foreground mb-2 block text-sm">
+            Chapter Title <span className="text-muted">(optional)</span>
+          </label>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value.slice(0, 100))}
+            disabled={busy || noStoryline}
+            placeholder={noStoryline ? "Select a storyline first" : "e.g. The Awakening"}
+            maxLength={100}
+            className="border-border bg-surface text-foreground placeholder:text-muted w-full rounded border px-3 py-2 text-sm focus:border-accent focus:outline-none disabled:opacity-50"
+          />
+          <span className="text-muted mt-1 block text-xs">{title.length}/100</span>
         </div>
 
         {/* Content */}

--- a/src/hooks/useChainPlot.ts
+++ b/src/hooks/useChainPlot.ts
@@ -13,7 +13,7 @@ export function useChainPlot() {
   const { state, error, txHash, execute, reset } = usePublish();
 
   const chainPlot = useCallback(
-    async (storylineId: number, content: string) => {
+    async (storylineId: number, content: string, title = "") => {
       await execute({
         content,
         uploadKeyPrefix: `plotlink/plots/${storylineId}`,
@@ -22,7 +22,7 @@ export function useChainPlot() {
           address: STORY_FACTORY,
           abi: storyFactoryAbi as unknown as [],
           functionName: "chainPlot",
-          args: [BigInt(storylineId), cid, contentHash],
+          args: [BigInt(storylineId), title, cid, contentHash],
         }),
       });
     },


### PR DESCRIPTION
## Summary
- **Contract redeployed** to Base Sepolia: `0x6B8d38af1773dd162Ebc6f4A8eb923F3c669605d` (verified on Sourcify)
- Added `string calldata title` param to `chainPlot()` function and `PlotChained` event
- Changed deadline enforcement from 72h to 168h (7 days) — matches frontend/docs
- Updated all frontend ABIs (web app + SDK), contract address, useChainPlot hook, SDK client, and CLI

## Contract changes (plotlink-contracts repo)
- `chainPlot(storylineId, title, contentCID, contentHash)` — new signature
- `PlotChained` event now includes `title` field
- Genesis emit in `createStoryline` passes storyline title to `PlotChained`
- All 15 Foundry tests pass

## Frontend changes
- `lib/contracts/abi.ts` + `packages/sdk/src/abi.ts`: title in event + function
- `lib/contracts/constants.ts` + `packages/sdk/src/constants.ts`: new contract address
- `src/hooks/useChainPlot.ts`: optional title param (default "")
- `packages/sdk/src/client.ts`: optional title param
- `packages/cli/src/commands/chain.ts`: `--title` flag

## Test plan
- [x] `forge test` — 15/15 pass (including updated deadline test at 168h)
- [x] Contract verified on Sourcify
- [ ] Frontend type check passes (tsc --noEmit clean)
- [ ] Create a storyline on new contract — verify genesis PlotChained event includes title
- [ ] Chain a plot with title — verify PlotChained event includes title
- [ ] Chain a plot without title — verify empty string works

Fixes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)