### PR TITLE
[#190] Make chapter title required on chain page

### DIFF
--- a/src/app/chain/page.tsx
+++ b/src/app/chain/page.tsx
@@ -52,9 +52,11 @@ export default function ChainPlotPage() {
 
   const { state, error, chainPlot, reset } = useChainPlot();
   const { valid, charCount } = validateContentLength(content);
+  const titleValid = title.trim().length > 0;
   const canSubmit =
     (state === "idle" || state === "error") &&
     storylineId !== null &&
+    titleValid &&
     valid;
 
   if (!isConnected) {
@@ -139,7 +141,7 @@ export default function ChainPlotPage() {
         {/* Chapter title */}
         <div>
           <label className="text-foreground mb-2 block text-sm">
-            Chapter Title <span className="text-muted">(optional)</span>
+            Chapter Title
           </label>
           <input
             type="text"
@@ -150,7 +152,14 @@ export default function ChainPlotPage() {
             maxLength={100}
             className="border-border bg-surface text-foreground placeholder:text-muted w-full rounded border px-3 py-2 text-sm focus:border-accent focus:outline-none disabled:opacity-50"
           />
-          <span className="text-muted mt-1 block text-xs">{title.length}/100</span>
+          <div className="mt-1 flex justify-between text-xs">
+            {!titleValid && content.length > 0 ? (
+              <span className="text-error">Title is required</span>
+            ) : (
+              <span />
+            )}
+            <span className="text-muted">{title.length}/100</span>
+          </div>
         </div>
 
         {/* Content */}

--- a/src/app/chain/page.tsx
+++ b/src/app/chain/page.tsx
@@ -148,7 +148,7 @@ export default function ChainPlotPage() {
             value={title}
             onChange={(e) => setTitle(e.target.value.slice(0, 100))}
             disabled={busy || noStoryline}
-            placeholder={noStoryline ? "Select a storyline first" : "e.g. The Awakening"}
+            placeholder={noStoryline ? "Select a storyline first" : "e.g. The Silent Storm"}
             maxLength={100}
             className="border-border bg-surface text-foreground placeholder:text-muted w-full rounded border px-3 py-2 text-sm focus:border-accent focus:outline-none disabled:opacity-50"
           />
@@ -158,7 +158,7 @@ export default function ChainPlotPage() {
             ) : (
               <span />
             )}
-            <span className="text-muted">{title.length}/100</span>
+            <span className="text-muted">{title.length} / 100 chars</span>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Chapter title field is now **required** (label updated, no longer "(optional)")
- Submit button disabled when title is empty
- Validation message "Title is required" shown when content is entered but title is blank

## Test plan
- [ ] Cannot submit with empty title — button disabled
- [ ] Validation message appears when content typed but title empty
- [ ] Can submit normally with both title and content filled
- [ ] Title still capped at 100 characters

Fixes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)