### PR TITLE
Fix metadataBase warning in root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,10 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+
 export const metadata: Metadata = {
+  metadataBase: new URL(appUrl),
   title: "PlotLink",
   description: "Tokenise your story from day 1. Publish plots, drive trading, earn royalties from every trade — powered by the market, not a platform.",
   icons: { icon: "/favicon.png" },


### PR DESCRIPTION
## Summary

- Add `metadataBase` to root layout metadata export to resolve Next.js warning about social OG/twitter image resolution
- Uses `NEXT_PUBLIC_APP_URL` (falls back to `localhost:3000` in dev)

One-line config fix — no logic changes.