### PR TITLE
Fix MCV2_Bond event ABIs: Mint/Burn not Minted/Burned

### DIFF
--- a/lib/contracts/abi.ts
+++ b/lib/contracts/abi.ts
@@ -91,31 +91,33 @@ export const donateFunction = {
 // MCV2_Bond events (from MCV2_Bond.sol upstream)
 // ---------------------------------------------------------------------------
 
-export const mcv2MintedEvent = {
+export const mcv2MintEvent = {
   type: "event",
-  name: "Minted",
+  name: "Mint",
   inputs: [
     { name: "token", type: "address", indexed: true },
-    { name: "account", type: "address", indexed: true },
-    { name: "tokenAmount", type: "uint256", indexed: false },
+    { name: "user", type: "address", indexed: true },
+    { name: "receiver", type: "address", indexed: false },
+    { name: "amountMinted", type: "uint256", indexed: false },
+    { name: "reserveToken", type: "address", indexed: true },
     { name: "reserveAmount", type: "uint256", indexed: false },
-    { name: "beneficiary", type: "address", indexed: false },
   ],
 } as const;
 
-export const mcv2BurnedEvent = {
+export const mcv2BurnEvent = {
   type: "event",
-  name: "Burned",
+  name: "Burn",
   inputs: [
     { name: "token", type: "address", indexed: true },
-    { name: "account", type: "address", indexed: true },
-    { name: "tokenAmount", type: "uint256", indexed: false },
+    { name: "user", type: "address", indexed: true },
+    { name: "receiver", type: "address", indexed: false },
+    { name: "amountBurned", type: "uint256", indexed: false },
+    { name: "reserveToken", type: "address", indexed: true },
     { name: "refundAmount", type: "uint256", indexed: false },
-    { name: "beneficiary", type: "address", indexed: false },
   ],
 } as const;
 
-export const mcv2BondEventAbi = [mcv2MintedEvent, mcv2BurnedEvent] as const;
+export const mcv2BondEventAbi = [mcv2MintEvent, mcv2BurnEvent] as const;
 
 // ---------------------------------------------------------------------------
 // MCV2_Bond view functions

--- a/src/app/api/cron/trade-history/route.ts
+++ b/src/app/api/cron/trade-history/route.ts
@@ -108,7 +108,7 @@ export async function GET(req: Request) {
         topics: log.topics,
       });
 
-      if (decoded.eventName !== "Minted" && decoded.eventName !== "Burned") {
+      if (decoded.eventName !== "Mint" && decoded.eventName !== "Burn") {
         skipped++;
         continue;
       }
@@ -132,7 +132,7 @@ export async function GET(req: Request) {
       );
       inserted++;
     } catch (err) {
-      // Skip events that don't decode as Minted/Burned
+      // Skip events that don't decode as Mint/Burn
       if (err instanceof Error && err.message.includes("could not find")) {
         skipped++;
         continue;
@@ -171,15 +171,16 @@ async function processTradeEvent(
 ) {
   const args = decoded.args as {
     token: `0x${string}`;
-    account: `0x${string}`;
-    tokenAmount: bigint;
+    user: `0x${string}`;
+    amountMinted?: bigint;
+    amountBurned?: bigint;
     reserveAmount?: bigint;
     refundAmount?: bigint;
   };
 
-  const isMint = decoded.eventName === "Minted";
+  const isMint = decoded.eventName === "Mint";
   const reserveAmount = isMint ? args.reserveAmount! : args.refundAmount!;
-  const tokenAmount = args.tokenAmount;
+  const tokenAmount = isMint ? args.amountMinted! : args.amountBurned!;
 
   // Compute price per token (reserve per token, 18 decimals)
   const pricePerToken =

--- a/src/app/api/index/trade/route.ts
+++ b/src/app/api/index/trade/route.ts
@@ -61,20 +61,21 @@ export async function POST(req: Request) {
         topics: log.topics,
       });
 
-      if (decoded.eventName !== "Minted" && decoded.eventName !== "Burned") continue;
+      if (decoded.eventName !== "Mint" && decoded.eventName !== "Burn") continue;
 
       const args = decoded.args as {
         token: `0x${string}`;
-        tokenAmount: bigint;
+        amountMinted?: bigint;
+        amountBurned?: bigint;
         reserveAmount?: bigint;
         refundAmount?: bigint;
       };
 
       if (args.token.toLowerCase() !== tokenAddress) continue;
 
-      const isMint = decoded.eventName === "Minted";
+      const isMint = decoded.eventName === "Mint";
       const reserveAmount = isMint ? args.reserveAmount! : args.refundAmount!;
-      const tokenAmount = args.tokenAmount;
+      const tokenAmount = isMint ? args.amountMinted! : args.amountBurned!;
 
       const pricePerToken =
         tokenAmount > BigInt(0)


### PR DESCRIPTION
## Summary

The MCV2_Bond event ABIs were completely wrong — wrong event names AND wrong signatures. This caused `decodeEventLog` to silently fail on every trade, resulting in zero rows in `trade_history`.

**What was wrong:**
- Used `Minted`/`Burned` — actual names are `Mint`/`Burn`
- Had 5 params with 2 indexed — actual has 6 params with 3 indexed
- Field names didn't match (`tokenAmount` vs `amountMinted`/`amountBurned`)

**Verified against:** [MCV2_Bond.sol upstream source](https://github.com/Steemhunt/mint.club-v2-contract/blob/main/contracts/MCV2_Bond.sol)

## Files changed

- `lib/contracts/abi.ts` — corrected event definitions
- `src/app/api/index/trade/route.ts` — updated event name checks and arg destructuring
- `src/app/api/cron/trade-history/route.ts` — same updates for cron

## Test plan

- [ ] Make a buy/sell trade on testnet
- [ ] Verify `POST /api/index/trade` returns `{ indexed: 1 }` (not 0)
- [ ] Verify row appears in `trade_history` Supabase table
- [ ] Verify price chart shows data after trade