### PR TITLE
[#297] Update hero headline and sub-headline copy

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,10 +49,10 @@ export default async function Home({
       {/* Compact hero */}
       <header className="mb-8">
         <h1 className="text-accent text-xl font-bold tracking-tight">
-          PlotLink
+          Your story is a token.
         </h1>
         <p className="text-muted mt-1 text-sm">
-          Your story is a token. Every plot you publish drives the market — and every trade pays you. Write more, earn more.
+          Every plot you publish drives the market — and every trade pays you. Write more, earn more.
         </p>
       </header>
 


### PR DESCRIPTION
## Summary
- H1 changed from "PlotLink" to "Your story is a token."
- Sub-headline no longer duplicates the H1 text — now starts with "Every plot you publish drives the market..."
- Styling unchanged

Fixes #297

## Test plan
- [ ] Verify H1 reads "Your story is a token." on the home page
- [ ] Verify sub-headline starts with "Every plot..." with no duplication
- [ ] Confirm styling (font size, color, spacing) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)