### PR TITLE
Fix PriceChart duplicate React key warning when ≤2 trades

### DIFF
--- a/src/components/PriceChart.tsx
+++ b/src/components/PriceChart.tsx
@@ -120,12 +120,15 @@ export function PriceChart({ tokenAddress, currentPriceRaw }: PriceChartProps) {
   // Y-axis ticks
   const yTicks = [minY, (minY + maxY) / 2, maxY];
 
-  // X-axis time labels (first, mid, last)
-  const xLabels = [
+  // X-axis time labels (first, mid, last) — deduplicated when indices overlap
+  const xLabelCandidates = [
     { idx: 0, label: formatTime(points[0].time) },
     { idx: Math.floor(lastIdx / 2), label: formatTime(points[Math.floor(lastIdx / 2)].time) },
     { idx: lastIdx, label: formatTime(points[lastIdx].time) },
   ];
+  const xLabels = xLabelCandidates.filter(
+    (item, i, arr) => arr.findIndex((a) => a.idx === item.idx) === i,
+  );
 
   return (
     <section className="border-border mt-4 rounded border px-4 py-4">


### PR DESCRIPTION
## Summary
- Deduplicate `xLabels` by `idx` before rendering in `PriceChart.tsx`
- When `lastIdx` is 0 (1 data point) or 1 (2 data points), the first/mid/last label indices overlap, producing duplicate `xl-*` React keys
- `filter` + `findIndex` removes duplicates so only unique indices render

## Files Changed
| File | Change |
|------|--------|
| `src/components/PriceChart.tsx` | Deduplicate `xLabels` array by `idx` |

## Test plan
- [ ] Buy tokens on a new storyline (0 prior trades) — no duplicate key warning in console
- [ ] View token with 2 trades — no warning
- [ ] View token with 3+ trades — chart renders 3 labels as before
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes

Fixes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)