### PR TITLE
Fix ClaimRoyalties messaging: three states + tooltip

### DIFF
--- a/src/components/ClaimRoyalties.tsx
+++ b/src/components/ClaimRoyalties.tsx
@@ -118,11 +118,11 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary }: ClaimRo
                 </p>
                 <p className="text-muted mt-1.5">To claim:</p>
                 <ul className="text-muted mt-0.5 list-inside list-disc">
-                  <li>
-                    Chain at least 2 plots ({plotCount}/2)
+                  <li className={eligible ? "line-through opacity-60" : ""}>
+                    Chain at least 2 plots ({plotCount}/2) {eligible && "\u2713"}
                   </li>
                   <li>
-                    Unclaimed &gt; 0 ({formatTruncated(unclaimed, decimals)} {reserveLabel})
+                    Royalties accrue when readers trade your token ({formatTruncated(unclaimed, decimals)} {reserveLabel} unclaimed)
                   </li>
                 </ul>
               </div>
@@ -149,7 +149,12 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary }: ClaimRo
       </div>
       {!eligible && txState === "idle" && (
         <p className="text-muted mt-1 text-[10px]">
-          Chain {2 - plotCount} more {2 - plotCount === 1 ? "plot" : "plots"} to unlock royalties
+          Chain at least 2 plots to enable royalty claims ({plotCount}/2)
+        </p>
+      )}
+      {eligible && unclaimed === BigInt(0) && txState === "idle" && (
+        <p className="text-muted mt-1 text-[10px]">
+          No royalties yet — royalties accrue when readers trade your token
         </p>
       )}
       {txHash && txState === "done" && (


### PR DESCRIPTION
## Summary
- Replace misleading "Chain X more plots to unlock royalties" with three distinct message states:
  1. `plotCount < 2`: "Chain at least 2 plots to enable royalty claims (X/2)"
  2. `plotCount >= 2` and `unclaimed == 0`: "No royalties yet — royalties accrue when readers trade your token"
  3. `plotCount >= 2` and `unclaimed > 0`: existing behavior (amount + enabled Claim button)
- Update tooltip: strikethrough + checkmark on the plot requirement when met; clarify that royalties come from trades

Fixes #248

## Test plan
- [ ] Verify messaging with `plotCount < 2` shows "Chain at least 2 plots to enable royalty claims (X/2)"
- [ ] Verify messaging with `plotCount >= 2` and no unclaimed shows "No royalties yet" message
- [ ] Verify `plotCount >= 2` and unclaimed > 0 shows amount + enabled Claim button (unchanged)
- [ ] Verify tooltip shows strikethrough + checkmark when plot requirement met
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)