### PR TITLE
[#339] Update frontend + SDK constants for Base mainnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,17 +30,24 @@ NEXT_PUBLIC_CHAIN_ID=84532
 # -----------------------------------------------------------------------------
 # Wallet / Contract (§12 — External Dependencies)
 # -----------------------------------------------------------------------------
-# StoryFactory address — set after contracts#7 testnet deployment
+# StoryFactory address
+# Testnet:  0xfa5489b6710Ba2f8406b37fA8f8c3018e51FA229
+# Mainnet:  0x66087c0032c304Eb724544ef8Fc7C7f3E6C8CdF5
 NEXT_PUBLIC_CONTRACT_ADDRESS=
 
 # -----------------------------------------------------------------------------
-# Mint Club V2 (Base Sepolia testnet addresses)
+# Mint Club V2
 # -----------------------------------------------------------------------------
+# Base Sepolia (testnet):
 # MCV2_Bond: 0x5dfA75b0185efBaEF286E80B847ce84ff8a62C2d
 # MCV2_Token: 0x37F540de37afE8bDf6C722d87CB019F30e5E406a
 # MCV2_ZapV1: 0x40c7DC399e01029a51cAb316f8Bca7D20DE31bad
 # MCV2_BondPeriphery: 0x20fBC8a650d75e4C2Dab8b7e85C27135f0D64e89
 # PLOT_TOKEN (WETH on testnet): 0x4200000000000000000000000000000000000006
+#
+# Base Mainnet:
+# MCV2_Bond: 0xc5a076cad94176c2996B32d8466Be1cE757FAa27
+# PLOT_TOKEN (PL_TEST): 0xF8A2C39111FCEB9C950aAf28A9E34EBaD99b85C1
 
 # -----------------------------------------------------------------------------
 # Contract Deployment (testnet only — used by Foundry deploy scripts)

--- a/lib/contracts/constants.ts
+++ b/lib/contracts/constants.ts
@@ -28,7 +28,7 @@ export const EXPLORER_URL = IS_TESTNET
 export const STORY_FACTORY = (process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ??
   (IS_TESTNET
     ? "0xfa5489b6710Ba2f8406b37fA8f8c3018e51FA229"
-    : "0x0000000000000000000000000000000000000000")) as `0x${string}`;
+    : "0x66087c0032c304Eb724544ef8Fc7C7f3E6C8CdF5")) as `0x${string}`;
 
 /** ZapPlotLinkMCV2 — one-click buy (ETH/USDC/HUNT -> storyline token) */
 export const ZAP_PLOTLINK = "0x0000000000000000000000000000000000000000" as const;
@@ -38,10 +38,10 @@ export const ZAP_PLOTLINK = "0x0000000000000000000000000000000000000000" as cons
  *  Mainnet: $PLOT ERC-20 (backed by $HUNT via Mint Club V2) */
 export const PLOT_TOKEN = (IS_TESTNET
   ? "0x4200000000000000000000000000000000000006"
-  : "0x0000000000000000000000000000000000000000") as `0x${string}`;
+  : "0xF8A2C39111FCEB9C950aAf28A9E34EBaD99b85C1") as `0x${string}`;
 
 /** Human-readable label for the reserve token */
-export const RESERVE_LABEL = IS_TESTNET ? "WETH" : "$PLOT";
+export const RESERVE_LABEL = IS_TESTNET ? "WETH" : "PL_TEST";
 
 // ---------------------------------------------------------------------------
 // Mint Club V2

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -26,10 +26,14 @@ const PlotChainedEvent = storyFactoryAbi.find(
 )!;
 import {
   STORY_FACTORY_ADDRESS,
+  STORY_FACTORY_MAINNET_ADDRESS,
   MCV2_BOND_ADDRESS,
+  MCV2_BOND_MAINNET_ADDRESS,
   ERC8004_REGISTRY_ADDRESS,
   BASE_SEPOLIA_CHAIN_ID,
+  BASE_MAINNET_CHAIN_ID,
   DEPLOYMENT_BLOCK,
+  DEPLOYMENT_BLOCK_MAINNET,
   SUPPORTED_CHAIN_IDS,
 } from "./constants";
 import { uploadWithRetry, type FilebaseConfig } from "./ipfs";
