### PR TITLE
[#302] Stack TVL and plot count on separate lines

### DIFF
--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -68,19 +68,16 @@ export function StoryCard({
         </Link>
       </div>
 
-      {/* Metadata row below card */}
-      <div className="text-muted mt-2 flex flex-wrap items-center justify-between gap-x-2 gap-y-1 pl-[7px] pr-1 text-[10px]">
-        <div className="flex items-center gap-1">
-          {storyline.token_address && (
-            <>
-              <StoryCardTVL tokenAddress={storyline.token_address} />
-              <span>|</span>
-            </>
-          )}
-          <span>
-            {storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"} linked
+      {/* Metadata below card */}
+      <div className="text-muted mt-2 flex flex-col gap-0.5 pl-[7px] pr-1 text-[10px]">
+        {storyline.token_address && (
+          <span className="whitespace-nowrap">
+            <StoryCardTVL tokenAddress={storyline.token_address} />
           </span>
-        </div>
+        )}
+        <span className="whitespace-nowrap">
+          {storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"} linked
+        </span>
         <RatingSummary storylineId={storyline.storyline_id} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Metadata below story cards now stacks vertically (flex-col) instead of inline
- Removed `|` separator between TVL and plot count
- Each value has `whitespace-nowrap` to prevent mid-value breaks on narrow cards
- Rating summary remains visible on its own line

Fixes #302

## Test plan
- [ ] Verify TVL and plot count on separate lines on mobile (2-col grid)
- [ ] Verify neither value wraps at narrow widths
- [ ] Verify rating summary still visible
- [ ] Check desktop (3-col grid) layout is acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)