### PR TITLE
Add migration to reconcile stale plot_count data

### DIFF
--- a/supabase/migrations/00013_reconcile_plot_counts.sql
+++ b/supabase/migrations/00013_reconcile_plot_counts.sql
@@ -1,0 +1,16 @@
+-- Reconcile stale storylines.plot_count and last_plot_time from plots table.
+-- Idempotent: only updates rows where values differ from computed aggregates.
+-- Context: PR #258 fixed the code path; this migration fixes existing stale data.
+
+UPDATE storylines s
+SET plot_count = sub.cnt,
+    last_plot_time = sub.latest
+FROM (
+  SELECT storyline_id,
+         COUNT(*) AS cnt,
+         MAX(block_timestamp) AS latest
+  FROM plots
+  GROUP BY storyline_id
+) sub
+WHERE s.storyline_id = sub.storyline_id
+  AND (s.plot_count != sub.cnt OR s.last_plot_time != sub.latest);

--- a/supabase/migrations/00013_reconcile_plot_counts.sql
+++ b/supabase/migrations/00013_reconcile_plot_counts.sql
@@ -13,4 +13,4 @@ FROM (
   GROUP BY storyline_id
 ) sub
 WHERE s.storyline_id = sub.storyline_id
-  AND (s.plot_count != sub.cnt OR s.last_plot_time != sub.latest);
+  AND (s.plot_count IS DISTINCT FROM sub.cnt OR s.last_plot_time IS DISTINCT FROM sub.latest);


### PR DESCRIPTION
## Summary
- Add `supabase/migrations/00013_reconcile_plot_counts.sql` to fix existing stale `storylines.plot_count` and `last_plot_time` values
- Idempotent UPDATE using `COUNT(*)` and `MAX(block_timestamp)` from `plots` — only updates rows where values differ
- Companion to PR #258 which fixed the code path going forward

Fixes #259

## Test plan
- [ ] Migration updates stale storyline rows with correct plot_count and last_plot_time
- [ ] Running migration twice produces no additional changes (idempotent)
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)