### PR TITLE
[#231] Validate plot existence before allowing comments

### DIFF
--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -113,6 +113,18 @@ export async function POST(req: NextRequest) {
   const serverClient = createServerClient();
   if (!serverClient) return error("Supabase not configured", 500);
 
+  // Validate that the (storyline_id, plot_index) pair exists
+  const { data: plot } = await serverClient.from("plots")
+    .select("id")
+    .eq("storyline_id", storylineId)
+    .eq("plot_index", plotIndex)
+    .eq("contract_address", STORY_FACTORY.toLowerCase())
+    .limit(1);
+
+  if (!plot || plot.length === 0) {
+    return error("Plot does not exist");
+  }
+
   // Rate limit: max 1 comment per address per plot per minute
   const oneMinuteAgo = new Date(Date.now() - 60 * 1000).toISOString();
   const { data: recent } = await serverClient.from("comments")

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -114,13 +114,14 @@ export async function POST(req: NextRequest) {
   if (!serverClient) return error("Supabase not configured", 500);
 
   // Validate that the (storyline_id, plot_index) pair exists
-  const { data: plot } = await serverClient.from("plots")
+  const { data: plot, error: plotError } = await serverClient.from("plots")
     .select("id")
     .eq("storyline_id", storylineId)
     .eq("plot_index", plotIndex)
     .eq("contract_address", STORY_FACTORY.toLowerCase())
     .limit(1);
 
+  if (plotError) return error(`Database error: ${plotError.message}`, 500);
   if (!plot || plot.length === 0) {
     return error("Plot does not exist");
   }


### PR DESCRIPTION
## Summary
- POST `/api/comments` now queries the `plots` table to verify the `(storyline_id, plot_index, contract_address)` tuple exists before inserting
- Returns 400 `"Plot does not exist"` if the plot is not found
- Check runs after signature verification but before rate limiting (no DB writes wasted on invalid plots)

## Test plan
- [ ] POST comment on valid plot → succeeds
- [ ] POST comment on non-existent plot_index → returns 400
- [ ] POST comment on non-existent storyline_id → returns 400

Fixes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)