### PR TITLE
[#312] Clean up all ESLint errors and warnings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Compiled SDK output
+    "packages/sdk/dist/**",
   ]),
 ]);
 

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -47,7 +47,7 @@ export default function CreateStorylinePage() {
   const [content, setContent] = useState("");
   const hasDeadline = true; // mandatory 7-day deadline for all storylines
 
-  const { state, error, receipt, execute, reset } = usePublish();
+  const { state, error, receipt, execute } = usePublish();
   const { pendingIntent, saveIntent, persistTxHash, clearIntent, attemptRetry } =
     usePublishIntent();
   const { valid, charCount } = validateContentLength(content);

--- a/src/components/ClaimRoyalties.tsx
+++ b/src/components/ClaimRoyalties.tsx
@@ -84,7 +84,7 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary }: ClaimRo
       setError(err instanceof Error ? err.message : "Claim failed");
       setTxState("error");
     }
-  }, [tokenAddress, unclaimed, writeContractAsync, refetch]);
+  }, [unclaimed, writeContractAsync, refetch]);
 
   const reset = useCallback(() => {
     setTxState("idle");

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 
 export interface SelectOption {
   value: string;
@@ -29,9 +29,10 @@ export function Select({
   const containerRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
 
-  const allOptions = placeholder
-    ? [{ value: "", label: placeholder }, ...options]
-    : options;
+  const allOptions = useMemo(
+    () => (placeholder ? [{ value: "", label: placeholder }, ...options] : options),
+    [placeholder, options],
+  );
 
   const selectedLabel =
     options.find((o) => o.value === value)?.label ?? placeholder;


### PR DESCRIPTION
## Summary
- Excluded `packages/sdk/dist/` from ESLint config (resolves 4 errors + 1 warning from compiled output)
- Removed unused `reset` destructuring in `src/app/create/page.tsx`
- Removed unnecessary `tokenAddress` dependency in `src/components/ClaimRoyalties.tsx`
- Wrapped `allOptions` in `useMemo` in `src/components/Select.tsx`
- `npm run lint` now exits with 0 errors and 0 warnings

Fixes #312

## Test plan
- [ ] `npm run lint` exits cleanly (0 errors, 0 warnings)
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] No functional behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)