### PR TITLE
[#395] Display slippage-adjusted cost in TradingWidget

### DIFF
--- a/src/components/TradingWidget.tsx
+++ b/src/components/TradingWidget.tsx
@@ -252,11 +252,11 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
       {/* Estimate */}
       {estimate != null && parsedAmount > BigInt(0) && (
         <div className="text-muted mt-2 text-xs">
-          {tab === "buy" ? "Estimated cost" : "Estimated return"}:{" "}
+          {tab === "buy" ? "Max cost" : "Min return"}:{" "}
           <span className="text-foreground">
-            {formatUnits(estimate, 18)} {RESERVE_LABEL}
+            {formatUnits(applySlippage(estimate, tab === "buy"), 18)} {RESERVE_LABEL}
           </span>
-          <span className="ml-2">(3% slippage tolerance)</span>
+          <span className="ml-2">(incl. 3% slippage)</span>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
Show "Max cost (incl. 3% slippage)" for buys and "Min return (incl. 3% slippage)" for sells instead of raw estimate. The displayed value now matches what the balance check uses, so "Insufficient balance" makes sense to users.

3-line change in `src/components/TradingWidget.tsx`.

Fixes #395

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)