### PR TITLE
[#296] Replace $ logo with SVG symbol in nav bar

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ConnectWallet } from "./ConnectWallet";
@@ -24,7 +25,7 @@ export function NavBar() {
           href="/"
           className="text-accent text-sm font-bold tracking-tight transition-opacity hover:opacity-80"
         >
-          <img src="/plotlink-logo-symbol.svg" alt="" width={18} height={18} className="mr-1.5 inline-block align-middle" />
+          <Image src="/plotlink-logo-symbol.svg" alt="" width={18} height={18} className="mr-1.5 inline-block align-middle" />
           <span className="align-middle">PlotLink</span>
         </Link>
 

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -24,8 +24,8 @@ export function NavBar() {
           href="/"
           className="text-accent text-sm font-bold tracking-tight transition-opacity hover:opacity-80"
         >
-          <span className="text-muted mr-1 font-normal">$</span>
-          PlotLink
+          <img src="/plotlink-logo-symbol.svg" alt="" width={18} height={18} className="mr-1.5 inline-block align-middle" />
+          <span className="align-middle">PlotLink</span>
         </Link>
 
         {/* Desktop nav links */}


### PR DESCRIPTION
## Summary
- Replaced the `$` text character in the nav bar logo with an `<img>` referencing `/plotlink-logo-symbol.svg`
- Logo sized at 18×18px, vertically aligned with "PlotLink" text using `align-middle`
- Link to `/` preserved, no layout shift

Fixes #296

## Test plan
- [ ] Verify SVG logo renders in nav bar instead of `$` character
- [ ] Verify vertical alignment with "PlotLink" text
- [ ] Check mobile and desktop nav bar appearance
- [ ] Confirm link still navigates to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)