### PR TITLE
[#267] Indexing recovery UI for failed publish

### DIFF
--- a/src/app/chain/page.tsx
+++ b/src/app/chain/page.tsx
@@ -11,6 +11,8 @@ import {
 import { supabase, type Storyline } from "../../../lib/supabase";
 import { STORY_FACTORY } from "../../../lib/contracts/constants";
 import { useChainPlot } from "../../hooks/useChainPlot";
+import { usePublishIntent } from "../../hooks/usePublishIntent";
+import { RecoveryBanner } from "../../components/RecoveryBanner";
 import type { PublishState } from "../../hooks/usePublish";
 import Link from "next/link";
 import { ConnectWallet } from "../../components/ConnectWallet";
@@ -52,7 +54,13 @@ export default function ChainPlotPage() {
     enabled: isConnected && !!address,
   });
 
-  const { state, error, chainPlot, reset } = useChainPlot();
+  const { pendingIntent, saveIntent, persistTxHash, clearIntent, attemptRetry } =
+    usePublishIntent();
+  const { state, error, chainPlot, reset } = useChainPlot({
+    onIntentSave: saveIntent,
+    onTxConfirmed: persistTxHash,
+    onIndexed: clearIntent,
+  });
   const { valid, charCount } = validateContentLength(content);
   const titleValid = title.trim().length > 0;
   const canSubmit =
@@ -104,6 +112,16 @@ export default function ChainPlotPage() {
       <h1 className="text-accent text-2xl font-bold tracking-tight">
         Chain Plot
       </h1>
+
+      {pendingIntent && (
+        <div className="mt-6">
+          <RecoveryBanner
+            intent={pendingIntent}
+            onRetry={attemptRetry}
+            onDismiss={clearIntent}
+          />
+        </div>
+      )}
 
       <form
         onSubmit={(e) => {

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -8,6 +8,8 @@ import {
   MAX_CONTENT_LENGTH,
 } from "../../../lib/content";
 import { usePublish, type PublishState } from "../../hooks/usePublish";
+import { usePublishIntent } from "../../hooks/usePublishIntent";
+import { RecoveryBanner } from "../../components/RecoveryBanner";
 import { storyFactoryAbi, storylineCreatedEvent } from "../../../lib/contracts/abi";
 import { STORY_FACTORY } from "../../../lib/contracts/constants";
 import { decodeEventLog, encodeEventTopics } from "viem";
@@ -46,6 +48,8 @@ export default function CreateStorylinePage() {
   const hasDeadline = true; // mandatory 7-day deadline for all storylines
 
   const { state, error, receipt, execute, reset } = usePublish();
+  const { pendingIntent, saveIntent, persistTxHash, clearIntent, attemptRetry } =
+    usePublishIntent();
   const { valid, charCount } = validateContentLength(content);
   const titleValid = title.trim().length > 0;
   const genreValid = genre.length > 0;
@@ -115,6 +119,16 @@ export default function CreateStorylinePage() {
         Create Storyline
       </h1>
 
+      {pendingIntent && (
+        <div className="mt-6">
+          <RecoveryBanner
+            intent={pendingIntent}
+            onRetry={attemptRetry}
+            onDismiss={clearIntent}
+          />
+        </div>
+      )}
+
       <form
         onSubmit={(e) => {
           e.preventDefault();
@@ -131,6 +145,9 @@ export default function CreateStorylinePage() {
                 gas: BigInt(16_000_000),
               }),
               metadata: { genre, language },
+              onIntentSave: saveIntent,
+              onTxConfirmed: persistTxHash,
+              onIndexed: clearIntent,
             });
         }}
         className="mt-8 space-y-6"

--- a/src/components/RecoveryBanner.tsx
+++ b/src/components/RecoveryBanner.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import { EXPLORER_URL } from "../../lib/contracts/constants";
+import type { PublishIntentData } from "../hooks/usePublishIntent";
+import { MAX_RETRY_ATTEMPTS } from "../hooks/usePublishIntent";
+
+interface RecoveryBannerProps {
+  intent: PublishIntentData;
+  onRetry: () => Promise<{ success: boolean; error?: string }>;
+  onDismiss: () => void;
+}
+
+export function RecoveryBanner({
+  intent,
+  onRetry,
+  onDismiss,
+}: RecoveryBannerProps) {
+  const [retrying, setRetrying] = useState(false);
+  const exhausted = intent.retryCount >= MAX_RETRY_ATTEMPTS;
+
+  async function handleRetry() {
+    setRetrying(true);
+    await onRetry();
+    setRetrying(false);
+  }
+
+  return (
+    <div className="border-accent/40 bg-surface mb-6 rounded border p-4">
+      <p className="text-foreground text-sm font-medium">
+        Your previous story was published on-chain but indexing failed.
+      </p>
+
+      {intent.txHash && (
+        <p className="text-muted mt-1 text-xs">
+          Tx:{" "}
+          <a
+            href={`${EXPLORER_URL}/tx/${intent.txHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            {intent.txHash.slice(0, 10)}...{intent.txHash.slice(-8)}
+          </a>
+        </p>
+      )}
+
+      {intent.lastError && (
+        <p className="text-error mt-1 text-xs">
+          Last error: {intent.lastError}
+        </p>
+      )}
+
+      {exhausted && (
+        <p className="text-muted mt-2 text-xs">
+          Max retries reached. You can dismiss — the backfill cron will index
+          this automatically, but client-side metadata (genre, language) may be
+          lost.
+        </p>
+      )}
+
+      <div className="mt-3 flex gap-2">
+        <button
+          onClick={handleRetry}
+          disabled={retrying || exhausted}
+          className="border-accent text-accent hover:bg-accent hover:text-background rounded border px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50"
+        >
+          {retrying ? "Retrying..." : "Retry Indexing"}
+        </button>
+        <button
+          onClick={onDismiss}
+          disabled={retrying}
+          className="border-border text-muted hover:text-foreground rounded border px-3 py-1.5 text-xs transition-colors disabled:opacity-50"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useChainPlot.ts
+++ b/src/hooks/useChainPlot.ts
@@ -5,11 +5,22 @@ import { usePublish } from "./usePublish";
 import { storyFactoryAbi } from "../../lib/contracts/abi";
 import { STORY_FACTORY } from "../../lib/contracts/constants";
 
+interface ChainPlotIntentCallbacks {
+  onIntentSave?: (opts: {
+    content: string;
+    metadata: Record<string, string>;
+    indexerRoute: string;
+    uploadKeyPrefix: string;
+  }) => void;
+  onTxConfirmed?: (hash: string) => void;
+  onIndexed?: () => void;
+}
+
 /**
  * Chain a plot to an existing storyline (P3-3).
  * Reuses the shared publishing state machine from usePublish.
  */
-export function useChainPlot() {
+export function useChainPlot(intentCallbacks?: ChainPlotIntentCallbacks) {
   const { state, error, txHash, execute, reset } = usePublish();
 
   const chainPlot = useCallback(
@@ -25,9 +36,12 @@ export function useChainPlot() {
           args: [BigInt(storylineId), title, cid, contentHash],
           gas: BigInt(500_000),
         }),
+        onIntentSave: intentCallbacks?.onIntentSave,
+        onTxConfirmed: intentCallbacks?.onTxConfirmed,
+        onIndexed: intentCallbacks?.onIndexed,
       });
     },
-    [execute],
+    [execute, intentCallbacks],
   );
 
   return { state, error, txHash, chainPlot, reset };

--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -128,14 +128,18 @@ export function usePublish() {
         // 4. Trigger indexer
         setState("indexing");
         await new Promise((r) => setTimeout(r, 5000));
-        await fetch(opts.indexerRoute, {
+        const indexerRes = await fetch(opts.indexerRoute, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ txHash: hash, content: opts.content, ...opts.metadata }),
         });
 
-        // Clear intent after successful indexing
-        opts.onIndexed?.();
+        // Only clear intent on success (2xx) or 409 (already indexed)
+        if (indexerRes.ok || indexerRes.status === 409) {
+          opts.onIndexed?.();
+        } else {
+          throw new Error(`Indexer error (${indexerRes.status})`);
+        }
 
         // 5. Done
         setState("published");

--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -115,14 +115,15 @@ export function usePublish() {
         const hash = await writeContractAsync(writeCall);
         setTxHash(hash);
 
+        // Persist tx hash immediately after broadcast (before receipt polling)
+        // so recovery works even if receipt polling fails
+        opts.onTxConfirmed?.(hash);
+
         // 3. Wait for tx confirmation
         setState("pending");
         const receipt = await publicClient.waitForTransactionReceipt({ hash });
 
         setReceipt(receipt);
-
-        // Persist tx hash after on-chain confirmation
-        opts.onTxConfirmed?.(hash);
 
         // 4. Trigger indexer
         setState("indexing");

--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -29,6 +29,31 @@ interface PublishOptions {
   indexerRoute: string;
   buildWriteCall: (cid: string, contentHash: Hex) => WriteCall;
   metadata?: Record<string, string>;
+  /** Called before wallet confirmation to save intent */
+  onIntentSave?: (opts: {
+    content: string;
+    metadata: Record<string, string>;
+    indexerRoute: string;
+    uploadKeyPrefix: string;
+  }) => void;
+  /** Called after tx confirms to persist tx hash */
+  onTxConfirmed?: (hash: string) => void;
+  /** Called after successful indexing to clear intent */
+  onIndexed?: () => void;
+}
+
+/**
+ * Returns true if the error is a user-rejected transaction (wallet popup dismissed).
+ */
+function isUserRejection(err: unknown): boolean {
+  const message =
+    err instanceof Error ? err.message.toLowerCase() : String(err).toLowerCase();
+  return (
+    message.includes("user rejected") ||
+    message.includes("user denied") ||
+    message.includes("rejected the request") ||
+    message.includes("cancelled")
+  );
 }
 
 /**
@@ -75,6 +100,14 @@ export function usePublish() {
           cachedCid.current = { cid, contentHash };
         }
 
+        // Save intent before wallet confirmation
+        opts.onIntentSave?.({
+          content: opts.content,
+          metadata: opts.metadata ?? {},
+          indexerRoute: opts.indexerRoute,
+          uploadKeyPrefix: opts.uploadKeyPrefix,
+        });
+
         // 2. Submit tx to wallet
         setState("confirming");
         const writeCall = opts.buildWriteCall(cid, contentHash);
@@ -88,6 +121,9 @@ export function usePublish() {
 
         setReceipt(receipt);
 
+        // Persist tx hash after on-chain confirmation
+        opts.onTxConfirmed?.(hash);
+
         // 4. Trigger indexer
         setState("indexing");
         await new Promise((r) => setTimeout(r, 5000));
@@ -97,6 +133,9 @@ export function usePublish() {
           body: JSON.stringify({ txHash: hash, content: opts.content, ...opts.metadata }),
         });
 
+        // Clear intent after successful indexing
+        opts.onIndexed?.();
+
         // 5. Done
         setState("published");
         cachedCid.current = null;
@@ -105,6 +144,11 @@ export function usePublish() {
           err instanceof Error ? err.message : "Unknown error";
         setError(message);
         setState("error");
+
+        // User rejected tx — clear intent (no recovery needed)
+        if (isUserRejection(err)) {
+          opts.onIndexed?.(); // reuse onIndexed to clear intent
+        }
       }
     },
     [writeContractAsync],

--- a/src/hooks/usePublishIntent.ts
+++ b/src/hooks/usePublishIntent.ts
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+
+export interface PublishIntentData {
+  txHash: string | null;
+  content: string;
+  metadata: Record<string, string>;
+  indexerRoute: string;
+  uploadKeyPrefix: string;
+  createdAt: number;
+  retryCount: number;
+  lastError: string | null;
+}
+
+const STORAGE_KEY = "plotlink_publish_intent_v1";
+const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
+export const MAX_RETRY_ATTEMPTS = 5;
+
+function readIntent(): PublishIntentData | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as PublishIntentData;
+  } catch {
+    return null;
+  }
+}
+
+function writeIntent(intent: PublishIntentData): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(intent));
+  } catch {
+    // localStorage full or unavailable
+  }
+}
+
+function removeIntent(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // silent
+  }
+}
+
+function loadPendingIntent(): PublishIntentData | null {
+  const intent = readIntent();
+  if (!intent) return null;
+
+  // Discard stale intents without a tx hash
+  if (!intent.txHash && Date.now() - intent.createdAt > STALE_THRESHOLD_MS) {
+    removeIntent();
+    return null;
+  }
+
+  // Pending = has txHash but indexer never succeeded
+  return intent.txHash ? intent : null;
+}
+
+export function usePublishIntent() {
+  const [pendingIntent, setPendingIntent] = useState<PublishIntentData | null>(
+    loadPendingIntent,
+  );
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const saveIntent = useCallback(
+    (opts: {
+      content: string;
+      metadata: Record<string, string>;
+      indexerRoute: string;
+      uploadKeyPrefix: string;
+    }): void => {
+      const intent: PublishIntentData = {
+        txHash: null,
+        content: opts.content,
+        metadata: opts.metadata,
+        indexerRoute: opts.indexerRoute,
+        uploadKeyPrefix: opts.uploadKeyPrefix,
+        createdAt: Date.now(),
+        retryCount: 0,
+        lastError: null,
+      };
+      writeIntent(intent);
+    },
+    [],
+  );
+
+  const persistTxHash = useCallback((hash: string): void => {
+    const intent = readIntent();
+    if (!intent) return;
+    const updated = { ...intent, txHash: hash };
+    writeIntent(updated);
+    // Don't setPendingIntent here — avoids recovery UI flash during active session
+  }, []);
+
+  const clearIntent = useCallback((): void => {
+    removeIntent();
+    if (mountedRef.current) setPendingIntent(null);
+  }, []);
+
+  const attemptRetry = useCallback(async (): Promise<{
+    success: boolean;
+    error?: string;
+  }> => {
+    const intent = readIntent();
+    if (!intent?.txHash) {
+      return { success: false, error: "No pending transaction found" };
+    }
+
+    try {
+      const response = await fetch(intent.indexerRoute, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          txHash: intent.txHash,
+          content: intent.content,
+          ...intent.metadata,
+        }),
+      });
+
+      // 409 = already indexed, treat as success
+      if (response.ok || response.status === 409) {
+        removeIntent();
+        if (mountedRef.current) setPendingIntent(null);
+        return { success: true };
+      }
+
+      const errorMessage = `Indexer error (${response.status})`;
+      const updated: PublishIntentData = {
+        ...intent,
+        retryCount: intent.retryCount + 1,
+        lastError: errorMessage,
+      };
+      writeIntent(updated);
+      if (mountedRef.current) setPendingIntent(updated);
+      return { success: false, error: errorMessage };
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "Network error";
+      const updated: PublishIntentData = {
+        ...intent,
+        retryCount: intent.retryCount + 1,
+        lastError: errorMessage,
+      };
+      writeIntent(updated);
+      if (mountedRef.current) setPendingIntent(updated);
+      return { success: false, error: errorMessage };
+    }
+  }, []);
+
+  return {
+    pendingIntent,
+    saveIntent,
+    persistTxHash,
+    clearIntent,
+    attemptRetry,
+  };
+}


### PR DESCRIPTION
## Summary
- New `usePublishIntent` hook: localStorage-based intent that persists content, metadata, tx hash, and indexer route across page reloads
- Updated `usePublish` to accept intent lifecycle callbacks (`onIntentSave`, `onTxConfirmed`, `onIndexed`) — user-rejected transactions clear intent immediately, all other errors preserve it for recovery
- New `RecoveryBanner` component: shows on create/chain pages when a pending intent exists, with retry (re-sends indexer POST) and dismiss options
- Wired into both `/create` (storyline) and `/chain` (plot chaining) pages

## Key design decisions
- **Error classification in `usePublish.ts`**: Only user-rejected tx clears the intent. Network errors, receipt poll failures, and indexer failures all preserve the intent for recovery (addresses T2a feedback on PR #280)
- **Lazy `useState` init** instead of `useEffect` for loading pending intent (avoids React strict-mode lint rule)
- **409 from indexer** treated as idempotent success (intent cleared)
- **Max 5 retries** with warning after exhausted; dismiss available at any time

## Test plan
- [ ] Create a storyline — verify intent is saved to localStorage before wallet popup
- [ ] Reject wallet popup — verify intent is cleared (no false recovery on reload)
- [ ] Simulate indexer failure (e.g., disconnect network after tx confirms) — verify recovery banner on page reload
- [ ] Click "Retry Indexing" — verify indexer POST is re-sent with all metadata
- [ ] Click "Dismiss" — verify intent is cleared
- [ ] Repeat above for plot chaining (`/chain`)
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (no new warnings)

Fixes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)