### PR TITLE
Fix trade indexer BlockNotFoundError with retry

### DIFF
--- a/src/app/api/index/trade/route.ts
+++ b/src/app/api/index/trade/route.ts
@@ -36,8 +36,18 @@ export async function POST(req: Request) {
   const receipt = await getReceiptWithRetry(txHash);
   if (!receipt) return error("Receipt not found", 404);
 
-  const block = await publicClient.getBlock({ blockNumber: receipt.blockNumber });
-  const timestampISO = new Date(Number(block.timestamp) * 1000).toISOString();
+  // Retry getBlock — RPC may not have the block yet on load-balanced nodes
+  let timestampISO: string;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      const block = await publicClient.getBlock({ blockNumber: receipt.blockNumber });
+      timestampISO = new Date(Number(block.timestamp) * 1000).toISOString();
+      break;
+    } catch (err) {
+      if (attempt >= 5) throw err;
+      await new Promise((r) => setTimeout(r, attempt * 1000));
+    }
+  }
 
   let indexed = 0;
 


### PR DESCRIPTION
## Summary

- Add retry loop (5 attempts, 1s linear backoff) to `getBlock` call in trade indexer
- Fixes `BlockNotFoundError` on recently confirmed blocks when RPC hasn't propagated yet
- Same pattern as existing `getReceiptWithRetry` in `lib/rpc.ts`

The trade indexer fires immediately after `waitForTransactionReceipt`, but load-balanced RPC nodes may not have the block metadata yet.