### PR TITLE
[#244] Fix MetaMask gas estimation for createStoryline and chainPlot

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -117,6 +117,7 @@ export default function CreateStorylinePage() {
                 abi: storyFactoryAbi as unknown as [],
                 functionName: "createStoryline",
                 args: [title.trim(), cid, contentHash, hasDeadline],
+                gas: BigInt(5_000_000),
               }),
             });
         }}

--- a/src/hooks/useChainPlot.ts
+++ b/src/hooks/useChainPlot.ts
@@ -23,6 +23,7 @@ export function useChainPlot() {
           abi: storyFactoryAbi as unknown as [],
           functionName: "chainPlot",
           args: [BigInt(storylineId), title, cid, contentHash],
+          gas: BigInt(500_000),
         }),
       });
     },

--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -20,6 +20,7 @@ interface WriteCall {
   abi: Abi;
   functionName: string;
   args: readonly unknown[];
+  gas?: bigint;
 }
 
 interface PublishOptions {


### PR DESCRIPTION
## Summary
- Added `gas?: bigint` to `WriteCall` interface in `usePublish.ts`
- `createStoryline`: explicit gas limit of 5M (deploys 500-step bonding curve token via MCV2_Bond)
- `chainPlot`: explicit gas limit of 500K (lighter write operation)
- Same pattern as existing fixes in DonateWidget (150K) and TradingWidget (2M)

## Test plan
- [ ] Create storyline → MetaMask shows reasonable gas, tx submits successfully
- [ ] Chain plot → MetaMask shows reasonable gas, tx submits successfully

Fixes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)