### PR TITLE
[#321] Fix SDK royalty ABI/client and web app MCV2 ABI accuracy

### DIFF
--- a/lib/price.ts
+++ b/lib/price.ts
@@ -21,7 +21,10 @@ export const mcv2BondAbi = [
       { name: "token", type: "address" },
       { name: "tokensToMint", type: "uint256" },
     ],
-    outputs: [{ name: "reserveAmount", type: "uint256" }],
+    outputs: [
+      { name: "reserveAmount", type: "uint256" },
+      { name: "royalty", type: "uint256" },
+    ],
   },
   {
     type: "function",
@@ -31,7 +34,10 @@ export const mcv2BondAbi = [
       { name: "token", type: "address" },
       { name: "tokensToBurn", type: "uint256" },
     ],
-    outputs: [{ name: "refundAmount", type: "uint256" }],
+    outputs: [
+      { name: "refundAmount", type: "uint256" },
+      { name: "royalty", type: "uint256" },
+    ],
   },
   {
     type: "function",
@@ -43,7 +49,7 @@ export const mcv2BondAbi = [
       { name: "maxReserveAmount", type: "uint256" },
       { name: "receiver", type: "address" },
     ],
-    outputs: [],
+    outputs: [{ name: "", type: "uint256" }],
   },
   {
     type: "function",
@@ -55,7 +61,7 @@ export const mcv2BondAbi = [
       { name: "minRefund", type: "uint256" },
       { name: "receiver", type: "address" },
     ],
-    outputs: [],
+    outputs: [{ name: "", type: "uint256" }],
   },
   {
     type: "function",

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -49,18 +49,18 @@ export function registerClaim(program: Command): void {
           // Default to 18/TOKEN if calls fail
         }
 
-        const info = await client.getRoyaltyInfo(tokenAddress, creator);
-        const formatted = formatUnits(info.unclaimed, decimals);
+        const info = await client.getRoyaltyInfo(creator, reserveToken);
+        const formatted = formatUnits(info.balance, decimals);
         console.log(`  Unclaimed:    ${formatted} ${symbol}`);
         console.log(`  Beneficiary:  ${creator}`);
 
-        if (info.unclaimed === 0n) {
+        if (info.balance === 0n) {
           console.log("No royalties to claim.");
           return;
         }
 
         console.log("Claiming royalties...");
-        const txHash = await client.claimRoyalties(tokenAddress);
+        const txHash = await client.claimRoyalties(reserveToken);
         console.log(`Royalties claimed! TX: ${txHash}`);
       } catch (err) {
         console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -56,6 +56,7 @@ export function registerStatus(program: Command): void {
         let tokenSymbol = "TOKEN";
         let tokenDecimals = 18;
         let bondCreator: Address | null = null;
+        let bondReserveToken: Address | null = null;
         try {
           const bond = await client.publicClient.readContract({
             address: MCV2_BOND_ADDRESS,
@@ -65,6 +66,7 @@ export function registerStatus(program: Command): void {
           });
           bondCreator = (bond as readonly unknown[])[0] as Address;
           const reserveToken = (bond as readonly unknown[])[4] as Address;
+          bondReserveToken = reserveToken;
           const [sym, dec] = await Promise.all([
             client.publicClient.readContract({
               address: reserveToken,
@@ -93,9 +95,9 @@ export function registerStatus(program: Command): void {
         // -----------------------------------------------------------------
         let unclaimedRoyalty: bigint | null = null;
         try {
-          if (bondCreator) {
-            const royalty = await client.getRoyaltyInfo(info.tokenAddress, bondCreator);
-            unclaimedRoyalty = royalty.unclaimed;
+          if (bondCreator && bondReserveToken) {
+            const royalty = await client.getRoyaltyInfo(bondCreator, bondReserveToken);
+            unclaimedRoyalty = royalty.balance;
           }
         } catch {
           // Token may not have a bond yet

--- a/packages/sdk/src/abi.ts
+++ b/packages/sdk/src/abi.ts
@@ -134,16 +134,19 @@ export const mcv2BondAbi = [
     name: "getRoyaltyInfo",
     stateMutability: "view",
     inputs: [
-      { name: "token", type: "address" },
-      { name: "beneficiary", type: "address" },
+      { name: "wallet", type: "address" },
+      { name: "reserveToken", type: "address" },
     ],
-    outputs: [{ name: "unclaimed", type: "uint256" }],
+    outputs: [
+      { name: "balance", type: "uint256" },
+      { name: "claimed", type: "uint256" },
+    ],
   },
   {
     type: "function",
     name: "claimRoyalties",
     stateMutability: "nonpayable",
-    inputs: [{ name: "token", type: "address" }],
+    inputs: [{ name: "reserveToken", type: "address" }],
     outputs: [],
   },
   {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -100,7 +100,8 @@ export interface SetAgentWalletResult {
 }
 
 export interface RoyaltyInfo {
-  unclaimed: bigint;
+  balance: bigint;
+  claimed: bigint;
 }
 
 export interface TokenPriceInfo {
@@ -493,37 +494,37 @@ export class PlotLink {
   // -------------------------------------------------------------------------
 
   /**
-   * Get unclaimed royalty info for a storyline token.
+   * Get royalty info for a beneficiary on a given reserve token.
    *
-   * @param tokenAddress - The storyline's ERC-20 token address
    * @param beneficiary - The royalty beneficiary (usually the bond creator)
-   * @returns Unclaimed royalty amount
+   * @param reserveToken - The reserve token address (e.g. WETH on testnet, $PLOT on mainnet)
+   * @returns Balance (unclaimed) and claimed royalty amounts
    */
-  async getRoyaltyInfo(tokenAddress: Address, beneficiary: Address): Promise<RoyaltyInfo> {
-    const unclaimed = await this.publicClient.readContract({
+  async getRoyaltyInfo(beneficiary: Address, reserveToken: Address): Promise<RoyaltyInfo> {
+    const [balance, claimed] = await this.publicClient.readContract({
       address: this.mcv2Bond,
       abi: mcv2BondAbi,
       functionName: "getRoyaltyInfo",
-      args: [tokenAddress, beneficiary],
-    });
+      args: [beneficiary, reserveToken],
+    }) as [bigint, bigint];
 
-    return { unclaimed: unclaimed as bigint };
+    return { balance, claimed };
   }
 
   /**
-   * Claim accumulated royalties for a storyline token from the MCV2_Bond
+   * Claim accumulated royalties for a reserve token from the MCV2_Bond
    * bonding curve contract.
    *
-   * @param tokenAddress - The storyline's ERC-20 token address
+   * @param reserveToken - The reserve token address (e.g. WETH on testnet, $PLOT on mainnet)
    * @returns Transaction hash
    */
-  async claimRoyalties(tokenAddress: Address): Promise<Hex> {
+  async claimRoyalties(reserveToken: Address): Promise<Hex> {
     const { request } = await this.publicClient.simulateContract({
       account: this.walletClient.account!,
       address: this.mcv2Bond,
       abi: mcv2BondAbi,
       functionName: "claimRoyalties",
-      args: [tokenAddress],
+      args: [reserveToken],
     });
 
     const txHash = await this.walletClient.writeContract(request);

--- a/src/components/PriceChart.tsx
+++ b/src/components/PriceChart.tsx
@@ -55,6 +55,7 @@ export function PriceChart({ tokenAddress, totalSupplyRaw, currentPriceRaw }: Pr
               functionName: "getReserveForToken",
               args: [tokenAddress, amount],
             })
+            .then((r) => (r as readonly [bigint, bigint])[0])
             .catch(() => BigInt(0)),
         );
       }

--- a/src/components/TradingWidget.tsx
+++ b/src/components/TradingWidget.tsx
@@ -65,7 +65,8 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
         functionName: tab === "buy" ? "getReserveForToken" : "getRefundForTokens",
         args: [tokenAddress, parsedAmount],
       });
-      return result;
+      // ABI returns [amount, royalty] tuple — extract the amount
+      return (result as readonly [bigint, bigint])[0];
     },
     enabled: parsedAmount > BigInt(0),
     refetchInterval: 15000,


### PR DESCRIPTION
## Summary
- **SDK ABI** (`packages/sdk/src/abi.ts`): Fixed `getRoyaltyInfo` inputs to `(wallet, reserveToken)` with outputs `(balance, claimed)`; renamed `claimRoyalties` input to `reserveToken`
- **SDK client** (`packages/sdk/src/client.ts`): `getRoyaltyInfo()` now passes `(beneficiary, reserveToken)` in correct order and returns both `balance` and `claimed`; `claimRoyalties()` accepts reserve token address
- **CLI claim** (`packages/cli/src/commands/claim.ts`): Passes `reserveToken` (already available from `tokenBond()`) to SDK methods instead of storyline token
- **CLI status** (`packages/cli/src/commands/status.ts`): Hoisted `bondReserveToken` for royalty info call
- **Web app ABI** (`lib/price.ts`): Added missing `royalty` output to `getReserveForToken`/`getRefundForTokens`; added `uint256` return to `mint`/`burn`
- **TradingWidget + PriceChart**: Extract first tuple element from updated ABI return types

Fixes #321

## Test plan
- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [ ] Verify trading estimates still display correctly (TradingWidget extracts `[0]` from tuple)
- [ ] Verify CLI `claim` command works with reserve token
- [ ] Verify CLI `status` command displays royalty info