### PR TITLE
Fix language 'All' filter reverting to English

### DIFF
--- a/src/components/GenreLanguageFilter.tsx
+++ b/src/components/GenreLanguageFilter.tsx
@@ -39,7 +39,7 @@ export function LanguageFilter({ active, tab, writer, genre }: { active: string;
         const params = new URLSearchParams({ tab });
         if (writer !== "all") params.set("writer", writer);
         if (genre !== "all") params.set("genre", genre);
-        if (value !== "all") params.set("lang", value);
+        params.set("lang", value);
         window.location.href = `/?${params.toString()}`;
       }}
       options={languageOptions}


### PR DESCRIPTION
## Summary
- `page.tsx`: accept `?lang=all` as valid (re-apply PR #273 fix reverted by PR #274)
- `GenreLanguageFilter.tsx`: always include `lang` param in URL when "All languages" selected

Fixes #275

## Test plan
- [ ] Select "All languages" → shows all stories, filter persists on reload
- [ ] Default (no lang param) → English
- [ ] Specific language selection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)