### PR TITLE
[#314] Fix filter bar dropdown clipping

### DIFF
--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -66,7 +66,7 @@ export function FilterBar({ writer, genre, lang, tab }: FilterBarProps) {
 
   return (
     <div ref={barRef}>
-      <div className="border-border flex min-w-0 items-center gap-x-3 overflow-x-auto rounded border px-3 py-2 text-xs">
+      <div className="border-border flex min-w-0 items-center gap-x-3 rounded border px-3 py-2 text-xs">
         {/* Writer token + dropdown */}
         <div className="relative min-w-0">
           <Token


### PR DESCRIPTION
## Summary
- Removed `overflow-x-auto` from the filter bar container which was clipping absolutely positioned dropdown menus
- Short mobile labels (`W:`, `G:`, `L:`) from #310 already prevent horizontal overflow, making `overflow-x-auto` unnecessary

Fixes #314

## Test plan
- [ ] Dropdowns render visibly above page content (not clipped)
- [ ] Filter bar still looks correct on narrow screens
- [ ] No horizontal overflow on mobile
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)