### PR TITLE
[#338] Add RLS SELECT policies for trade_history tables

### DIFF
--- a/supabase/migrations/00018_rls_public_read.sql
+++ b/supabase/migrations/00018_rls_public_read.sql
@@ -1,0 +1,8 @@
+-- trade_history: public read for price charts
+create policy "Public read" on public.trade_history for select using (true);
+
+-- backfill_failures: public read for diagnostics
+create policy "Public read" on public.backfill_failures for select using (true);
+
+-- backfill_cursor: public read for status checks
+create policy "Public read" on public.backfill_cursor for select using (true);


### PR DESCRIPTION
## Summary
- Adds migration `00018_rls_public_read.sql` with public SELECT policies for `trade_history`, `backfill_failures`, and `backfill_cursor`
- Fixes empty arrays returned by anon Supabase client that broke PriceChart

## Test plan
- [ ] Migration applies cleanly (`supabase db push` or apply in dashboard)
- [ ] `npm run typecheck` passes
- [ ] PriceChart renders trade data when `trade_history` has rows

Fixes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)