### PR TITLE
[#267] Indexing recovery UI for failed publish

### DIFF
--- a/src/app/chain/page.tsx
+++ b/src/app/chain/page.tsx
@@ -12,6 +12,7 @@ import { supabase, type Storyline } from "../../../lib/supabase";
 import { STORY_FACTORY } from "../../../lib/contracts/constants";
 import { useChainPlot } from "../../hooks/useChainPlot";
 import type { PublishState } from "../../hooks/usePublish";
+import { PublishRecovery } from "../../components/PublishRecovery";
 import Link from "next/link";
 import { ConnectWallet } from "../../components/ConnectWallet";
 import { Select } from "../../components/Select";
@@ -101,6 +102,9 @@ export default function ChainPlotPage() {
 
   return (
     <div className="mx-auto max-w-2xl px-6 py-12">
+      {/* Recovery banner for failed indexing */}
+      <PublishRecovery />
+
       <h1 className="text-accent text-2xl font-bold tracking-tight">
         Chain Plot
       </h1>

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -8,6 +8,7 @@ import {
   MAX_CONTENT_LENGTH,
 } from "../../../lib/content";
 import { usePublish, type PublishState } from "../../hooks/usePublish";
+import { PublishRecovery } from "../../components/PublishRecovery";
 import { storyFactoryAbi, storylineCreatedEvent } from "../../../lib/contracts/abi";
 import { STORY_FACTORY } from "../../../lib/contracts/constants";
 import { decodeEventLog, encodeEventTopics } from "viem";
@@ -123,6 +124,9 @@ export default function CreateStorylinePage() {
 
   return (
     <div className="animate-in mx-auto max-w-2xl px-6 py-12">
+      {/* Recovery banner for failed indexing */}
+      <PublishRecovery />
+
       {/* Manuscript header */}
       <div className="mb-8">
         <h1 className="text-2xl font-bold tracking-tight text-foreground">

--- a/src/components/PublishRecovery.tsx
+++ b/src/components/PublishRecovery.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState } from "react";
+import {
+  usePublishIntent,
+  MAX_RETRY_COUNT,
+} from "../hooks/usePublishIntent";
+import { EXPLORER_URL } from "../../lib/contracts/constants";
+
+/**
+ * Recovery banner for failed indexing after successful on-chain tx.
+ * Mount on any page where publishing can occur (create, chain).
+ * Renders nothing if no pending intent exists.
+ */
+export function PublishRecovery() {
+  const { pendingIntent, retryIndexing, clearIntent } = usePublishIntent();
+  const [retrying, setRetrying] = useState(false);
+
+  if (!pendingIntent) return null;
+
+  const maxRetriesExceeded = pendingIntent.retryCount >= MAX_RETRY_COUNT;
+
+  const handleRetry = async () => {
+    setRetrying(true);
+    await retryIndexing();
+    setRetrying(false);
+  };
+
+  return (
+    <div className="mb-6 rounded-lg border border-accent-dim/30 bg-surface px-4 py-4">
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 text-accent-dim text-sm">!</span>
+        <div className="flex-1">
+          <p className="text-sm font-medium text-foreground">
+            Previous publish needs indexing
+          </p>
+          <p className="mt-1 text-xs text-muted">
+            Your transaction was confirmed on-chain but indexing failed.
+            {maxRetriesExceeded
+              ? " Maximum retries reached — the backfill process will handle this automatically."
+              : " You can retry indexing or dismiss this notice."}
+          </p>
+
+          {/* Tx hash link */}
+          {pendingIntent.txHash && (
+            <p className="mt-2 text-xs">
+              <span className="text-muted">TX: </span>
+              <a
+                href={`${EXPLORER_URL}/tx/${pendingIntent.txHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent-dim hover:text-accent break-all transition-colors"
+              >
+                {pendingIntent.txHash.slice(0, 10)}...
+                {pendingIntent.txHash.slice(-8)}
+              </a>
+            </p>
+          )}
+
+          {/* Last error */}
+          {pendingIntent.lastError && (
+            <p className="mt-1 text-xs text-error">
+              {pendingIntent.lastError}
+              {pendingIntent.retryCount > 0 && (
+                <span className="text-muted">
+                  {" "}
+                  ({pendingIntent.retryCount}/{MAX_RETRY_COUNT} retries)
+                </span>
+              )}
+            </p>
+          )}
+
+          {/* Actions */}
+          <div className="mt-3 flex gap-2">
+            {!maxRetriesExceeded && (
+              <button
+                type="button"
+                onClick={handleRetry}
+                disabled={retrying}
+                className="rounded border border-accent px-3 py-1.5 text-xs text-accent transition-colors hover:bg-accent hover:text-background disabled:opacity-50"
+              >
+                {retrying ? "Retrying..." : "Retry Indexing"}
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={clearIntent}
+              className="rounded border border-border px-3 py-1.5 text-xs text-muted transition-colors hover:text-foreground"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -5,6 +5,7 @@ import { useWriteContract } from "wagmi";
 import { hashContent } from "../../lib/content";
 import { publicClient } from "../../lib/rpc";
 import type { Hex, Abi, TransactionReceipt } from "viem";
+import { usePublishIntent } from "./usePublishIntent";
 
 export type PublishState =
   | "idle"
@@ -36,15 +37,19 @@ interface PublishOptions {
  *
  * Manages the 5-state flow: uploading -> confirming -> pending -> indexing -> published.
  * Caches CID keyed by content hash for retry (skips re-upload if content unchanged).
+ * Integrates with usePublishIntent for crash-safe recovery.
  */
 export function usePublish() {
   const [state, setState] = useState<PublishState>("idle");
   const [error, setError] = useState<string | null>(null);
   const [txHash, setTxHash] = useState<Hex | undefined>(undefined);
-  const [receipt, setReceipt] = useState<TransactionReceipt | undefined>(undefined);
+  const [receipt, setReceipt] = useState<TransactionReceipt | undefined>(
+    undefined,
+  );
   const cachedCid = useRef<{ cid: string; contentHash: string } | null>(null);
 
   const { writeContractAsync } = useWriteContract();
+  const { saveIntent, persistTxHash, clearIntent } = usePublishIntent();
 
   const execute = useCallback(
     async (opts: PublishOptions) => {
@@ -75,27 +80,59 @@ export function usePublish() {
           cachedCid.current = { cid, contentHash };
         }
 
+        // Save intent before wallet confirmation
+        saveIntent({
+          content: opts.content,
+          metadata: opts.metadata ?? {},
+          indexerRoute: opts.indexerRoute,
+          uploadKeyPrefix: opts.uploadKeyPrefix,
+        });
+
         // 2. Submit tx to wallet
         setState("confirming");
         const writeCall = opts.buildWriteCall(cid, contentHash);
 
-        const hash = await writeContractAsync(writeCall);
+        let hash: Hex;
+        try {
+          hash = await writeContractAsync(writeCall);
+        } catch (err) {
+          // User rejected tx — clear intent, no recovery needed
+          clearIntent();
+          throw err;
+        }
         setTxHash(hash);
+
+        // Persist tx hash after wallet confirms
+        persistTxHash(hash);
 
         // 3. Wait for tx confirmation
         setState("pending");
-        const receipt = await publicClient.waitForTransactionReceipt({ hash });
+        const txReceipt = await publicClient.waitForTransactionReceipt({
+          hash,
+        });
 
-        setReceipt(receipt);
+        setReceipt(txReceipt);
 
         // 4. Trigger indexer
         setState("indexing");
         await new Promise((r) => setTimeout(r, 5000));
-        await fetch(opts.indexerRoute, {
+        const indexRes = await fetch(opts.indexerRoute, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ txHash: hash, content: opts.content, ...opts.metadata }),
+          body: JSON.stringify({
+            txHash: hash,
+            content: opts.content,
+            ...opts.metadata,
+          }),
         });
+
+        // 409 = already indexed, treat as success
+        if (!indexRes.ok && indexRes.status !== 409) {
+          throw new Error(`Indexing failed (${indexRes.status})`);
+        }
+
+        // Clear intent on success
+        clearIntent();
 
         // 5. Done
         setState("published");
@@ -107,7 +144,7 @@ export function usePublish() {
         setState("error");
       }
     },
-    [writeContractAsync],
+    [writeContractAsync, saveIntent, persistTxHash, clearIntent],
   );
 
   const reset = useCallback(() => {

--- a/src/hooks/usePublishIntent.ts
+++ b/src/hooks/usePublishIntent.ts
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+
+export interface PublishIntent {
+  txHash: string | null;
+  content: string;
+  metadata: Record<string, string>;
+  indexerRoute: string;
+  uploadKeyPrefix: string;
+  createdAt: number;
+  retryCount: number;
+  lastError: string | null;
+}
+
+const STORAGE_KEY = "plotlink_publish_intent_v1";
+const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
+export const MAX_RETRY_COUNT = 5;
+
+function readIntent(): PublishIntent | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as PublishIntent;
+  } catch {
+    return null;
+  }
+}
+
+function writeIntent(intent: PublishIntent): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(intent));
+  } catch {
+    // localStorage full or unavailable
+  }
+}
+
+function removeIntent(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // silent
+  }
+}
+
+/**
+ * localStorage-backed publish intent for crash-safe recovery.
+ *
+ * Stores intent before wallet confirmation. If the browser crashes after
+ * on-chain tx but before indexing completes, the intent survives and can
+ * be retried on next page load.
+ */
+export function usePublishIntent() {
+  const [pendingIntent, setPendingIntent] = useState<PublishIntent | null>(
+    () => {
+      if (typeof window === "undefined") return null;
+      const intent = readIntent();
+      if (!intent) return null;
+      // Discard intents without txHash that are older than 24h
+      if (
+        !intent.txHash &&
+        Date.now() - intent.createdAt > STALE_THRESHOLD_MS
+      ) {
+        removeIntent();
+        return null;
+      }
+      // Only surface intents that have a txHash (tx confirmed) but indexing never succeeded
+      return intent.txHash ? intent : null;
+    },
+  );
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const saveIntent = useCallback(
+    (data: Omit<PublishIntent, "txHash" | "createdAt" | "retryCount" | "lastError">) => {
+      const intent: PublishIntent = {
+        ...data,
+        txHash: null,
+        createdAt: Date.now(),
+        retryCount: 0,
+        lastError: null,
+      };
+      writeIntent(intent);
+    },
+    [],
+  );
+
+  const persistTxHash = useCallback((hash: string) => {
+    const intent = readIntent();
+    if (!intent) return;
+    const updated = { ...intent, txHash: hash };
+    writeIntent(updated);
+    // Don't setPendingIntent here — avoids recovery UI flash during active session
+  }, []);
+
+  const clearIntent = useCallback(() => {
+    removeIntent();
+    if (mountedRef.current) setPendingIntent(null);
+  }, []);
+
+  const retryIndexing = useCallback(async (): Promise<{
+    success: boolean;
+    error?: string;
+  }> => {
+    const intent = readIntent();
+    if (!intent?.txHash) {
+      return { success: false, error: "No transaction found" };
+    }
+
+    try {
+      const response = await fetch(intent.indexerRoute, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          txHash: intent.txHash,
+          content: intent.content,
+          ...intent.metadata,
+        }),
+      });
+
+      // 409 = already indexed (idempotent success)
+      if (response.ok || response.status === 409) {
+        removeIntent();
+        if (mountedRef.current) setPendingIntent(null);
+        return { success: true };
+      }
+
+      const errorMessage = `Indexer error (${response.status})`;
+      const updated: PublishIntent = {
+        ...intent,
+        retryCount: intent.retryCount + 1,
+        lastError: errorMessage,
+      };
+      writeIntent(updated);
+      if (mountedRef.current) setPendingIntent(updated);
+      return { success: false, error: errorMessage };
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "Network error";
+      const updated: PublishIntent = {
+        ...intent,
+        retryCount: intent.retryCount + 1,
+        lastError: errorMessage,
+      };
+      writeIntent(updated);
+      if (mountedRef.current) setPendingIntent(updated);
+      return { success: false, error: errorMessage };
+    }
+  }, []);
+
+  return {
+    pendingIntent,
+    saveIntent,
+    persistTxHash,
+    clearIntent,
+    retryIndexing,
+  };
+}


### PR DESCRIPTION
## Summary

Fixes #267

- **`usePublishIntent` hook** — localStorage-backed intent that tracks pending publishes across browser sessions. Saves before wallet confirmation, persists tx hash after on-chain confirmation, clears on indexing success, retains on failure with retry count.
- **`usePublish` integration** — Intent lifecycle wired into the 5-state publish flow. User-rejected tx clears intent immediately (no false recovery). Indexer 409 treated as idempotent success.
- **`PublishRecovery` component** — Recovery banner showing tx hash (linked to explorer), retry button, dismiss option, max retry warning (5 retries). Renders nothing when no pending intent exists.
- **Create + Chain pages** — Recovery banner mounted on both `src/app/create/page.tsx` and `src/app/chain/page.tsx`.

### Error classification
- User rejected tx → intent cleared, no recovery
- Tx confirmed, indexer fails → intent persisted with txHash, recovery UI on reload
- Indexer 409 → idempotent success, intent cleared
- Stale intents (24h, no txHash) → auto-cleaned on mount

## Test plan
- [ ] Normal publish flow works unchanged (intent saved + cleared transparently)
- [ ] After simulated indexer failure: reload page shows recovery banner
- [ ] Recovery banner shows tx hash linked to block explorer
- [ ] "Retry Indexing" re-sends POST with all metadata
- [ ] "Dismiss" clears the intent
- [ ] User-rejected wallet tx does not trigger recovery on reload
- [ ] Indexer 409 response clears the intent (no recovery shown)
- [ ] Recovery works on both create page and chain page
- [ ] Max retry count (5) shows warning message
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)