### PR TITLE
[#348] Show success message + story link after retry indexing

### DIFF
--- a/src/components/RecoveryBanner.tsx
+++ b/src/components/RecoveryBanner.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useState } from "react";
+import { decodeEventLog } from "viem";
+import Link from "next/link";
 import { EXPLORER_URL } from "../../lib/contracts/constants";
+import { storyFactoryAbi } from "../../lib/contracts/abi";
+import { publicClient } from "../../lib/rpc";
 import type { PublishIntentData } from "../hooks/usePublishIntent";
 import { MAX_RETRY_ATTEMPTS } from "../hooks/usePublishIntent";
 
@@ -17,12 +21,66 @@ export function RecoveryBanner({
   onDismiss,
 }: RecoveryBannerProps) {
   const [retrying, setRetrying] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [storylineId, setStorylineId] = useState<number | null>(null);
   const exhausted = intent.retryCount >= MAX_RETRY_ATTEMPTS;
 
   async function handleRetry() {
     setRetrying(true);
-    await onRetry();
+    const result = await onRetry();
+    if (result.success && intent.txHash) {
+      // Parse storylineId from tx receipt for the story link
+      try {
+        const receipt = await publicClient.getTransactionReceipt({
+          hash: intent.txHash as `0x${string}`,
+        });
+        for (const log of receipt.logs) {
+          try {
+            const decoded = decodeEventLog({
+              abi: storyFactoryAbi,
+              data: log.data,
+              topics: log.topics,
+            });
+            if (decoded.eventName === "StorylineCreated") {
+              setStorylineId(Number(decoded.args.storylineId));
+              break;
+            }
+            if (decoded.eventName === "PlotChained") {
+              setStorylineId(Number(decoded.args.storylineId));
+              break;
+            }
+          } catch { /* not our event */ }
+        }
+      } catch { /* receipt fetch failed, still show success */ }
+      setSuccess(true);
+    }
     setRetrying(false);
+  }
+
+  if (success) {
+    return (
+      <div className="border-accent/40 bg-surface mb-6 rounded border p-4">
+        <p className="text-accent text-sm font-medium">
+          Storyline indexed successfully!
+        </p>
+        <div className="mt-3 flex gap-2">
+          {storylineId != null && (
+            <Link
+              href={`/story/${storylineId}`}
+              className="border-accent text-accent hover:bg-accent hover:text-background rounded border px-3 py-1.5 text-xs font-medium transition-colors"
+            >
+              View your story
+            </Link>
+          )}
+          <Link
+            href="/"
+            className="border-border text-muted hover:text-foreground rounded border px-3 py-1.5 text-xs transition-colors"
+          >
+            Go home
+          </Link>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/hooks/usePublishIntent.ts
+++ b/src/hooks/usePublishIntent.ts
@@ -128,7 +128,8 @@ export function usePublishIntent() {
       // 409 = already indexed, treat as success
       if (response.ok || response.status === 409) {
         removeIntent();
-        if (mountedRef.current) setPendingIntent(null);
+        // Don't setPendingIntent(null) here — let RecoveryBanner show
+        // the success state before unmounting
         return { success: true };
       }
 


### PR DESCRIPTION
## Summary
- RecoveryBanner now shows a success state after successful retry instead of silently disappearing
- Parses tx receipt for `StorylineCreated`/`PlotChained` events to get storylineId
- Shows "View your story" link (to `/story/{id}`) and "Go home" link
- Stops clearing `pendingIntent` React state on success so banner stays mounted for feedback

Fixes #348

## Files changed
- `src/components/RecoveryBanner.tsx` — added success state with story link
- `src/hooks/usePublishIntent.ts` — removed `setPendingIntent(null)` on success path

## Test plan
- [x] `next build` passes
- [ ] Retry indexing → success → banner shows "Storyline indexed successfully!" with story link
- [ ] Retry indexing → failure → banner still shows error + retry button as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)