### PR TITLE
Fix plot_count: reconcile storyline after plot upsert

### DIFF
--- a/lib/reconcile.ts
+++ b/lib/reconcile.ts
@@ -1,0 +1,52 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "./supabase";
+
+type SupabaseDB = SupabaseClient<Database>;
+
+/**
+ * Reconcile a storyline's plot_count and last_plot_time from the plots table.
+ * Uses COUNT(*) and MAX(block_timestamp) — idempotent and safe for replays.
+ *
+ * Throws on any Supabase error so callers can handle failures.
+ */
+export async function reconcileStorylinePlotCount(
+  supabase: SupabaseDB,
+  storylineId: number,
+): Promise<void> {
+  const [countResult, latestResult] = await Promise.all([
+    supabase
+      .from("plots")
+      .select("*", { count: "exact", head: true })
+      .eq("storyline_id", storylineId),
+    supabase
+      .from("plots")
+      .select("block_timestamp")
+      .eq("storyline_id", storylineId)
+      .order("block_timestamp", { ascending: false })
+      .limit(1)
+      .single(),
+  ]);
+
+  if (countResult.error) {
+    throw new Error(`Reconcile count error: ${countResult.error.message}`);
+  }
+  if (latestResult.error) {
+    throw new Error(`Reconcile latest plot error: ${latestResult.error.message}`);
+  }
+
+  if (countResult.count === null) return;
+
+  const { error: updateError } = await supabase
+    .from("storylines")
+    .update({
+      plot_count: countResult.count,
+      ...(latestResult.data?.block_timestamp
+        ? { last_plot_time: latestResult.data.block_timestamp }
+        : {}),
+    })
+    .eq("storyline_id", storylineId);
+
+  if (updateError) {
+    throw new Error(`Reconcile update error: ${updateError.message}`);
+  }
+}

