### PR TITLE
[#218] Add 'By:' prefix to StoryCard + remove unused import

### DIFF
--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -41,7 +41,7 @@ export function StoryCard({
 
       {/* Author + meta */}
       <div className="text-muted mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
-        <span>{truncateAddress(storyline.writer_address)}</span>
+        <span>By: {truncateAddress(storyline.writer_address)}</span>
         <span>
           {storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"}
         </span>

--- a/src/components/StoryCardStats.tsx
+++ b/src/components/StoryCardStats.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { formatUnits, type Address } from "viem";
+import { type Address } from "viem";
 import { getTokenTVL, getTokenPrice } from "../../lib/price";
 import { IS_TESTNET } from "../../lib/contracts/constants";
 


### PR DESCRIPTION
## Summary
- Added "By: " prefix before truncated writer address in StoryCard
- Removed unused `formatUnits` import from StoryCardStats

## Test plan
- [ ] Home page cards show "By: 0xAB...CD" format
- [ ] No lint warnings for unused imports

Fixes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)