### PR TITLE
[#287] Show Farcaster identity on plot pages

### DIFF
--- a/src/app/story/[storylineId]/[plotIndex]/page.tsx
+++ b/src/app/story/[storylineId]/[plotIndex]/page.tsx
@@ -1,8 +1,10 @@
 import { type Metadata } from "next";
+import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import { createServerClient, type Storyline, type Plot } from "../../../../../lib/supabase";
 import { STORY_FACTORY } from "../../../../../lib/contracts/constants";
 import { truncateAddress } from "../../../../../lib/utils";
+import { WriterIdentity } from "../../../../components/WriterIdentity";
 import { ViewTracker } from "../../../../components/ViewCount";
 import { CommentSection } from "../../../../components/CommentSection";
 import Link from "next/link";
@@ -104,7 +106,12 @@ export default async function PlotDetailPage({ params }: { params: Params }) {
           {chapterTitle}
         </h1>
         <div className="text-muted mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs">
-          <span>by {truncateAddress(sl.writer_address)}</span>
+          <span>
+            by{" "}
+            <Suspense fallback={<span className="text-foreground">{truncateAddress(sl.writer_address)}</span>}>
+              <WriterIdentity address={sl.writer_address} />
+            </Suspense>
+          </span>
           {p.block_timestamp && (
             <time dateTime={p.block_timestamp}>
               {new Date(p.block_timestamp).toLocaleDateString("en-US", {

--- a/src/app/story/[storylineId]/og/route.tsx
+++ b/src/app/story/[storylineId]/og/route.tsx
@@ -2,6 +2,7 @@ import { ImageResponse } from "next/og";
 import { type Address } from "viem";
 import { createServerClient, type Storyline } from "../../../../../lib/supabase";
 import { getTokenPrice } from "../../../../../lib/price";
+import { lookupByAddress } from "../../../../../lib/farcaster";
 import { RESERVE_LABEL, STORY_FACTORY } from "../../../../../lib/contracts/constants";
 import { truncateAddress } from "../../../../../lib/utils";
 
@@ -37,9 +38,10 @@ export async function GET(
 
   const sl = storyline as Storyline;
 
-  const priceInfo = sl.token_address
-    ? await getTokenPrice(sl.token_address as Address)
-    : null;
+  const [priceInfo, farcasterProfile] = await Promise.all([
+    sl.token_address ? getTokenPrice(sl.token_address as Address) : null,
+    lookupByAddress(sl.writer_address).catch(() => null),
+  ]);
 
   const reserveLabel = RESERVE_LABEL;
   const priceDisplay = priceInfo
@@ -103,7 +105,7 @@ export async function GET(
             color: "#737373",
           }}
         >
-          <span>by {truncateAddress(sl.writer_address)}</span>
+          <span>by {farcasterProfile ? `@${farcasterProfile.username}` : truncateAddress(sl.writer_address)}</span>
           <span>
             {sl.plot_count} {sl.plot_count === 1 ? "plot" : "plots"}
           </span>


### PR DESCRIPTION
## Summary
- Plot detail page: replaced `truncateAddress(sl.writer_address)` with `<WriterIdentity>` wrapped in `<Suspense>` (same pattern as storyline page)
- OG image route: resolves Farcaster fname server-side via `lookupByAddress()` in parallel with price fetch, falls back to truncated address

## Test plan
- [ ] Plot detail page shows Farcaster @username + avatar for linked writers
- [ ] Plot detail page falls back to truncated address for non-Farcaster writers
- [ ] OG image (`/story/{id}/og`) shows @username when Farcaster is linked
- [ ] OG image falls back to truncated address when not linked
- [ ] `npm run typecheck` passes

Fixes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)