### PR TITLE
Fix createStoryline gas limit + indexer 502 delay

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -117,7 +117,7 @@ export default function CreateStorylinePage() {
                 abi: storyFactoryAbi as unknown as [],
                 functionName: "createStoryline",
                 args: [title.trim(), cid, contentHash, hasDeadline],
-                gas: BigInt(5_000_000),
+                gas: BigInt(16_000_000),
               }),
             });
         }}

--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -89,6 +89,7 @@ export function usePublish() {
 
         // 4. Trigger indexer
         setState("indexing");
+        await new Promise((r) => setTimeout(r, 5000));
         await fetch(opts.indexerRoute, {
           method: "POST",
           headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- **#251**: Increase `createStoryline` gas limit from 5M to 16M — the 500-step bonding curve requires ~14.4M gas, causing OutOfGas reverts at 5M
- **#252**: Restore 5s delay before indexer API call in `usePublish` — Base Sepolia load-balanced RPCs need propagation time, especially after heavy txs like `createStoryline`

Fixes #251
Fixes #252

## Test plan
- [ ] `createStoryline` tx succeeds without OutOfGas revert
- [ ] Indexer call after tx confirmation returns 200 (not 502)
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)