### PR TITLE
[#389] Add browserClient for CORS-safe RPC in client components

### DIFF
--- a/lib/rpc.ts
+++ b/lib/rpc.ts
@@ -67,6 +67,28 @@ export const publicClient = createPublicClient({
   transport: buildServerTransport(),
 });
 
+/**
+ * Browser-safe public client with CORS fallback transport.
+ * Use in client components ("use client") instead of publicClient.
+ */
+export const browserClient = createPublicClient({
+  chain,
+  transport: IS_MAINNET
+    ? fallback(
+        CORS_RPC_ENDPOINTS.map((url) =>
+          http(url, {
+            timeout: 5_000,
+            retryCount: 0,
+            fetchOptions: { mode: "cors", credentials: "omit" },
+          }),
+        ),
+        { rank: false },
+      )
+    : CUSTOM_RPC_URL
+      ? fallback([http(CUSTOM_RPC_URL), http()])
+      : http(),
+});
+
 // ---------------------------------------------------------------------------
 // Exports for wagmi
 // ---------------------------------------------------------------------------

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -16,7 +16,7 @@ import { RecoveryBanner } from "../../components/RecoveryBanner";
 import { storyFactoryAbi, storylineCreatedEvent } from "../../../lib/contracts/abi";
 import { STORY_FACTORY, MCV2_BOND } from "../../../lib/contracts/constants";
 import { supabase, type Storyline } from "../../../lib/supabase";
-import { publicClient } from "../../../lib/rpc";
+import { browserClient as publicClient } from "../../../lib/rpc";
 import { decodeEventLog, encodeEventTopics, formatEther } from "viem";
 import Link from "next/link";
 import { ConnectWallet } from "../../components/ConnectWallet";

--- a/src/app/dashboard/reader/page.tsx
+++ b/src/app/dashboard/reader/page.tsx
@@ -10,7 +10,7 @@ import { WriterIdentityClient } from "../../../components/WriterIdentityClient";
 import { formatUnits } from "viem";
 import { ConnectWallet } from "../../../components/ConnectWallet";
 import { RESERVE_LABEL, PLOT_TOKEN, STORY_FACTORY, EXPLORER_URL } from "../../../../lib/contracts/constants";
-import { publicClient } from "../../../../lib/rpc";
+import { browserClient as publicClient } from "../../../../lib/rpc";
 import { type Address } from "viem";
 
 /** Truncate formatUnits output to at most `digits` decimal places */

--- a/src/app/register-agent/page.tsx
+++ b/src/app/register-agent/page.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import { useAccount, useWriteContract, useSignTypedData } from "wagmi";
 import { decodeEventLog, type Hex } from "viem";
 import { useRouter } from "next/navigation";
-import { publicClient } from "../../../lib/rpc";
+import { browserClient as publicClient } from "../../../lib/rpc";
 import { erc8004Abi } from "../../../lib/contracts/erc8004";
 import { ERC8004_REGISTRY, BASE_CHAIN_ID, EXPLORER_URL } from "../../../lib/contracts/constants";
 import { ConnectWallet } from "../../components/ConnectWallet";

--- a/src/components/ClaimRoyalties.tsx
+++ b/src/components/ClaimRoyalties.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { useWriteContract } from "wagmi";
 import { useQuery } from "@tanstack/react-query";
 import { formatUnits, type Address } from "viem";
-import { publicClient } from "../../lib/rpc";
+import { browserClient as publicClient } from "../../lib/rpc";
 import { mcv2BondAbi, getTokenTVL } from "../../lib/price";
 import { MCV2_BOND, RESERVE_LABEL, EXPLORER_URL, PLOT_TOKEN } from "../../lib/contracts/constants";
 

--- a/src/components/DonateWidget.tsx
+++ b/src/components/DonateWidget.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback } from "react";
 import { useAccount, useWriteContract } from "wagmi";
 import { useQuery } from "@tanstack/react-query";
 import { parseUnits, formatUnits } from "viem";
-import { publicClient } from "../../lib/rpc";
+import { browserClient as publicClient } from "../../lib/rpc";
 import { erc20Abi } from "../../lib/price";
 import { storyFactoryAbi } from "../../lib/contracts/abi";
 import { STORY_FACTORY, PLOT_TOKEN, RESERVE_LABEL, EXPLORER_URL } from "../../lib/contracts/constants";

