### PR TITLE
[#344] Update StoryFactory address and deployment block after redeploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ NEXT_PUBLIC_CHAIN_ID=84532
 # -----------------------------------------------------------------------------
 # StoryFactory address
 # Testnet:  0xfa5489b6710Ba2f8406b37fA8f8c3018e51FA229
-# Mainnet:  0x66087c0032c304Eb724544ef8Fc7C7f3E6C8CdF5
+# Mainnet:  0xc278F4099298118efA8dF30DF0F4876632571948
 NEXT_PUBLIC_CONTRACT_ADDRESS=
 
 # -----------------------------------------------------------------------------

--- a/lib/contracts/constants.ts
+++ b/lib/contracts/constants.ts
@@ -28,7 +28,7 @@ export const EXPLORER_URL = IS_TESTNET
 export const STORY_FACTORY = (process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ??
   (IS_TESTNET
     ? "0xfa5489b6710Ba2f8406b37fA8f8c3018e51FA229"
-    : "0x66087c0032c304Eb724544ef8Fc7C7f3E6C8CdF5")) as `0x${string}`;
+    : "0xc278F4099298118efA8dF30DF0F4876632571948")) as `0x${string}`;
 
 /** ZapPlotLinkMCV2 — one-click buy (ETH/USDC/HUNT -> storyline token) */
 export const ZAP_PLOTLINK = "0x0000000000000000000000000000000000000000" as const;

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -26,7 +26,7 @@ export const DEPLOYMENT_BLOCK = BigInt(20_000_000);
  * Deployment block for PlotLink contracts on Base mainnet.
  * Used as the default fromBlock for mainnet event log queries.
  */
-export const DEPLOYMENT_BLOCK_MAINNET = BigInt(43_559_145);
+export const DEPLOYMENT_BLOCK_MAINNET = BigInt(43_561_137);
 
 /** Supported chain IDs for the PlotLink SDK. */
 export const SUPPORTED_CHAIN_IDS = new Set([BASE_SEPOLIA_CHAIN_ID, BASE_MAINNET_CHAIN_ID]);
@@ -41,7 +41,7 @@ export const STORY_FACTORY_ADDRESS =
 
 /** StoryFactory — storyline + plot management (Base mainnet). */
 export const STORY_FACTORY_MAINNET_ADDRESS =
-  "0x66087c0032c304Eb724544ef8Fc7C7f3E6C8CdF5" as const;
+  "0xc278F4099298118efA8dF30DF0F4876632571948" as const;
 
 /** MCV2_Bond — bonding curve trading (Base Sepolia). */
 export const MCV2_BOND_ADDRESS =


### PR DESCRIPTION
## Summary
- Replace old StoryFactory address `0x66087c...` with `0xc278F4099298118efA8dF30DF0F4876632571948` in all constants
- Update deployment block from `43559145` to `43561137`
- Updated in: `lib/contracts/constants.ts`, `packages/sdk/src/constants.ts`, `.env.example`

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] No remaining references to old address `0x66087c...`

Fixes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)