### PR TITLE
[#238] Add contract_address filter to admin hide/unhide

### DIFF
--- a/src/app/api/admin/auth.ts
+++ b/src/app/api/admin/auth.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { timingSafeEqual } from "node:crypto";
 import { createServiceRoleClient } from "../../../../lib/supabase";
+import { STORY_FACTORY } from "../../../../lib/contracts/constants";
 
 /**
  * Constant-time string comparison that does NOT leak length.
@@ -70,9 +71,10 @@ export async function handleModeration(
 
   const hidden = action === "hide";
 
+  const contractAddr = STORY_FACTORY.toLowerCase();
   const { error: dbError } = type === "storyline"
-    ? await supabase.from("storylines").update({ hidden }).eq("storyline_id", id)
-    : await supabase.from("plots").update({ hidden }).eq("id", id);
+    ? await supabase.from("storylines").update({ hidden }).eq("storyline_id", id).eq("contract_address", contractAddr)
+    : await supabase.from("plots").update({ hidden }).eq("id", id).eq("contract_address", contractAddr);
 
   if (dbError) {
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- Added `.eq("contract_address", STORY_FACTORY.toLowerCase())` to both admin update queries
- Prevents hide/unhide from affecting storylines/plots on other contracts

## Test plan
- [ ] Admin hide storyline → only affects current contract's storyline
- [ ] Admin unhide plot → only affects current contract's plot

Fixes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)