### PR TITLE
Default language filter to English on discovery page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,7 +33,7 @@ export default async function Home({
     : "all";
   const page = Math.max(1, parseInt(rawPage ?? "1", 10) || 1);
   const genre = rawGenre && (GENRES as readonly string[]).includes(rawGenre) ? rawGenre : "all";
-  const lang = rawLang && (LANGUAGES as readonly string[]).includes(rawLang) ? rawLang : "all";
+  const lang = rawLang && (LANGUAGES as readonly string[]).includes(rawLang) ? rawLang : "English";
 
   const supabase = createServerClient();
 


### PR DESCRIPTION
## Summary
- Change language filter fallback from `"all"` to `"English"` on discovery page
- First-time visitors now see English stories by default, matching spec

Fixes #269

## Test plan
- [ ] Discovery page shows English stories by default
- [ ] "All languages" option still works when explicitly selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)