### PR TITLE
Allow 'All languages' filter on discovery page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,7 +33,7 @@ export default async function Home({
     : "all";
   const page = Math.max(1, parseInt(rawPage ?? "1", 10) || 1);
   const genre = rawGenre && (GENRES as readonly string[]).includes(rawGenre) ? rawGenre : "all";
-  const lang = rawLang && (LANGUAGES as readonly string[]).includes(rawLang) ? rawLang : "English";
+  const lang = rawLang === "all" ? "all" : rawLang && (LANGUAGES as readonly string[]).includes(rawLang) ? rawLang : "English";
 
   const supabase = createServerClient();
 


### PR DESCRIPTION
## Summary
- Accept `?lang=all` as a valid URL param instead of rejecting it and falling back to English
- No `lang` param still defaults to English (unchanged)

Fixes #271

## Test plan
- [ ] No `lang` in URL → English filter (default)
- [ ] `?lang=all` → shows all languages
- [ ] Selecting "All languages" dropdown persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)