### PR TITLE
[#240] Fix contract address backfill for pre-redeploy data

### DIFF
--- a/supabase/migrations/00012_fix_contract_address_backfill.sql
+++ b/supabase/migrations/00012_fix_contract_address_backfill.sql
@@ -2,9 +2,26 @@
 -- (0x6b8d...) back to the old contract (0x05c4...) where all pre-redeploy
 -- data was actually created. Migration 00009 incorrectly defaulted to the
 -- new address.
-UPDATE storylines SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474' WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d';
-UPDATE plots SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474' WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d';
-UPDATE donations SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474' WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d';
-UPDATE ratings SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474' WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d';
-UPDATE comments SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474' WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d';
-UPDATE page_views SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474' WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d';
+--
+-- Scoped to rows indexed/created before 2026-03-17T09:00:00Z (the time
+-- migration 00009 was deployed). Any rows indexed after this cutoff on
+-- the new contract are legitimate new-contract data and must not be
+-- re-tagged.
+UPDATE storylines SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474'
+  WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d'
+    AND indexed_at < '2026-03-17T09:00:00Z';
+UPDATE plots SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474'
+  WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d'
+    AND indexed_at < '2026-03-17T09:00:00Z';
+UPDATE donations SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474'
+  WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d'
+    AND indexed_at < '2026-03-17T09:00:00Z';
+UPDATE ratings SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474'
+  WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d'
+    AND created_at < '2026-03-17T09:00:00Z';
+UPDATE comments SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474'
+  WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d'
+    AND created_at < '2026-03-17T09:00:00Z';
+UPDATE page_views SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474'
+  WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d'
+    AND viewed_at < '2026-03-17T09:00:00Z';

--- a/supabase/migrations/00012_fix_contract_address_backfill.sql
+++ b/supabase/migrations/00012_fix_contract_address_backfill.sql
@@ -1,0 +1,10 @@
+-- Fix contract_address on existing data: re-tag from the new contract
+-- (0x6b8d...) back to the old contract (0x05c4...) where all pre-redeploy
+-- data was actually created. Migration 00009 incorrectly defaulted to the
+-- new address.
+UPDATE storylines SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474' WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d';
+UPDATE plots SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474' WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d';
+UPDATE donations SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474' WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d';
+UPDATE ratings SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474' WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d';
+UPDATE comments SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474' WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d';
+UPDATE page_views SET contract_address = '0x05c4d59529807316d6fa09cdaa509addfe85b474' WHERE contract_address = '0x6b8d38af1773dd162ebc6f4a8eb923f3c669605d';


### PR DESCRIPTION
## Summary
- Migration 00009 incorrectly defaulted existing rows to the new contract address (`0x6b8d...`)
- All pre-redeploy data was actually created on the old contract (`0x05c4...`)
- New migration 00012 re-tags all 6 tables back to the correct old contract address
- **Operator action needed**: Run the same SQL manually against Supabase to fix production data immediately

## Test plan
- [ ] Migration applies cleanly
- [ ] Old data tagged with old contract address (`0x05c4...`)
- [ ] Home page shows empty (no storylines on new contract yet)
- [ ] Old data still queryable with old contract address filter

Fixes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)