### PR TITLE
[#187] Plot detail pages: genesis redirect

### DIFF
--- a/src/app/story/[storylineId]/[plotIndex]/page.tsx
+++ b/src/app/story/[storylineId]/[plotIndex]/page.tsx
@@ -1,4 +1,5 @@
 import { type Metadata } from "next";
+import { redirect } from "next/navigation";
 import { createServerClient, type Storyline, type Plot } from "../../../../../lib/supabase";
 import { truncateAddress } from "../../../../../lib/utils";
 import { ViewTracker } from "../../../../components/ViewCount";
@@ -54,6 +55,11 @@ export default async function PlotDetailPage({ params }: { params: Params }) {
 
   if (isNaN(sid) || sid <= 0 || isNaN(pidx) || pidx < 0) {
     return <NotFound message="Invalid plot URL" />;
+  }
+
+  // Genesis (plot 0) redirects to the main story page
+  if (pidx === 0) {
+    redirect(`/story/${sid}`);
   }
 
   const supabase = createServerClient();


### PR DESCRIPTION
## Summary
- `/story/[id]/0` (genesis) now redirects to `/story/[id]` since genesis is displayed on the main story page
- All other #187 acceptance criteria were already implemented in PR #227:
  - Individual plot pages at `/story/[storylineId]/[plotIndex]`
  - Chapter header with title/author/date
  - Full plot content
  - Prev/Next navigation buttons
  - "Table of Contents" link
  - OG metadata per chapter
  - SSR with revalidate

## Test plan
- [ ] `/story/2/0` redirects to `/story/2`
- [ ] `/story/2/1` renders chapter detail page
- [ ] Prev/Next buttons work across chapters
- [ ] Mobile responsive

Fixes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)