### PR TITLE
[#304] Floating bottom bar for Trade/Donate/Rate on mobile

### DIFF
--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -17,6 +17,7 @@ import { AgentBadge } from "../../../components/AgentBadge";
 import { WriterIdentity } from "../../../components/WriterIdentity";
 import { ViewCount, ViewTracker } from "../../../components/ViewCount";
 import { CommentSection } from "../../../components/CommentSection";
+import { MobileActionBar } from "../../../components/MobileActionBar";
 
 type Params = Promise<{ storylineId: string }>;
 
@@ -130,7 +131,7 @@ export default async function StoryPage({ params }: { params: Params }) {
     : null;
 
   return (
-    <div className="mx-auto max-w-5xl px-6 py-10">
+    <div className="mx-auto max-w-5xl px-6 py-10 pb-24 lg:pb-10">
       <ViewTracker storylineId={id} />
       <StoryHeader storyline={storyline} priceInfo={priceInfo} />
 
@@ -152,10 +153,15 @@ export default async function StoryPage({ params }: { params: Params }) {
               chapters={chapters}
             />
           )}
+
+          {/* Share — visible on mobile (sidebar hidden) */}
+          <div className="mt-6 lg:hidden">
+            <ShareToFarcaster storylineId={id} title={sl.title} />
+          </div>
         </main>
 
-        {/* Sidebar — engagement widgets */}
-        <aside className="order-first space-y-4 lg:order-none">
+        {/* Sidebar — desktop only */}
+        <aside className="hidden space-y-4 lg:block">
           {sl.token_address && priceInfo && (
             <PriceChart
               tokenAddress={sl.token_address as Address}
@@ -173,6 +179,32 @@ export default async function StoryPage({ params }: { params: Params }) {
           <ShareToFarcaster storylineId={id} title={sl.title} />
         </aside>
       </div>
+
+      {/* Mobile floating bottom bar */}
+      <MobileActionBar
+        tradeContent={
+          sl.token_address ? (
+            <>
+              {priceInfo && (
+                <PriceChart
+                  tokenAddress={sl.token_address as Address}
+                  totalSupplyRaw={priceInfo.totalSupplyRaw}
+                  currentPriceRaw={priceInfo.priceRaw}
+                />
+              )}
+              <TradingWidget tokenAddress={sl.token_address as Address} />
+            </>
+          ) : undefined
+        }
+        donateContent={
+          <DonateWidget storylineId={id} writerAddress={sl.writer_address} />
+        }
+        rateContent={
+          sl.token_address ? (
+            <RatingWidget storylineId={id} tokenAddress={sl.token_address} />
+          ) : undefined
+        }
+      />
     </div>
   );
 }

--- a/src/components/MobileActionBar.tsx
+++ b/src/components/MobileActionBar.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+
+type Panel = "trade" | "donate" | "rate" | null;
+
+export function MobileActionBar({
+  tradeContent,
+  donateContent,
+  rateContent,
+}: {
+  tradeContent?: ReactNode;
+  donateContent: ReactNode;
+  rateContent?: ReactNode;
+}) {
+  const [open, setOpen] = useState<Panel>(null);
+
+  const buttons: { key: Panel; label: string; content?: ReactNode }[] = [
+    { key: "trade", label: "Trade", content: tradeContent },
+    { key: "donate", label: "Donate", content: donateContent },
+    { key: "rate", label: "Rate", content: rateContent },
+  ].filter((b) => b.content != null) as { key: Panel; label: string; content: ReactNode }[];
+
+  return (
+    <div className="lg:hidden">
+      {/* Backdrop */}
+      {open && (
+        <div
+          className="fixed inset-0 z-40 bg-black/60"
+          onClick={() => setOpen(null)}
+        />
+      )}
+
+      {/* Bottom sheet */}
+      {open && (
+        <div className="fixed inset-x-0 bottom-0 z-50 max-h-[80vh] overflow-y-auto rounded-t-lg border-t border-[var(--border)] bg-[var(--bg)] p-4">
+          <div className="mb-3 flex items-center justify-between">
+            <span className="text-foreground text-sm font-medium capitalize">
+              {open}
+            </span>
+            <button
+              onClick={() => setOpen(null)}
+              className="text-muted hover:text-foreground text-xs transition-colors"
+            >
+              [close]
+            </button>
+          </div>
+          <div className="space-y-4">
+            {buttons.find((b) => b.key === open)?.content}
+          </div>
+        </div>
+      )}
+
+      {/* Fixed bottom bar */}
+      <div className="fixed inset-x-0 bottom-0 z-30 grid grid-cols-3 gap-2 border-t border-[var(--border)] bg-[var(--bg)]/95 p-3 backdrop-blur-sm">
+        {buttons.map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => setOpen(open === key ? null : key)}
+            className={`rounded border px-3 py-2 text-xs transition-colors ${
+              open === key
+                ? "border-accent text-accent"
+                : "border-[var(--border)] text-muted hover:text-foreground"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `MobileActionBar` client component: fixed bottom bar (hidden on `lg:`) with Trade, Donate, Rate buttons
- Tapping a button opens a bottom sheet overlay with the corresponding widget (Trade includes PriceChart + TradingWidget)
- Sidebar now `hidden lg:block` — story content is the primary view on mobile
- Share to Farcaster shown inline on mobile (below story content), kept in sidebar on desktop
- Bottom padding (`pb-24 lg:pb-10`) prevents footer from being hidden behind the bar
- Buttons that don't apply (Trade/Rate when no token) are automatically excluded

Fixes #304

## Test plan
- [ ] Mobile: no sidebar widgets above story content
- [ ] Mobile: floating bottom bar visible with Trade/Donate/Rate buttons
- [ ] Tapping each button opens bottom sheet with correct widget
- [ ] Backdrop click closes the sheet
- [ ] Footer visible (not hidden behind bar)
- [ ] Desktop (`lg:`): sidebar layout unchanged
- [ ] Share to Farcaster accessible on both mobile and desktop
- [ ] Stories without token_address: only Donate button shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)