### PR TITLE
Fix royalty ABI: correct parameter order and return values

### DIFF
--- a/lib/price.ts
+++ b/lib/price.ts
@@ -62,16 +62,19 @@ export const mcv2BondAbi = [
     name: "getRoyaltyInfo",
     stateMutability: "view",
     inputs: [
-      { name: "token", type: "address" },
-      { name: "beneficiary", type: "address" },
+      { name: "wallet", type: "address" },
+      { name: "reserveToken", type: "address" },
     ],
-    outputs: [{ name: "unclaimed", type: "uint256" }],
+    outputs: [
+      { name: "balance", type: "uint256" },
+      { name: "claimed", type: "uint256" },
+    ],
   },
   {
     type: "function",
     name: "claimRoyalties",
     stateMutability: "nonpayable",
-    inputs: [{ name: "token", type: "address" }],
+    inputs: [{ name: "reserveToken", type: "address" }],
     outputs: [],
   },
   priceForNextMintFunction,

--- a/src/components/ClaimRoyalties.tsx
+++ b/src/components/ClaimRoyalties.tsx
@@ -6,7 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { formatUnits, type Address } from "viem";
 import { publicClient } from "../../lib/rpc";
 import { mcv2BondAbi, getTokenTVL } from "../../lib/price";
-import { MCV2_BOND, IS_TESTNET, EXPLORER_URL } from "../../lib/contracts/constants";
+import { MCV2_BOND, IS_TESTNET, EXPLORER_URL, PLOT_TOKEN } from "../../lib/contracts/constants";
 
 function formatTruncated(value: bigint, decimals: number, digits = 10): string {
   const raw = formatUnits(value, decimals);
@@ -39,13 +39,13 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary }: ClaimRo
   const { data: royaltyInfo, refetch } = useQuery({
     queryKey: ["royalty-info", tokenAddress, beneficiary],
     queryFn: async () => {
-      const unclaimed = await publicClient.readContract({
+      const [balance] = await publicClient.readContract({
         address: MCV2_BOND,
         abi: mcv2BondAbi,
         functionName: "getRoyaltyInfo",
-        args: [tokenAddress, beneficiary],
+        args: [beneficiary, PLOT_TOKEN],
       });
-      return { unclaimed };
+      return { unclaimed: balance };
     },
     refetchInterval: 30000,
   });
@@ -71,7 +71,7 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary }: ClaimRo
         address: MCV2_BOND,
         abi: mcv2BondAbi,
         functionName: "claimRoyalties",
-        args: [tokenAddress],
+        args: [PLOT_TOKEN],
       });
       setTxHash(hash);
 


### PR DESCRIPTION
## Summary
- Fix `getRoyaltyInfo` ABI: inputs changed from `(token, beneficiary)` to `(wallet, reserveToken)`, outputs from single `uint256` to `(balance, claimed)`
- Fix `claimRoyalties` ABI: pass reserve token address (`PLOT_TOKEN`) instead of storyline token
- Update `ClaimRoyalties.tsx`: swap args to `getRoyaltyInfo(beneficiary, PLOT_TOKEN)`, destructure `[balance]` from tuple return, call `claimRoyalties(PLOT_TOKEN)`

Fixes #261

## Test plan
- [ ] Writer dashboard shows non-zero royalties after trades occur
- [ ] Claim button successfully claims royalties
- [ ] `getRoyaltyInfo` called with `(writerAddress, PLOT_TOKEN)` — verified in contract call
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)