@@ -147,6 +151,7 @@ export class PlotLink {
   private readonly erc8004Registry: Address;
   private readonly filebase: FilebaseConfig | undefined;
   private readonly chain: Chain;
+  private readonly deploymentBlock: bigint;
 
   constructor(config: PlotLinkConfig) {
     const chainId = config.chainId ?? BASE_SEPOLIA_CHAIN_ID;
@@ -155,7 +160,9 @@ export class PlotLink {
         `Unsupported chainId: ${chainId}. PlotLink SDK supports Base (8453) and Base Sepolia (84532).`,
       );
     }
-    this.chain = chainId === 8453 ? base : baseSepolia;
+    const isMainnet = chainId === BASE_MAINNET_CHAIN_ID;
+    this.chain = isMainnet ? base : baseSepolia;
+    this.deploymentBlock = isMainnet ? DEPLOYMENT_BLOCK_MAINNET : DEPLOYMENT_BLOCK;
 
     const normalizedKey = config.privateKey.startsWith("0x")
       ? config.privateKey
@@ -175,8 +182,8 @@ export class PlotLink {
 
     this.address = account.address;
     this.storyFactory =
-      config.storyFactoryAddress ?? STORY_FACTORY_ADDRESS;
-    this.mcv2Bond = config.mcv2BondAddress ?? MCV2_BOND_ADDRESS;
+      config.storyFactoryAddress ?? (isMainnet ? STORY_FACTORY_MAINNET_ADDRESS : STORY_FACTORY_ADDRESS);
+    this.mcv2Bond = config.mcv2BondAddress ?? (isMainnet ? MCV2_BOND_MAINNET_ADDRESS : MCV2_BOND_ADDRESS);
     this.erc8004Registry =
       config.erc8004RegistryAddress ?? ERC8004_REGISTRY_ADDRESS;
     this.filebase = config.filebase;
@@ -298,7 +305,7 @@ export class PlotLink {
       address: this.storyFactory,
       event: StorylineCreatedEvent,
       args: { storylineId },
-      fromBlock: DEPLOYMENT_BLOCK,
+      fromBlock: this.deploymentBlock,
       toBlock: "latest",
     });
 
@@ -335,7 +342,7 @@ export class PlotLink {
       address: this.storyFactory,
       event: PlotChainedEvent,
       args: { storylineId },
-      fromBlock: DEPLOYMENT_BLOCK,
+      fromBlock: this.deploymentBlock,
       toBlock: "latest",
     });
 

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -22,6 +22,12 @@ export const BASE_MAINNET_CHAIN_ID = 8453;
  */
 export const DEPLOYMENT_BLOCK = BigInt(20_000_000);
 
+/**
+ * Deployment block for PlotLink contracts on Base mainnet.
+ * Used as the default fromBlock for mainnet event log queries.
+ */
+export const DEPLOYMENT_BLOCK_MAINNET = BigInt(43_559_145);
+
 /** Supported chain IDs for the PlotLink SDK. */
 export const SUPPORTED_CHAIN_IDS = new Set([BASE_SEPOLIA_CHAIN_ID, BASE_MAINNET_CHAIN_ID]);
 
@@ -29,13 +35,21 @@ export const SUPPORTED_CHAIN_IDS = new Set([BASE_SEPOLIA_CHAIN_ID, BASE_MAINNET_
 // PlotLink contracts (Base Sepolia defaults)
 // ---------------------------------------------------------------------------
 
-/** StoryFactory — storyline + plot management. */
+/** StoryFactory — storyline + plot management (Base Sepolia). */
 export const STORY_FACTORY_ADDRESS =
   "0xfa5489b6710Ba2f8406b37fA8f8c3018e51FA229" as const;
 
-/** MCV2_Bond — bonding curve trading, token creation, royalty distribution. */
+/** StoryFactory — storyline + plot management (Base mainnet). */
+export const STORY_FACTORY_MAINNET_ADDRESS =
+  "0x66087c0032c304Eb724544ef8Fc7C7f3E6C8CdF5" as const;
+
+/** MCV2_Bond — bonding curve trading (Base Sepolia). */
 export const MCV2_BOND_ADDRESS =
   "0x5dfA75b0185efBaEF286E80B847ce84ff8a62C2d" as const;
+
+/** MCV2_Bond — bonding curve trading (Base mainnet). */
+export const MCV2_BOND_MAINNET_ADDRESS =
+  "0xc5a076cad94176c2996B32d8466Be1cE757FAa27" as const;
 
 /** ERC-8004 Agent Identity Registry. */
 export const ERC8004_REGISTRY_ADDRESS =


### PR DESCRIPTION
## Summary
- Set mainnet StoryFactory address `0x66087c0032c304Eb724544ef8Fc7C7f3E6C8CdF5` in `lib/contracts/constants.ts`
- Set mainnet PLOT_TOKEN to PL_TEST (`0xF8A2C39111FCEB9C950aAf28A9E34EBaD99b85C1`)
- Update RESERVE_LABEL from `"$PLOT"` to `"PL_TEST"` for test phase
- Add `STORY_FACTORY_MAINNET_ADDRESS`, `MCV2_BOND_MAINNET_ADDRESS`, `DEPLOYMENT_BLOCK_MAINNET` (43,559,145) to SDK
- Update `.env.example` with mainnet addresses and comments

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [ ] Constants switch correctly between testnet/mainnet based on `NEXT_PUBLIC_CHAIN_ID`

Fixes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)