--- a/src/components/RatingWidget.tsx
+++ b/src/components/RatingWidget.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useAccount, useSignMessage } from "wagmi";
 import { useQuery } from "@tanstack/react-query";
-import { publicClient } from "../../lib/rpc";
+import { browserClient as publicClient } from "../../lib/rpc";
 import { erc20Abi } from "../../lib/price";
 import type { Address } from "viem";
 import { StarDisplay, StarInput } from "./StarRating";

--- a/src/components/ReaderPortfolio.tsx
+++ b/src/components/ReaderPortfolio.tsx
@@ -4,7 +4,7 @@ import { useAccount } from "wagmi";
 import { useQuery } from "@tanstack/react-query";
 import { formatUnits, type Address } from "viem";
 import { formatPrice, formatSupply } from "../../lib/format";
-import { publicClient } from "../../lib/rpc";
+import { browserClient as publicClient } from "../../lib/rpc";
 import { erc20Abi, mcv2BondAbi, get24hPriceChange, getTokenTVL } from "../../lib/price";
 import { MCV2_BOND, RESERVE_LABEL, STORY_FACTORY } from "../../lib/contracts/constants";
 import { supabase, type Storyline } from "../../lib/supabase";

--- a/src/components/RecoveryBanner.tsx
+++ b/src/components/RecoveryBanner.tsx
@@ -5,7 +5,7 @@ import { decodeEventLog } from "viem";
 import Link from "next/link";
 import { EXPLORER_URL } from "../../lib/contracts/constants";
 import { storyFactoryAbi } from "../../lib/contracts/abi";
-import { publicClient } from "../../lib/rpc";
+import { browserClient as publicClient } from "../../lib/rpc";
 import type { PublishIntentData } from "../hooks/usePublishIntent";
 import { MAX_RETRY_ATTEMPTS } from "../hooks/usePublishIntent";
 

--- a/src/components/TradingWidget.tsx
+++ b/src/components/TradingWidget.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback } from "react";
 import { useAccount, useWriteContract } from "wagmi";
 import { useQuery } from "@tanstack/react-query";
 import { parseUnits, formatUnits, type Address } from "viem";
-import { publicClient } from "../../lib/rpc";
+import { browserClient as publicClient } from "../../lib/rpc";
 import { mcv2BondAbi, erc20Abi } from "../../lib/price";
 import { MCV2_BOND, PLOT_TOKEN, RESERVE_LABEL, EXPLORER_URL } from "../../lib/contracts/constants";
 

--- a/src/components/WriterTradingStats.tsx
+++ b/src/components/WriterTradingStats.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { formatUnits, type Address } from "viem";
-import { publicClient } from "../../lib/rpc";
+import { browserClient as publicClient } from "../../lib/rpc";
 import { mcv2BondAbi, getTokenTVL } from "../../lib/price";
 import { MCV2_BOND, RESERVE_LABEL } from "../../lib/contracts/constants";
 import { formatPrice } from "../../lib/format";

--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -3,7 +3,7 @@
 import { useState, useCallback, useRef } from "react";
 import { useWriteContract } from "wagmi";
 import { hashContent } from "../../lib/content";
-import { publicClient } from "../../lib/rpc";
+import { browserClient as publicClient } from "../../lib/rpc";
 import type { Hex, Abi, TransactionReceipt } from "viem";
 
 export type PublishState =


### PR DESCRIPTION
## Summary
- Add `browserClient` export to `lib/rpc.ts` — uses CORS-safe fallback transport (5 endpoints) for browser use
- Switch all 9 client components from `publicClient` to `browserClient` via `import { browserClient as publicClient }` (minimal diff, zero internal code changes)
- Server-side `publicClient` unchanged for API routes

### Affected files
- `src/components/TradingWidget.tsx`
- `src/components/RatingWidget.tsx`
- `src/components/DonateWidget.tsx`
- `src/components/ClaimRoyalties.tsx`
- `src/components/ReaderPortfolio.tsx`
- `src/components/WriterTradingStats.tsx`
- `src/components/RecoveryBanner.tsx`
- `src/app/create/page.tsx`
- `src/app/dashboard/reader/page.tsx`

Fixes #389

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [ ] Manual: verify no 429 errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)