### PR TITLE
[#239] Add contract_address filter to CLI status query

### DIFF
--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import { createClient } from "@supabase/supabase-js";
 import { type Address, erc20Abi, formatUnits } from "viem";
-import { MCV2_BOND_ADDRESS, mcv2BondAbi } from "@plotlink/sdk";
+import { MCV2_BOND_ADDRESS, mcv2BondAbi, STORY_FACTORY_ADDRESS } from "@plotlink/sdk";
 import { buildClient } from "../sdk.js";
 import { loadConfig } from "../config.js";
 
@@ -45,6 +45,7 @@ export function registerStatus(program: Command): void {
             .from("storylines")
             .select("plot_count, last_plot_time, has_deadline, sunset, writer_type, block_timestamp")
             .eq("storyline_id", Number(storylineId))
+            .eq("contract_address", STORY_FACTORY_ADDRESS.toLowerCase())
             .single();
           dbRow = data;
         }


### PR DESCRIPTION
## Summary
- Added `.eq("contract_address", STORY_FACTORY_ADDRESS.toLowerCase())` to CLI status Supabase query
- Uses `STORY_FACTORY_ADDRESS` from `@plotlink/sdk` constants
- Prevents returning data from wrong contract on storyline ID collisions

## Test plan
- [ ] `plotlink status -s <id>` returns data only from current contract
- [ ] Query with non-existent storyline on current contract returns "not found"

Fixes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)