### PR TITLE
Fix Farcaster identity: Steemhunt API + Neynar fallback

### DIFF
--- a/lib/farcaster.ts
+++ b/lib/farcaster.ts
@@ -1,8 +1,10 @@
 /**
- * Farcaster identity lookup via Neynar API.
+ * Farcaster identity lookup — Steemhunt primary, Neynar fallback.
  *
- * Resolves an Ethereum address to a Farcaster username + avatar.
- * Results are cached in memory to avoid redundant API calls.
+ * Steemhunt's Farcaster Indexer (https://fc.hunt.town) is free and requires
+ * no API key. Neynar is used as a fallback only when NEYNAR_API_KEY is set.
+ *
+ * Simple in-memory cache with 1h TTL, 3s request timeout.
  */
 
 export interface FarcasterProfile {
@@ -12,59 +14,92 @@ export interface FarcasterProfile {
   pfpUrl: string | null;
 }
 
+const STEEMHUNT_BASE = "https://fc.hunt.town";
 const NEYNAR_BASE = "https://api.neynar.com/v2/farcaster";
+const REQUEST_TIMEOUT_MS = 3000;
+const CACHE_TTL_MS = 3600_000; // 1 hour
 
-const CACHE_TTL_MS = 3600_000; // 1 hour for successful lookups
-const cache = new Map<string, { profile: FarcasterProfile; expiresAt: number }>();
+const cache = new Map<string, { profile: FarcasterProfile | null; expiresAt: number }>();
+const inFlight = new Map<string, Promise<FarcasterProfile | null>>();
 
-function getApiKey(): string | undefined {
-  return process.env.NEYNAR_API_KEY;
+/**
+ * Try Steemhunt first, then Neynar if configured. Returns null if both fail.
+ */
+async function steemhuntLookup(address: string): Promise<FarcasterProfile | null> {
+  const res = await fetch(`${STEEMHUNT_BASE}/users/byWallet/${address}`, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  if (!data || !data.fid) return null;
+  return {
+    fid: data.fid,
+    username: data.username,
+    displayName: data.displayName ?? data.username,
+    pfpUrl: data.pfpUrl ?? null,
+  };
+}
+
+async function neynarLookup(address: string): Promise<FarcasterProfile | null> {
+  const apiKey = process.env.NEYNAR_API_KEY;
+  if (!apiKey) return null;
+  const res = await fetch(
+    `${NEYNAR_BASE}/user/bulk-by-address?addresses=${address}`,
+    {
+      headers: { accept: "application/json", "x-api-key": apiKey },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    },
+  );
+  if (!res.ok) return null;
+  const json = await res.json();
+  const users = json[address];
+  if (!Array.isArray(users) || users.length === 0) return null;
+  const user = users[0];
+  return {
+    fid: user.fid,
+    username: user.username,
+    displayName: user.display_name ?? user.username,
+    pfpUrl: user.pfp_url ?? null,
+  };
 }
 
 /**
  * Look up a Farcaster profile by Ethereum address.
- * Returns `null` when no Farcaster account is linked or the API is unavailable.
- * Only caches successful lookups with TTL; transient errors are never cached.
+ * Returns `null` when no Farcaster account is linked or both APIs are unavailable.
  */
 export async function lookupByAddress(
   address: string,
 ): Promise<FarcasterProfile | null> {
   const key = address.toLowerCase();
 
+  // Check cache
   const cached = cache.get(key);
   if (cached && cached.expiresAt > Date.now()) return cached.profile;
   if (cached) cache.delete(key);
 
-  const apiKey = getApiKey();
-  if (!apiKey) return null;
+  // Deduplicate in-flight requests
+  const existing = inFlight.get(key);
+  if (existing) return existing;
 
-  try {
-    const res = await fetch(
-      `${NEYNAR_BASE}/user/bulk-by-address?addresses=${key}`,
-      {
-        headers: { accept: "application/json", "x-api-key": apiKey },
-        next: { revalidate: 3600 },
-      },
-    );
+  const promise = (async () => {
+    try {
+      // Steemhunt first (free, no key needed)
+      const profile = await steemhuntLookup(key).catch(() => null);
+      if (profile) {
+        cache.set(key, { profile, expiresAt: Date.now() + CACHE_TTL_MS });
+        return profile;
+      }
 
-    if (!res.ok) return null;
+      // Neynar fallback
+      const fallback = await neynarLookup(key).catch(() => null);
+      cache.set(key, { profile: fallback, expiresAt: Date.now() + CACHE_TTL_MS });
+      return fallback;
+    } finally {
+      inFlight.delete(key);
+    }
+  })();
 
-    const json = await res.json();
-    const users = json[key];
-
-    if (!Array.isArray(users) || users.length === 0) return null;
-
-    const user = users[0];
-    const profile: FarcasterProfile = {
-      fid: user.fid,
-      username: user.username,
-      displayName: user.display_name ?? user.username,
-      pfpUrl: user.pfp_url ?? null,
-    };
-
-    cache.set(key, { profile, expiresAt: Date.now() + CACHE_TTL_MS });
-    return profile;
-  } catch {
-    return null;
-  }
+  inFlight.set(key, promise);
+  return promise;
 }

--- a/lib/farcaster.ts
+++ b/lib/farcaster.ts
@@ -22,17 +22,19 @@ const CACHE_TTL_MS = 3600_000; // 1 hour
 const cache = new Map<string, { profile: FarcasterProfile | null; expiresAt: number }>();
 const inFlight = new Map<string, Promise<FarcasterProfile | null>>();
 
-/**
- * Try Steemhunt first, then Neynar if configured. Returns null if both fail.
- */
-async function steemhuntLookup(address: string): Promise<FarcasterProfile | null> {
+// Sentinel: API responded successfully but wallet is not linked to Farcaster
+const NOT_FOUND = Symbol("NOT_FOUND");
+type LookupResult = FarcasterProfile | typeof NOT_FOUND | null; // null = transient error
+
+async function steemhuntLookup(address: string): Promise<LookupResult> {
   const res = await fetch(`${STEEMHUNT_BASE}/users/byWallet/${address}`, {
     headers: { Accept: "application/json" },
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
-  if (!res.ok) return null;
+  if (res.status === 404) return NOT_FOUND; // confirmed not linked
+  if (!res.ok) return null; // transient error
   const data = await res.json();
-  if (!data || !data.fid) return null;
+  if (!data || !data.fid) return NOT_FOUND;
   return {
     fid: data.fid,
     username: data.username,
@@ -41,7 +43,7 @@ async function steemhuntLookup(address: string): Promise<FarcasterProfile | null
   };
 }
 
-async function neynarLookup(address: string): Promise<FarcasterProfile | null> {
+async function neynarLookup(address: string): Promise<LookupResult> {
   const apiKey = process.env.NEYNAR_API_KEY;
   if (!apiKey) return null;
   const res = await fetch(
@@ -51,10 +53,10 @@ async function neynarLookup(address: string): Promise<FarcasterProfile | null> {
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     },
   );
-  if (!res.ok) return null;
+  if (!res.ok) return null; // transient error
   const json = await res.json();
   const users = json[address];
-  if (!Array.isArray(users) || users.length === 0) return null;
+  if (!Array.isArray(users) || users.length === 0) return NOT_FOUND;
   const user = users[0];
   return {
     fid: user.fid,
@@ -85,16 +87,29 @@ export async function lookupByAddress(
   const promise = (async () => {
     try {
       // Steemhunt first (free, no key needed)
-      const profile = await steemhuntLookup(key).catch(() => null);
-      if (profile) {
-        cache.set(key, { profile, expiresAt: Date.now() + CACHE_TTL_MS });
-        return profile;
+      const steemhunt = await steemhuntLookup(key).catch(() => null);
+      if (steemhunt && steemhunt !== NOT_FOUND) {
+        cache.set(key, { profile: steemhunt, expiresAt: Date.now() + CACHE_TTL_MS });
+        return steemhunt;
       }
 
-      // Neynar fallback
-      const fallback = await neynarLookup(key).catch(() => null);
-      cache.set(key, { profile: fallback, expiresAt: Date.now() + CACHE_TTL_MS });
-      return fallback;
+      // If Steemhunt confirmed "not linked", skip Neynar and cache null
+      if (steemhunt === NOT_FOUND) {
+        cache.set(key, { profile: null, expiresAt: Date.now() + CACHE_TTL_MS });
+        return null;
+      }
+
+      // Steemhunt had a transient error — try Neynar fallback
+      const neynar = await neynarLookup(key).catch(() => null);
+      if (neynar && neynar !== NOT_FOUND) {
+        cache.set(key, { profile: neynar, expiresAt: Date.now() + CACHE_TTL_MS });
+        return neynar;
+      }
+      // Only cache null if Neynar confirmed not found; skip cache on transient errors
+      if (neynar === NOT_FOUND) {
+        cache.set(key, { profile: null, expiresAt: Date.now() + CACHE_TTL_MS });
+      }
+      return null;
     } finally {
       inFlight.delete(key);
     }


### PR DESCRIPTION
## Summary
- Rewrite `lib/farcaster.ts` to use Steemhunt's free Farcaster Indexer API (`fc.hunt.town`) as primary lookup
- Falls back to Neynar only when `NEYNAR_API_KEY` is configured
- Simple implementation: in-memory `Map` cache (1h TTL), 3s request timeout, in-flight dedup
- No external dependencies added (no `node-cache` needed)
- Existing consumers (`WriterIdentity.tsx`, `WriterIdentityClient.tsx`) require no changes — same `lookupByAddress()` signature and `FarcasterProfile` type

Fixes #250

## Test plan
- [ ] Farcaster username + avatar displays for wallets linked to FC accounts (without NEYNAR_API_KEY)
- [ ] Falls back to Neynar if Steemhunt returns null and API key is set
- [ ] Falls back to truncated address if both fail
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)