### PR TITLE
[#350] Round token price and supply to readable precision

### DIFF
--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared number formatting utilities for readable display.
+ *
+ * formatPrice  — token prices (small decimals, 4 sig digits)
+ * formatSupply — token supply / balances (large numbers, commas)
+ */
+
+/** Format a token price for display. Accepts a string or number. */
+export function formatPrice(value: string | number): string {
+  const v = typeof value === "string" ? parseFloat(value) : value;
+  if (v === 0 || isNaN(v)) return "0";
+  if (v < 0.001) return v.toExponential(0);
+  if (v < 1) return v.toFixed(4);
+  return v.toFixed(2);
+}
+
+/** Format a token supply or balance for display. Accepts a string or number. */
+export function formatSupply(value: string | number): string {
+  const v = typeof value === "string" ? parseFloat(value) : value;
+  if (v === 0 || isNaN(v)) return "0";
+  if (v < 1) return v.toFixed(4);
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1_000) return Math.round(v).toLocaleString("en-US");
+  return v.toFixed(2);
+}

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -11,6 +11,7 @@ import { RatingSummary } from "../../../components/RatingSummary";
 import { ShareToFarcaster } from "../../../components/ShareToFarcaster";
 import { getTokenPrice, type TokenPriceInfo } from "../../../../lib/price";
 import { RESERVE_LABEL, STORY_FACTORY } from "../../../../lib/contracts/constants";
+import { formatPrice, formatSupply } from "../../../../lib/format";
 import { type Address } from "viem";
 import { truncateAddress } from "../../../../lib/utils";
 import Link from "next/link";
@@ -56,7 +57,7 @@ export async function generateMetadata({
     : null;
   const reserveLabel = RESERVE_LABEL;
   const priceSuffix = priceInfo
-    ? ` — Price: ${priceInfo.pricePerToken} ${reserveLabel}`
+    ? ` — Price: ${formatPrice(priceInfo.pricePerToken)} ${reserveLabel}`
     : "";
   const description = `An on-chain story by ${truncateAddress(sl.writer_address)} — ${sl.plot_count} ${sl.plot_count === 1 ? "plot" : "plots"}${priceSuffix}`;
 
@@ -260,7 +261,7 @@ function StoryHeader({
               Token Price
             </span>
             <span className="text-foreground">
-              {priceInfo.pricePerToken} {reserveLabel}
+              {formatPrice(priceInfo.pricePerToken)} {reserveLabel}
             </span>
           </div>
           <div>
@@ -268,7 +269,7 @@ function StoryHeader({
               Supply Minted
             </span>
             <span className="text-foreground">
-              {priceInfo.totalSupply} tokens
+              {formatSupply(priceInfo.totalSupply)} tokens
             </span>
           </div>
         </div>

--- a/src/components/ReaderPortfolio.tsx
+++ b/src/components/ReaderPortfolio.tsx
@@ -3,6 +3,7 @@
 import { useAccount } from "wagmi";
 import { useQuery } from "@tanstack/react-query";
 import { formatUnits, type Address } from "viem";
+import { formatPrice, formatSupply } from "../../lib/format";
 import { publicClient } from "../../lib/rpc";
 import { erc20Abi, mcv2BondAbi, get24hPriceChange, getTokenTVL } from "../../lib/price";
 import { MCV2_BOND, RESERVE_LABEL, STORY_FACTORY } from "../../lib/contracts/constants";
@@ -125,7 +126,7 @@ export function ReaderPortfolio() {
                 Total Value
               </span>
               <span className="text-accent text-sm font-medium">
-                {formatUnits(totalValue, reserveDecimals)} {RESERVE_LABEL}
+                {formatPrice(formatUnits(totalValue, reserveDecimals))} {RESERVE_LABEL}
               </span>
             </div>
             {bestPick && bestPick.priceChange !== null && (
@@ -159,12 +160,12 @@ export function ReaderPortfolio() {
                     {h.storyline.title}
                   </Link>
                   <div className="text-muted mt-0.5">
-                    {formatUnits(h.balance, 18)} tokens
+                    {formatSupply(formatUnits(h.balance, 18))} tokens
                   </div>
                 </div>
                 <div className="text-right">
                   <div className="text-foreground">
-                    {formatUnits(h.value, h.reserveDecimals)} {RESERVE_LABEL}
+                    {formatPrice(formatUnits(h.value, h.reserveDecimals))} {RESERVE_LABEL}
                   </div>
                   {h.priceChange !== null && (
                     <div

--- a/src/components/WriterTradingStats.tsx
+++ b/src/components/WriterTradingStats.tsx
@@ -5,6 +5,7 @@ import { formatUnits, type Address } from "viem";
 import { publicClient } from "../../lib/rpc";
 import { mcv2BondAbi, getTokenTVL } from "../../lib/price";
 import { MCV2_BOND, RESERVE_LABEL } from "../../lib/contracts/constants";
+import { formatPrice } from "../../lib/format";
 import type { Storyline } from "../../lib/supabase";
 
 interface WriterTradingStatsProps {
@@ -46,7 +47,7 @@ export function WriterTradingStats({ storyline }: WriterTradingStatsProps) {
           Token Price
         </span>
         <span className="text-foreground">
-          {data ? `${data.price} ${RESERVE_LABEL}` : "—"}
+          {data ? `${formatPrice(data.price)} ${RESERVE_LABEL}` : "—"}
         </span>
       </div>
       <div>
@@ -54,7 +55,7 @@ export function WriterTradingStats({ storyline }: WriterTradingStatsProps) {
           TVL
         </span>
         <span className="text-foreground">
-          {data ? `${data.tvl} ${RESERVE_LABEL}` : "—"}
+          {data ? `${formatPrice(data.tvl)} ${RESERVE_LABEL}` : "—"}
         </span>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Added shared `formatPrice()` and `formatSupply()` utilities in `lib/format.ts`
- `formatPrice`: `0.017411...` → `0.0174`, `12.345...` → `12.35`, tiny values → exponential
- `formatSupply`: `379827.26...` → `379,827`, millions → `1.2M`
- Applied to: story page header, reader portfolio, writer dashboard, OG metadata

Fixes #350

## Files changed
- `lib/format.ts` — new shared formatting utilities
- `src/app/story/[storylineId]/page.tsx` — price + supply in header and OG metadata
- `src/components/ReaderPortfolio.tsx` — total value, balances, holding values
- `src/components/WriterTradingStats.tsx` — price + TVL

## Test plan
- [x] `next build` passes
- [ ] Verify story page shows `0.0174 PL_TEST` instead of `0.017411310665880643 PL_TEST`
- [ ] Verify supply shows `379,827 tokens` instead of `379827.262608456025243581 tokens`
- [ ] Verify reader portfolio and writer dashboard values are rounded

🤖 Generated with [Claude Code](https://claude.com/claude-code)