### PR TITLE
[#376] Fall back to provided content on IPFS hash mismatch

### DIFF
--- a/src/app/api/index/plot/route.ts
+++ b/src/app/api/index/plot/route.ts
@@ -74,24 +74,31 @@ export async function POST(req: Request) {
     decoded.args;
 
   // 4. Fetch content from IPFS (with fallback)
-  let content: string;
+  let content: string | null = null;
   try {
     const ipfsRes = await fetch(`${IPFS_GATEWAY}${contentCID}`, {
       signal: AbortSignal.timeout(IPFS_TIMEOUT_MS),
     });
     if (!ipfsRes.ok) throw new Error(`IPFS status ${ipfsRes.status}`);
-    content = await ipfsRes.text();
-  } catch {
-    if (!fallbackContent) {
-      return error("IPFS fetch failed and no fallback content provided", 502);
+    const ipfsContent = await ipfsRes.text();
+    // Verify IPFS content hash matches on-chain hash
+    if (hashContent(ipfsContent) === contentHash) {
+      content = ipfsContent;
     }
-    content = fallbackContent;
+    // If hash mismatches, fall through to fallback content below
+  } catch {
+    // IPFS fetch failed — fall through to fallback content below
   }
 
-  // 5. Verify content hash
-  const computedHash = hashContent(content);
-  if (computedHash !== contentHash) {
-    return error("Content hash mismatch");
+  // 5. Try fallback content if IPFS content was unavailable or hash-mismatched
+  if (!content && fallbackContent) {
+    if (hashContent(fallbackContent) === contentHash) {
+      content = fallbackContent;
+    }
+  }
+
+  if (!content) {
+    return error("Content hash mismatch (IPFS and fallback both failed)");
   }
 
   // 6. Get block timestamp

--- a/src/app/api/index/storyline/route.ts
+++ b/src/app/api/index/storyline/route.ts
@@ -100,27 +100,31 @@ export async function POST(req: Request) {
   const writerType = await detectWriterType(writer);
 
   // 6. Fetch genesis plot content from IPFS (with fallback)
-  let genesisContent: string;
+  let genesisContent: string | null = null;
   try {
     const ipfsRes = await fetch(`${IPFS_GATEWAY}${openingCID}`, {
       signal: AbortSignal.timeout(IPFS_TIMEOUT_MS),
     });
     if (!ipfsRes.ok) throw new Error(`IPFS status ${ipfsRes.status}`);
-    genesisContent = await ipfsRes.text();
-  } catch {
-    if (!fallbackContent) {
-      return error(
-        "IPFS fetch failed and no fallback content provided",
-        502
-      );
+    const ipfsContent = await ipfsRes.text();
+    // Verify IPFS content hash matches on-chain hash
+    if (hashContent(ipfsContent) === openingHash) {
+      genesisContent = ipfsContent;
     }
-    genesisContent = fallbackContent;
+    // If hash mismatches, fall through to fallback content below
+  } catch {
+    // IPFS fetch failed — fall through to fallback content below
   }
 
-  // 7. Verify genesis content hash
-  const computedHash = hashContent(genesisContent);
-  if (computedHash !== openingHash) {
-    return error("Genesis content hash mismatch");
+  // 7. Try fallback content if IPFS content was unavailable or hash-mismatched
+  if (!genesisContent && fallbackContent) {
+    if (hashContent(fallbackContent) === openingHash) {
+      genesisContent = fallbackContent;
+    }
+  }
+
+  if (!genesisContent) {
+    return error("Genesis content hash mismatch (IPFS and fallback both failed)");
   }
 
   // 8. Upsert storyline to Supabase


### PR DESCRIPTION
## Summary
- Storyline and plot indexer routes now try fallback content when IPFS content's hash doesn't match the on-chain hash
- Previously fallback was only used on IPFS fetch failure — now also used on hash mismatch
- Both paths still validate the content hash before insert

## Test plan
- [ ] POST with valid tx hash + correct fallback content → 200 (even when IPFS returns wrong content)
- [ ] POST with valid tx hash, no content, IPFS hash matches → 200 (existing behavior preserved)
- [ ] POST with valid tx hash, wrong fallback content, IPFS hash mismatches → 400 (both sources fail)

Fixes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)