### PR TITLE
[#357] Hide 'Read the first Plot' button when only genesis exists

### DIFF
--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -143,12 +143,14 @@ export default async function StoryPage({ params }: { params: Params }) {
           {genesis ? (
             <>
               <GenesisSection plot={genesis} />
-              <a
-                href={chapters.length > 0 ? `/story/${id}/1` : "#genesis"}
-                className="border-accent text-accent hover:bg-accent/10 mt-8 block w-full rounded border py-3 text-center text-sm font-medium transition-colors"
-              >
-                Read the first Plot
-              </a>
+              {chapters.length > 0 && (
+                <a
+                  href={`/story/${id}/1`}
+                  className="border-accent text-accent hover:bg-accent/10 mt-8 block w-full rounded border py-3 text-center text-sm font-medium transition-colors"
+                >
+                  Read the first Plot
+                </a>
+              )}
               <CommentSection storylineId={id} plotIndex={0} />
             </>
           ) : (


### PR DESCRIPTION
## Summary
- Button was displayed even when no chapters exist (only genesis), linking to `#genesis` — a useless self-link
- Fix: only render the button when `chapters.length > 0`

Fixes #357

## Files changed
- `src/app/story/[storylineId]/page.tsx` — conditional render of the CTA button

## Test plan
- [x] `next build` passes
- [ ] Story with only genesis: button hidden
- [ ] Story with chapters: button shown, links to `/story/{id}/1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)