### PR TITLE
[#354] Fix donations stat misalignment on writer dashboard

### DIFF
--- a/src/app/dashboard/writer/page.tsx
+++ b/src/app/dashboard/writer/page.tsx
@@ -152,11 +152,10 @@ function StorylineDetail({ storyline, writerAddress }: { storyline: Storyline; w
           </span>
         </div>
         <div>
-          <span className="text-[10px] uppercase tracking-wider">
+          <span className="block text-[10px] uppercase tracking-wider">
             Donations
+            <DonationsTooltip />
           </span>
-          <DonationsTooltip />
-          <br />
           {storyline.token_address
             ? <DonationCount storylineId={storyline.storyline_id} tokenAddress={storyline.token_address} />
             : <span className="text-foreground">—</span>


### PR DESCRIPTION
## Summary
- Donations label was missing the `block` class used by the other 3 stat columns (Plots, Views, Created)
- It also used `<br />` to separate label from value, causing vertical misalignment
- Fix: add `block` class to the label span and nest the tooltip inside it, matching the other columns' pattern

Fixes #354

## Files changed
- `src/app/dashboard/writer/page.tsx` — 2-line fix in the stats grid

## Test plan
- [x] `next build` passes
- [ ] Verify all 4 stat columns (Plots, Views, Created, Donations) are baseline-aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)