### PR TITLE
[#385] Fix price chart: marginal price + scaling + backfill

### DIFF
--- a/scripts/backfill-trade-prices.ts
+++ b/scripts/backfill-trade-prices.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env npx tsx
+/**
+ * Backfill trade_history.price_per_token with marginal price (priceForNextMint)
+ * instead of the batch average that was previously stored.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-trade-prices.ts
+ *
+ * Requires: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { formatUnits } from "viem";
+import { publicClient } from "../lib/rpc";
+import { priceForNextMintFunction } from "../lib/contracts/abi";
+import { MCV2_BOND } from "../lib/contracts/constants";
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || "";
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+async function main() {
+  console.log("=== Backfill Trade Prices ===");
+  console.log(`MCV2_BOND: ${MCV2_BOND}`);
+
+  const { data: trades, error: fetchError } = await supabase
+    .from("trade_history")
+    .select("id, token_address, block_number, price_per_token")
+    .order("block_number", { ascending: true });
+
+  if (fetchError) {
+    console.error("Failed to fetch trades:", fetchError.message);
+    process.exit(1);
+  }
+
+  if (!trades || trades.length === 0) {
+    console.log("No trades to backfill.");
+    return;
+  }
+
+  console.log(`Found ${trades.length} trades to backfill.`);
+
+  let updated = 0;
+  let failed = 0;
+
+  for (const trade of trades) {
+    try {
+      const price = await publicClient.readContract({
+        address: MCV2_BOND as `0x${string}`,
+        abi: [priceForNextMintFunction],
+        functionName: "priceForNextMint",
+        args: [trade.token_address as `0x${string}`],
+        blockNumber: BigInt(trade.block_number),
+      });
+
+      const marginalPrice = Number(formatUnits(price, 18));
+
+      const { error: updateError } = await supabase
+        .from("trade_history")
+        .update({ price_per_token: marginalPrice })
+        .eq("id", trade.id);
+
+      if (updateError) {
+        console.error(`  [FAIL] id=${trade.id}: ${updateError.message}`);
+        failed++;
+      } else {
+        const oldPrice = trade.price_per_token;
+        if (Math.abs(marginalPrice - oldPrice) > 0.0001) {
+          console.log(`  [FIX] id=${trade.id} block=${trade.block_number}: ${oldPrice} → ${marginalPrice}`);
+        }
+        updated++;
+      }
+    } catch (err) {
+      console.error(`  [FAIL] id=${trade.id} block=${trade.block_number}: ${(err as Error).message?.slice(0, 80)}`);
+      failed++;
+    }
+
+    // Delay between RPC calls to avoid rate limits
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  console.log("");
+  console.log(`=== Backfill complete: ${updated} updated, ${failed} failed ===`);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(2);
+});

--- a/src/app/api/index/trade/route.ts
+++ b/src/app/api/index/trade/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { type Hex, decodeEventLog, formatUnits } from "viem";
 import { publicClient, getReceiptWithRetry } from "../../../../../lib/rpc";
 import { createServerClient } from "../../../../../lib/supabase";
-import { mcv2BondEventAbi } from "../../../../../lib/contracts/abi";
+import { mcv2BondEventAbi, priceForNextMintFunction } from "../../../../../lib/contracts/abi";
 import { MCV2_BOND } from "../../../../../lib/contracts/constants";
 import { erc20Abi } from "../../../../../lib/price";
 import type { Database } from "../../../../../lib/supabase";
@@ -78,11 +78,24 @@ export async function POST(req: Request) {
       const reserveAmount = isMint ? args.reserveAmount! : args.refundAmount!;
       const tokenAmount = isMint ? args.amountMinted! : args.amountBurned!;
 
-      const pricePerToken =
-        tokenAmount > BigInt(0)
+      // Marginal price from bonding curve (not batch average)
+      let pricePerToken = 0;
+      try {
+        const price = await publicClient.readContract({
+          address: MCV2_BOND as `0x${string}`,
+          abi: [priceForNextMintFunction],
+          functionName: "priceForNextMint",
+          args: [args.token],
+          blockNumber: receipt.blockNumber,
+        });
+        pricePerToken = Number(formatUnits(price, 18));
+      } catch {
+        // Fallback to batch average if RPC call fails
+        pricePerToken = tokenAmount > BigInt(0)
           ? Number(formatUnits(reserveAmount, 18)) /
             Number(formatUnits(tokenAmount, 18))
           : 0;
+      }
 
       let totalSupply = BigInt(0);
       try {

--- a/src/components/PriceChart.tsx
+++ b/src/components/PriceChart.tsx
@@ -88,17 +88,19 @@ export function PriceChart({ tokenAddress, currentPriceRaw }: PriceChartProps) {
     );
   }
 
-  // Build points array
+  // Build points array (round to eliminate floating-point noise)
   const points = tradePoints.map((t) => ({
     time: t.block_timestamp,
-    price: Number(t.price_per_token),
+    price: Math.round(Number(t.price_per_token) * 1e8) / 1e8,
   }));
 
-  // Scale
+  // Scale with minimum Y range to prevent micro-noise exaggeration
   const prices = points.map((p) => p.price);
   const minY = Math.min(...prices);
   const maxY = Math.max(...prices);
-  const yRange = maxY - minY || maxY || 1;
+  const rawRange = maxY - minY;
+  const minRange = maxY * 0.01;
+  const yRange = Math.max(rawRange, minRange) || maxY || 1;
   const yPad = yRange * 0.1;
 
   const scaleX = (i: number) =>


### PR DESCRIPTION
## Summary
- **Trade indexer**: Reads `priceForNextMint` (marginal price) from bonding curve at the trade's block instead of batch average (`reserveAmount / tokenAmount`). Batch average kept as fallback if RPC fails.
- **PriceChart**: Rounds prices to eliminate FP noise; enforces minimum Y-axis range (1% of max) to prevent micro-noise exaggeration on flat/similar prices.
- **Backfill**: Script created and run — all 22 existing trades corrected. Key fix: story #15 price went from 0.006 (batch avg of 426,700 token buy) to 2.0 (actual marginal price at 500,900 supply).

Fixes #385

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] Backfill script ran: 22/22 updated, 0 failures
- [x] Chart price now matches header TOKEN PRICE at latest data point

🤖 Generated with [Claude Code](https://claude.com/claude-code)