### PR TITLE
[#294] Book card polish: accent title + metadata alignment

### DIFF
--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -49,7 +49,7 @@ export function StoryCard({
 
             {/* Center: title */}
             <div className="flex flex-1 flex-col items-center justify-center px-2 text-center">
-              <h3 className="text-foreground text-base font-bold leading-tight tracking-tight sm:text-lg">
+              <h3 className="text-accent text-base font-bold leading-tight tracking-tight sm:text-lg">
                 {storyline.title}
               </h3>
               {storyline.language && storyline.language !== "English" && (
@@ -69,7 +69,7 @@ export function StoryCard({
       </div>
 
       {/* Metadata row below card */}
-      <div className="text-muted mt-2 flex flex-wrap items-center justify-between gap-x-2 gap-y-1 px-1 text-[10px]">
+      <div className="text-muted mt-2 flex flex-wrap items-center justify-between gap-x-2 gap-y-1 pl-[7px] pr-1 text-[10px]">
         <div className="flex items-center gap-1">
           {storyline.token_address && (
             <>


### PR DESCRIPTION
## Summary
- Book title color changed from `text-foreground` (white) to `text-accent` (green) to reinforce the terminal aesthetic
- Metadata row left padding adjusted from `px-1` to `pl-[7px] pr-1` to align with the front cover's visual left edge (6px layer offset + 1px border)

Fixes #294

## Test plan
- [ ] Verify book titles render in green (#00ff88) on home page
- [ ] Verify metadata row (TVL, plot count, rating) aligns with card left edge
- [ ] Check responsive behavior at mobile (2-col) and desktop (3-col) grid sizes
- [ ] Confirm no layout shifts or text clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)