### PR TITLE
Apply Farcaster identity to Ratings and Donate widgets

### DIFF
--- a/src/components/DonateWidget.tsx
+++ b/src/components/DonateWidget.tsx
@@ -8,7 +8,7 @@ import { publicClient } from "../../lib/rpc";
 import { erc20Abi } from "../../lib/price";
 import { storyFactoryAbi } from "../../lib/contracts/abi";
 import { STORY_FACTORY, PLOT_TOKEN, IS_TESTNET, EXPLORER_URL } from "../../lib/contracts/constants";
-import { truncateAddress } from "../../lib/utils";
+import { FarcasterAvatar } from "./FarcasterAvatar";
 
 type TxState = "idle" | "approving" | "confirming" | "pending" | "indexing" | "done" | "error";
 
@@ -169,7 +169,7 @@ export function DonateWidget({ storylineId, writerAddress }: DonateWidgetProps) 
           <span className="text-foreground">
             {formatUnits(parsedAmount, 18)} {reserveLabel}
           </span>{" "}
-          to {writerAddress ? truncateAddress(writerAddress) : `story #${storylineId}`}
+          to {writerAddress ? <FarcasterAvatar address={writerAddress} size={12} linkProfile={false} /> : `story #${storylineId}`}
         </p>
       )}
 

--- a/src/components/RatingWidget.tsx
+++ b/src/components/RatingWidget.tsx
@@ -6,8 +6,8 @@ import { useQuery } from "@tanstack/react-query";
 import { publicClient } from "../../lib/rpc";
 import { erc20Abi } from "../../lib/price";
 import type { Address } from "viem";
-import { truncateAddress } from "../../lib/utils";
 import { StarDisplay, StarInput } from "./StarRating";
+import { FarcasterAvatar } from "./FarcasterAvatar";
 
 interface RatingData {
   id: number;
@@ -193,7 +193,7 @@ export function RatingWidget({ storylineId, tokenAddress }: RatingWidgetProps) {
               <div key={r.id} className="text-xs">
                 <div className="flex items-center gap-2">
                   <span className="text-foreground">
-                    {truncateAddress(r.rater_address)}
+                    <FarcasterAvatar address={r.rater_address} size={12} />
                   </span>
                   <StarDisplay rating={r.rating} size={12} />
                 </div>


### PR DESCRIPTION
## Summary
- Replace `truncateAddress` with `FarcasterAvatar` in RatingWidget (recent ratings list)
- Replace `truncateAddress` with `FarcasterAvatar` in DonateWidget (donation confirmation, `linkProfile={false}`)
- Falls back to truncated address when no FC account is linked

Fixes #262

## Test plan
- [ ] Recent ratings show Farcaster avatar + @username for raters with linked FC accounts
- [ ] Donate confirmation shows Farcaster identity for writer
- [ ] Falls back to truncated address when no FC account linked
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)