### PR TITLE
[#323] Remove lib/viem.ts re-export shim

### DIFF
--- a/lib/contracts/erc8004.ts
+++ b/lib/contracts/erc8004.ts
@@ -1,5 +1,5 @@
 import { type Address } from "viem";
-import { publicClient } from "../viem";
+import { publicClient } from "../rpc";
 import { ERC8004_REGISTRY } from "./constants";
 
 // ---------------------------------------------------------------------------

--- a/lib/price.ts
+++ b/lib/price.ts
@@ -1,5 +1,5 @@
 import { type Address, formatUnits } from "viem";
-import { publicClient } from "./viem";
+import { publicClient } from "./rpc";
 import { MCV2_BOND } from "./contracts/constants";
 import {
   priceForNextMintFunction,

--- a/lib/viem.ts
+++ b/lib/viem.ts
@@ -1,3 +1,0 @@
-// Re-export from lib/rpc.ts — this file exists for backward compatibility.
-// New code should import from "lib/rpc" directly.
-export { publicClient } from "./rpc";

--- a/src/app/api/cron/backfill/route.ts
+++ b/src/app/api/cron/backfill/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { decodeEventLog, type Log } from "viem";
-import { publicClient } from "../../../../../lib/viem";
+import { publicClient } from "../../../../../lib/rpc";
 import { createServerClient } from "../../../../../lib/supabase";
 import { storyFactoryAbi } from "../../../../../lib/contracts/abi";
 import { STORY_FACTORY } from "../../../../../lib/contracts/constants";


### PR DESCRIPTION
## Summary
- Updated 3 files (`lib/price.ts`, `lib/contracts/erc8004.ts`, `src/app/api/cron/backfill/route.ts`) to import `publicClient` from `lib/rpc` instead of `lib/viem`
- Deleted `lib/viem.ts` (1-line re-export shim flagged in audit #320, items F1/F5)
- `npm run build` passes

Fixes #323

## Test plan
- [x] `npm run build` passes
- [ ] Verify backfill cron still works (uses `publicClient` from `lib/rpc`)