--- a/src/app/api/cron/backfill/route.ts
+++ b/src/app/api/cron/backfill/route.ts
@@ -285,6 +285,32 @@ async function processPlotChained(
   if (plotError) {
     throw new Error(`Database error (plot): ${plotError.message}`);
   }
+
+  // Reconcile parent storyline plot_count and last_plot_time (idempotent)
+  const storyId = Number(storylineId);
+  const [{ count }, { data: latestPlot }] = await Promise.all([
+    supabase
+      .from("plots")
+      .select("*", { count: "exact", head: true })
+      .eq("storyline_id", storyId),
+    supabase
+      .from("plots")
+      .select("block_timestamp")
+      .eq("storyline_id", storyId)
+      .order("block_timestamp", { ascending: false })
+      .limit(1)
+      .single(),
+  ]);
+
+  if (count !== null) {
+    await supabase
+      .from("storylines")
+      .update({
+        plot_count: count,
+        ...(latestPlot?.block_timestamp ? { last_plot_time: latestPlot.block_timestamp } : {}),
+      })
+      .eq("storyline_id", storyId);
+  }
 }
 
 async function processDonation(

--- a/src/app/api/cron/backfill/route.ts
+++ b/src/app/api/cron/backfill/route.ts
@@ -6,6 +6,7 @@ import { storyFactoryAbi } from "../../../../../lib/contracts/abi";
 import { STORY_FACTORY } from "../../../../../lib/contracts/constants";
 import { hashContent } from "../../../../../lib/content";
 import { detectWriterType } from "../../../../../lib/contracts/erc8004";
+import { reconcileStorylinePlotCount } from "../../../../../lib/reconcile";
 import type { Database } from "../../../../../lib/supabase";
 
 const IPFS_GATEWAY = "https://ipfs.filebase.io/ipfs/";
@@ -287,30 +288,7 @@ async function processPlotChained(
   }
 
   // Reconcile parent storyline plot_count and last_plot_time (idempotent)
-  const storyId = Number(storylineId);
-  const [{ count }, { data: latestPlot }] = await Promise.all([
-    supabase
-      .from("plots")
-      .select("*", { count: "exact", head: true })
-      .eq("storyline_id", storyId),
-    supabase
-      .from("plots")
-      .select("block_timestamp")
-      .eq("storyline_id", storyId)
-      .order("block_timestamp", { ascending: false })
-      .limit(1)
-      .single(),
-  ]);
-
-  if (count !== null) {
-    await supabase
-      .from("storylines")
-      .update({
-        plot_count: count,
-        ...(latestPlot?.block_timestamp ? { last_plot_time: latestPlot.block_timestamp } : {}),
-      })
-      .eq("storyline_id", storyId);
-  }
+  await reconcileStorylinePlotCount(supabase, Number(storylineId));
 }
 
 async function processDonation(

--- a/src/app/api/index/plot/route.ts
+++ b/src/app/api/index/plot/route.ts
@@ -133,5 +133,31 @@ export async function POST(req: Request) {
     return error(`Database error: ${dbError.message}`, 500);
   }
 
+  // Reconcile parent storyline plot_count and last_plot_time (idempotent)
+  const storyId = Number(storylineId);
+  const [{ count }, { data: latestPlot }] = await Promise.all([
+    supabase
+      .from("plots")
+      .select("*", { count: "exact", head: true })
+      .eq("storyline_id", storyId),
+    supabase
+      .from("plots")
+      .select("block_timestamp")
+      .eq("storyline_id", storyId)
+      .order("block_timestamp", { ascending: false })
+      .limit(1)
+      .single(),
+  ]);
+
+  if (count !== null) {
+    await supabase
+      .from("storylines")
+      .update({
+        plot_count: count,
+        ...(latestPlot?.block_timestamp ? { last_plot_time: latestPlot.block_timestamp } : {}),
+      })
+      .eq("storyline_id", storyId);
+  }
+
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/index/plot/route.ts
+++ b/src/app/api/index/plot/route.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../../../lib/contracts/abi";
 import { STORY_FACTORY } from "../../../../../lib/contracts/constants";
 import { hashContent } from "../../../../../lib/content";
+import { reconcileStorylinePlotCount } from "../../../../../lib/reconcile";
 import type { Database } from "../../../../../lib/supabase";
 
 const IPFS_GATEWAY = "https://ipfs.filebase.io/ipfs/";
@@ -134,29 +135,12 @@ export async function POST(req: Request) {
   }
 
   // Reconcile parent storyline plot_count and last_plot_time (idempotent)
-  const storyId = Number(storylineId);
-  const [{ count }, { data: latestPlot }] = await Promise.all([
-    supabase
-      .from("plots")
-      .select("*", { count: "exact", head: true })
-      .eq("storyline_id", storyId),
-    supabase
-      .from("plots")
-      .select("block_timestamp")
-      .eq("storyline_id", storyId)
-      .order("block_timestamp", { ascending: false })
-      .limit(1)
-      .single(),
-  ]);
-
-  if (count !== null) {
-    await supabase
-      .from("storylines")
-      .update({
-        plot_count: count,
-        ...(latestPlot?.block_timestamp ? { last_plot_time: latestPlot.block_timestamp } : {}),
-      })
-      .eq("storyline_id", storyId);
+  try {
+    await reconcileStorylinePlotCount(supabase, Number(storylineId));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown reconciliation error";
+    console.error(`[index/plot] Reconciliation failed for storyline ${storylineId}: ${msg}`);
+    return error(`Reconciliation failed: ${msg}`, 500);
   }
 
   return NextResponse.json({ success: true });


### PR DESCRIPTION
## Summary
- After upserting a plot row, reconcile the parent storyline's `plot_count` (via `COUNT(*)`) and `last_plot_time` (via MAX `block_timestamp`)
- Applied to both the real-time indexer (`src/app/api/index/plot/route.ts`) and the backfill cron (`src/app/api/cron/backfill/route.ts`)
- Idempotent: duplicate indexer calls and backfill replays produce the same result (no double-counting)
- Note: existing stale data requires a one-time SQL fix in Supabase (see issue #257 for the migration query)

Fixes #257

## Test plan
- [ ] Chain a new plot — verify `storylines.plot_count` increments and `last_plot_time` updates
- [ ] Re-index the same plot — verify count doesn't double
- [ ] Backfill cron processes PlotChained events — verify storyline reconciled
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)