### PR TITLE
[#378] Fix trade indexing: remove missing user_address column

### DIFF
--- a/src/app/api/cron/trade-history/route.ts
+++ b/src/app/api/cron/trade-history/route.ts
@@ -203,7 +203,9 @@ async function processTradeEvent(
 
   const timestampISO = await getTimestamp(log.blockNumber!);
 
-  const row: TradeInsert = {
+  // Note: user_address omitted — column does not exist in the DB yet.
+  // Add via migration, then restore user_address here.
+  const row: Omit<TradeInsert, "user_address"> = {
     token_address: tokenAddress,
     storyline_id: storylineId,
     event_type: isMint ? "mint" : "burn",
@@ -215,7 +217,6 @@ async function processTradeEvent(
     tx_hash: log.transactionHash!.toLowerCase(),
     log_index: log.logIndex!,
     contract_address: MCV2_BOND.toLowerCase(),
-    user_address: args.user.toLowerCase(),
   };
 
   const { error } = await supabase

--- a/src/app/api/index/trade/route.ts
+++ b/src/app/api/index/trade/route.ts
@@ -96,7 +96,7 @@ export async function POST(req: Request) {
         // Fall back to 0
       }
 
-      const row: TradeInsert = {
+      const row: Omit<TradeInsert, "user_address"> = {
         token_address: tokenAddress,
         storyline_id: storyline.storyline_id,
         event_type: isMint ? "mint" : "burn",
@@ -108,7 +108,6 @@ export async function POST(req: Request) {
         tx_hash: txHash.toLowerCase(),
         log_index: log.logIndex!,
         contract_address: MCV2_BOND.toLowerCase(),
-        user_address: args.user.toLowerCase(),
       };
 
       const { error: dbError } = await supabase


### PR DESCRIPTION
## Summary
- Root cause: `trade_history` table lacks `user_address` column, causing all trade upserts to fail silently with PostgREST error
- Fix: omit `user_address` from insert in both `/api/index/trade` and `/api/cron/trade-history`
- Follow-up needed: add `user_address TEXT` column to `trade_history` via Supabase migration, then restore the field in the insert

## Test plan
- [ ] POST trade tx → `indexed: N` where N > 0 (currently returns `indexed: 0`)
- [ ] trade_history rows appear in Supabase after indexing
- [ ] Cron trade-history route also works

Fixes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)