### PR TITLE
[#246] Fix token symbol collision — redeploy with PLT- prefix

### DIFF
--- a/lib/contracts/constants.ts
+++ b/lib/contracts/constants.ts
@@ -27,7 +27,7 @@ export const EXPLORER_URL = IS_TESTNET
 /** StoryFactory — storyline + plot management */
 export const STORY_FACTORY = (process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ??
   (IS_TESTNET
-    ? "0x6B8d38af1773dd162Ebc6f4A8eb923F3c669605d"
+    ? "0xfa5489b6710Ba2f8406b37fA8f8c3018e51FA229"
     : "0x0000000000000000000000000000000000000000")) as `0x${string}`;
 
 /** ZapPlotLinkMCV2 — one-click buy (ETH/USDC/HUNT -> storyline token) */

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -31,7 +31,7 @@ export const SUPPORTED_CHAIN_IDS = new Set([BASE_SEPOLIA_CHAIN_ID, BASE_MAINNET_
 
 /** StoryFactory — storyline + plot management. */
 export const STORY_FACTORY_ADDRESS =
-  "0x6B8d38af1773dd162Ebc6f4A8eb923F3c669605d" as const;
+  "0xfa5489b6710Ba2f8406b37fA8f8c3018e51FA229" as const;
 
 /** MCV2_Bond — bonding curve trading, token creation, royalty distribution. */
 export const MCV2_BOND_ADDRESS =


### PR DESCRIPTION
## Summary
- Changed StoryFactory token symbol prefix from `PLOT-` to `PLT-` in `StoryFactory.sol` to avoid MCV2_Bond duplicate symbol rejection
- Deployed new StoryFactory to Base Sepolia: `0xfa5489b6710Ba2f8406b37fA8f8c3018e51FA229`
- Updated `STORY_FACTORY` in `lib/contracts/constants.ts` and `packages/sdk/src/constants.ts`
- All 15 forge tests pass
- No ABI changes

## Deployment details
- Chain: Base Sepolia (84532)
- New contract: `0xfa5489b6710Ba2f8406b37fA8f8c3018e51FA229`
- Old contract: `0x6B8d38af1773dd162Ebc6f4A8eb923F3c669605d`

## Operator action needed
- Update `NEXT_PUBLIC_CONTRACT_ADDRESS` env var if set
- Run migration to re-tag existing data if needed

## Test plan
- [x] `forge test` — 15/15 pass
- [ ] `createStoryline` on new contract succeeds without symbol collision

Fixes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)