### PR TITLE
[#316] Highlight Trade button with green accent in mobile action bar

### DIFF
--- a/src/components/MobileActionBar.tsx
+++ b/src/components/MobileActionBar.tsx
@@ -60,7 +60,9 @@ export function MobileActionBar({
             className={`rounded border px-3 py-2 text-xs transition-colors ${
               open === key
                 ? "border-accent text-accent"
-                : "border-[var(--border)] text-muted hover:text-foreground"
+                : key === "trade"
+                  ? "border-accent text-accent hover:opacity-80"
+                  : "border-[var(--border)] text-muted hover:text-foreground"
             }`}
           >
             {label}


### PR DESCRIPTION
## Summary
- Trade button in the mobile floating bottom bar now uses green accent border and text (`border-accent text-accent`) by default
- Donate and Rate buttons remain muted styling
- When any button is active (panel open), it keeps the existing accent highlight

Fixes #316

## Test plan
- [ ] Trade button shows green border + text on mobile
- [ ] Donate and Rate buttons remain muted
- [ ] Active state still highlights correctly for all buttons
- [ ] `npm run typecheck` and `npm run lint` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)