### PR TITLE
[#380] Update StoryFactory v2 address and ABI

### DIFF
--- a/lib/contracts/abi.ts
+++ b/lib/contracts/abi.ts
@@ -53,7 +53,7 @@ export const donationEvent = {
 export const createStorylineFunction = {
   type: "function",
   name: "createStoryline",
-  stateMutability: "nonpayable",
+  stateMutability: "payable",
   inputs: [
     { name: "title", type: "string" },
     { name: "openingCID", type: "string" },
@@ -152,11 +152,48 @@ export const tokenBondFunction = {
 // Combined ABI (for viem contract instances)
 // ---------------------------------------------------------------------------
 
+export const curveUpdatedEvent = {
+  type: "event",
+  name: "CurveUpdated",
+  inputs: [{ name: "newStepCount", type: "uint256", indexed: false }],
+} as const;
+
+export const hasSunsetFunction = {
+  type: "function",
+  name: "hasSunset",
+  stateMutability: "view",
+  inputs: [{ name: "storylineId", type: "uint256" }],
+  outputs: [{ name: "", type: "bool" }],
+} as const;
+
+export const updateCurveFunction = {
+  type: "function",
+  name: "updateCurve",
+  stateMutability: "nonpayable",
+  inputs: [
+    { name: "newRanges", type: "uint128[]" },
+    { name: "newPrices", type: "uint128[]" },
+  ],
+  outputs: [],
+} as const;
+
+export const ownerFunction = {
+  type: "function",
+  name: "owner",
+  stateMutability: "view",
+  inputs: [],
+  outputs: [{ name: "", type: "address" }],
+} as const;
+
 export const storyFactoryAbi = [
   plotChainedEvent,
   storylineCreatedEvent,
   donationEvent,
+  curveUpdatedEvent,
   createStorylineFunction,
   chainPlotFunction,
   donateFunction,
+  hasSunsetFunction,
+  updateCurveFunction,
+  ownerFunction,
 ] as const;

--- a/lib/contracts/constants.ts
+++ b/lib/contracts/constants.ts
@@ -24,6 +24,9 @@ export const EXPLORER_URL = IS_TESTNET
 // PlotLink contracts
 // ---------------------------------------------------------------------------
 
+/** Deployment block for the v2 StoryFactory on Base mainnet */
+export const DEPLOYMENT_BLOCK = BigInt(43_606_398);
+
 /** StoryFactory — storyline + plot management */
 export const STORY_FACTORY = (process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ??
   (IS_TESTNET

--- a/lib/contracts/constants.ts
+++ b/lib/contracts/constants.ts
@@ -28,7 +28,7 @@ export const EXPLORER_URL = IS_TESTNET
 export const STORY_FACTORY = (process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ??
   (IS_TESTNET
     ? "0xfa5489b6710Ba2f8406b37fA8f8c3018e51FA229"
-    : "0xc278F4099298118efA8dF30DF0F4876632571948")) as `0x${string}`;
+    : "0x27B4FCf333f29a3865b3B76ea00C955D7b64BD0F")) as `0x${string}`;
 
 /** ZapPlotLinkMCV2 — one-click buy (ETH/USDC/HUNT -> storyline token) */
 export const ZAP_PLOTLINK = "0x0000000000000000000000000000000000000000" as const;

--- a/packages/sdk/src/abi.ts
+++ b/packages/sdk/src/abi.ts
@@ -45,11 +45,16 @@ export const storyFactoryAbi = [
       { name: "amount", type: "uint256", indexed: false },
     ],
   },
+  {
+    type: "event",
+    name: "CurveUpdated",
+    inputs: [{ name: "newStepCount", type: "uint256", indexed: false }],
+  },
   // Functions
   {
     type: "function",
     name: "createStoryline",
-    stateMutability: "nonpayable",
+    stateMutability: "payable",
     inputs: [
       { name: "title", type: "string" },
       { name: "openingCID", type: "string" },
@@ -79,6 +84,30 @@ export const storyFactoryAbi = [
       { name: "amount", type: "uint256" },
     ],
     outputs: [],
+  },
+  {
+    type: "function",
+    name: "hasSunset",
+    stateMutability: "view",
+    inputs: [{ name: "storylineId", type: "uint256" }],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "updateCurve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "newRanges", type: "uint128[]" },
+      { name: "newPrices", type: "uint128[]" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "owner",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
   },
 ] as const;
 

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -26,7 +26,7 @@ export const DEPLOYMENT_BLOCK = BigInt(20_000_000);
  * Deployment block for PlotLink contracts on Base mainnet.
  * Used as the default fromBlock for mainnet event log queries.
  */
-export const DEPLOYMENT_BLOCK_MAINNET = BigInt(43_561_137);
+export const DEPLOYMENT_BLOCK_MAINNET = BigInt(43_606_398);
 
 /** Supported chain IDs for the PlotLink SDK. */
 export const SUPPORTED_CHAIN_IDS = new Set([BASE_SEPOLIA_CHAIN_ID, BASE_MAINNET_CHAIN_ID]);
@@ -41,7 +41,7 @@ export const STORY_FACTORY_ADDRESS =
 
 /** StoryFactory — storyline + plot management (Base mainnet). */
 export const STORY_FACTORY_MAINNET_ADDRESS =
-  "0xc278F4099298118efA8dF30DF0F4876632571948" as const;
+  "0x27B4FCf333f29a3865b3B76ea00C955D7b64BD0F" as const;
 
 /** MCV2_Bond — bonding curve trading (Base Sepolia). */
 export const MCV2_BOND_ADDRESS =


### PR DESCRIPTION
## Summary
- Updated mainnet StoryFactory address to `0x27B4FCf333f29a3865b3B76ea00C955D7b64BD0F`
- Added `hasSunset`, `updateCurve`, `owner` functions and `CurveUpdated` event to ABI
- Fixed `createStoryline` stateMutability from `nonpayable` to `payable`
- Mirrored all ABI/address/deployment-block changes in SDK package
- `sunset` references are all Supabase DB queries (not contract reads) — no changes needed

## Acceptance
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes

Fixes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)