### PR TITLE
[#303] Tidy discovery filter bar layout on mobile

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -57,12 +57,10 @@ export default async function Home({
       </header>
 
       {/* Filter bar */}
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex flex-wrap items-center gap-3">
-          <WriterFilter active={writer} tab={tab} basePath="/" />
-          <GenreFilter active={genre} tab={tab} writer={writer} lang={lang} />
-          <LanguageFilter active={lang} tab={tab} writer={writer} genre={genre} />
-        </div>
+      <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:items-center sm:justify-between sm:gap-3">
+        <WriterFilter active={writer} tab={tab} basePath="/" />
+        <GenreFilter active={genre} tab={tab} writer={writer} lang={lang} />
+        <LanguageFilter active={lang} tab={tab} writer={writer} genre={genre} />
         <SortDropdown active={tab} writer={writer} basePath="/" />
       </div>
 


### PR DESCRIPTION
## Summary
- Mobile: uses `grid grid-cols-2` to organize filters into two clean rows (Writer+Genre, Language+Sort)
- Desktop (sm+): reverts to original `flex-wrap` row layout via responsive classes
- No functionality changes — same query params and controls

Fixes #303

## Test plan
- [ ] Verify mobile shows 2x2 grid: Writer+Genre on row 1, Language+Sort on row 2
- [ ] Verify all four controls remain accessible and functional
- [ ] Verify desktop layout unchanged (flex row)
- [ ] Confirm no query param changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)