### PR TITLE
[#353] Add NEW tag on story cards for recent plot activity

### DIFF
--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -77,6 +77,10 @@ export function StoryCard({
         )}
         <span className="whitespace-nowrap">
           {storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"} linked
+          {storyline.last_plot_time &&
+            Date.now() - new Date(storyline.last_plot_time).getTime() < 24 * 60 * 60 * 1000 && (
+              <span className="text-accent ml-1 text-[10px] font-bold">NEW</span>
+            )}
         </span>
         <RatingSummary storylineId={storyline.storyline_id} />
       </div>

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -5,6 +5,11 @@ import { WriterIdentityClient } from "./WriterIdentityClient";
 import { RatingSummary } from "./RatingSummary";
 import { StoryCardTVL } from "./StoryCardStats";
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+function isWithin24h(timestamp: string): boolean {
+  return Date.now() - new Date(timestamp).getTime() < DAY_MS;
+}
+
 export function StoryCard({
   storyline,
   genre,
@@ -13,6 +18,9 @@ export function StoryCard({
   genre?: string;
 }) {
   const displayGenre = genre || storyline.genre;
+  const isNew = storyline.last_plot_time
+    ? isWithin24h(storyline.last_plot_time)
+    : false;
 
   return (
     <div className="flex flex-col">
@@ -77,10 +85,7 @@ export function StoryCard({
         )}
         <span className="whitespace-nowrap">
           {storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"} linked
-          {storyline.last_plot_time &&
-            Date.now() - new Date(storyline.last_plot_time).getTime() < 24 * 60 * 60 * 1000 && (
-              <span className="text-accent ml-1 text-[10px] font-bold">NEW</span>
-            )}
+          {isNew && <span className="text-accent ml-1 text-[10px] font-bold">NEW</span>}
         </span>
         <RatingSummary storylineId={storyline.storyline_id} />
       </div>


### PR DESCRIPTION
## Summary
- Shows "NEW" badge next to plot count on story cards when `last_plot_time` is within the last 24 hours
- Pure frontend — no DB or API changes needed

Fixes #353

## Files changed
- `src/components/StoryCard.tsx` — 4-line addition

## Test plan
- [x] `next build` passes
- [ ] Story with plot activity < 24h ago shows "NEW" badge
- [ ] Story with older activity does not show badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)