### PR TITLE
[#412] Book card polish v2 — accent color, spine hinge, headline, paper texture

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,9 +7,8 @@
   --shelf-shadow: rgba(44, 24, 16, 0.08);
   --text: #2C1810;
   --text-muted: #8B7355;
-  --accent: #DAAA63;
-  --accent-dim: #C4944F;
-  --accent-title: #8B4513;
+  --accent: #8B4513;
+  --accent-dim: #6B3410;
   --border: #D4C5B0;
   --error: #CC3333;
 }
@@ -21,7 +20,6 @@
   --color-muted: var(--text-muted);
   --color-accent: var(--accent);
   --color-accent-dim: var(--accent-dim);
-  --color-accent-title: var(--accent-title);
   --color-border: var(--border);
   --color-error: var(--error);
   --font-heading: var(--font-montserrat);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,10 +45,10 @@ export default async function Home({
       {/* Hero: featured section */}
       <header className="mb-10">
         <h1 className="font-heading text-2xl font-bold tracking-tight text-[var(--accent)] sm:text-3xl">
-          The Bookshelf
+          Your story is a token.
         </h1>
         <p className="mt-2 font-body text-sm leading-relaxed text-[var(--text-muted)]">
-          Every plot you publish drives the market — and every trade pays you. Browse the shelf, pick a story.
+          Every plot you publish drives the market — and every trade pays you. Write more, earn more.
         </p>
       </header>
 

--- a/src/app/story/[storylineId]/og/route.tsx
+++ b/src/app/story/[storylineId]/og/route.tsx
@@ -70,7 +70,7 @@ export async function GET(
             alignItems: "center",
             gap: "12px",
             fontSize: "24px",
-            color: "#DAAA63",
+            color: "#8B4513",
           }}
         >
           PlotLink
@@ -88,7 +88,7 @@ export async function GET(
             style={{
               fontSize: "48px",
               fontWeight: 700,
-              color: "#DAAA63",
+              color: "#8B4513",
               overflow: "hidden",
             }}
           >

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -310,7 +310,14 @@ function GenesisSection({ plot }: { plot: Plot }) {
         )}
       </div>
       {plot.content ? (
-        <div className="rounded border border-border bg-surface/50 px-5 py-4 text-foreground whitespace-pre-wrap text-sm leading-relaxed">
+        <div
+          className="rounded border border-border px-5 py-4 text-foreground whitespace-pre-wrap text-sm leading-relaxed"
+          style={{
+            backgroundColor: "#fffef0",
+            backgroundImage: "url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAUVBMVEWFhYWDg4N3d3dtbW17e3t1dXWBgYGHh4d5eXlzc3OLi4ubm5uVlZWPj4+NjY19fX2JiYl/f39ra2uRkZGZmZlpaWmXl5dvb29xcXGTk5NnZ2c8TV1mAAAAG3RSTlNAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAvEOwtAAAFVklEQVR4XpWWB67c2BUFb3g557T/hRo9/WUMZHlgr4Bg8Z4qQgQJlHI4A8SzFVrapvmTF9O7dmYRFZ60YiBhJRCgh1FYhiLAmdvX0CzTOpNE77ME0Zty/nWWzchDtiqrmQDeuv3powQ5ta2eN0FY0InkqDD73lT9c9lEzwUNqgFHs9VQce3TVClFCQrSTfOiYkVJQBmpbq2L6iZavPnAPcoU0dSw0SUTqz/GtrGuXfbyyBniKykOWQWGqwwMA7QiYAxi+IlPdqo+hYHnUt5ZPfnsHJyNiDtnpJyayNBkF6cWoYGAMY92U2hXHF/C1M8uP/ZtYdiuj26UdAdQQSXQErwSOMzt/XWRWAz5GuSBIkwG1H3FabJ2OsUOUhGC6tK4EMtJO0ttC6IBD3kM0ve0tJwMdSfjZo+EEISaeTr9P3wYrGjXqyC1krcKdhMpxEnt5JetoulscpyzhXN5FRpuPHvbeQaKxFAEB6EN+cYN6xD7RYGpXpNndMmZgM5Dcs3YSNFDHUo2LGfZuukSWyUYirJAdYbF3MfqEKmjM+I2EfhA94iG3L7uKrR+GdWD73ydlIB+6hgref1QTlmgmbM3/LeX5GI1Ux1RWpgxpLuZ2+I+IjzZ8wqE4nilvQdkUdfhzI5QDWy+kw5Wgg2pGpeEVeCCA7b85BO3F9DzxB3cdqvBzWcmzbyMiqhzuYqtHRVG2y4x+KOlnyqla8AoWWpuBoYRxzXrfKuILl6SfiWCbjxoZJUaCBj1CjH7GIaDbc9kqBY3W/Rgjda1iqQcOJu2WW+76pZC9QG7M00dffe9hNnseupFL53r8F7YHSwJWUKP2q+k7RdsxyOB11n0xtOvnW4irMMFNV4H0uqwS5ExsmP9AxbDTc9JwgneAT5vTiUSm1E7BSflSt3bfa1tv8Di3R8n3Af7MNWzs49hmauE2wP+ttrq+AsWpFG2awvsuOqbipWHgtuvuaAE+A1Z/7gC9hesnr+7wqCwG8c5yAg3AL1fm8T9AZtp/bbJGwl1pNrE7RuOX7PeMRUERVaPpEs+yqeoSmuOlokqw49pgomjLeh7icHNlG19yjs6XXOMedYm5xH2YxpV2tc0Ro2jJfxC50ApuxGob7lMsxfTbeUv07TyYxpeLucEH1gNd4IKH2LAg5TdVhlCafZvpskfncCfx8pOhJzd76bJWeYFnFciwcYfubRc12Ip/ppIhA1/mSZ/RxjFDrJC5xifFjJpY2Xl5zXdguFqYyTR1zSp1Y9p+tktDYYSNflcxI0iyO4TPBdlRcpeqjK/piF5bklq77VSEaA+z8qmJTFzIWiitbnzR794USKBUaT0NTEsVjZqLaFVqJoPN9ODG70IPbfBHKK+/q/AWR0tJzYHRULOa4MP+W/HfGadZUbfw177G7j/OGbIs8TahLyynl4X4RinF793Oz+BU0saXtUHrVBFT/DnA3ctNPoGbs4hRIjTok8i+algT1lTHi4SxFvONKNrgQFAq2/gFnWMXgwffgYMJpiKYkmW3tTg3ZQ9Jq+f8XN+A5eeUKHWvJWJ2sgJ1Sop+wwhqFVijqWaJhwtD8MNlSBeWNNWTa5Z5kPZw5+LbVT99wqTdx29lMUH4OIG/D86ruKEauBjvH5xy6um/Sfj7ei6UUVk4AIl3MyD4MSSTOFgSwsH/QJWaQ5as7ZcmgBZkzjjU1UrQ74ci1gWBCSGHtuV1H2mhSnO3Wp/3fEV5a+4wz//6qy8JxjZsmxxy5+4w9CDNJY09T072iKG0EnOS0arEYgXqYnXcYHwjTtUNAcMelOd4xpkoqiTYICWFq0JSiPfPDQdnt+4/wuqcXY47QILbgAAAABJRU5ErkJggg==)",
+            boxShadow: "0 0 30px rgba(143, 89, 34, 0.15) inset",
+          }}
+        >
           {plot.content}
         </div>
       ) : (

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -33,11 +33,11 @@ export function StoryCard({
         {/* Drop shadow beneath book — grows on hover */}
         <div className="pointer-events-none absolute -bottom-2 left-2 right-2 h-4 rounded-sm bg-[var(--shelf-shadow)] blur-md transition-all duration-300 group-hover:-bottom-3 group-hover:left-1 group-hover:right-1 group-hover:blur-lg" />
 
-        {/* Spine — dark cloth-bound band */}
+        {/* Spine — hardcover hinge */}
         <div
           className="absolute inset-y-0 left-0 w-5 rounded-l-sm"
           style={{
-            background: "linear-gradient(to right, #1A0F0A, #2C1810, #3A2A1A)",
+            background: "linear-gradient(to right, #1A0F0A, #2C1810 40%, #1A0F0A 48%, #0E0806 52%, #2C1810 56%, #3A2A1A)",
             transform: "translateZ(-2px)",
           }}
         />
@@ -61,7 +61,14 @@ export function StoryCard({
         />
 
         {/* Front cover */}
-        <div className="relative flex aspect-[2/3] flex-col justify-between overflow-hidden rounded-sm rounded-l-none border border-[var(--border)] bg-gradient-to-br from-[#F7F0E5] via-[#F2E8D6] to-[#EBE0CE] transition-[border-color,box-shadow] duration-300 group-hover:border-[var(--accent-dim)] group-hover:shadow-lg">
+        <div
+          className="relative flex aspect-[2/3] flex-col justify-between overflow-hidden rounded-sm rounded-l-none border border-[var(--border)] transition-[border-color,box-shadow] duration-300 group-hover:border-[var(--accent-dim)] group-hover:shadow-lg"
+          style={{
+            backgroundColor: "#fffef0",
+            backgroundImage: "url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAUVBMVEWFhYWDg4N3d3dtbW17e3t1dXWBgYGHh4d5eXlzc3OLi4ubm5uVlZWPj4+NjY19fX2JiYl/f39ra2uRkZGZmZlpaWmXl5dvb29xcXGTk5NnZ2c8TV1mAAAAG3RSTlNAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAvEOwtAAAFVklEQVR4XpWWB67c2BUFb3g557T/hRo9/WUMZHlgr4Bg8Z4qQgQJlHI4A8SzFVrapvmTF9O7dmYRFZ60YiBhJRCgh1FYhiLAmdvX0CzTOpNE77ME0Zty/nWWzchDtiqrmQDeuv3powQ5ta2eN0FY0InkqDD73lT9c9lEzwUNqgFHs9VQce3TVClFCQrSTfOiYkVJQBmpbq2L6iZavPnAPcoU0dSw0SUTqz/GtrGuXfbyyBniKykOWQWGqwwMA7QiYAxi+IlPdqo+hYHnUt5ZPfnsHJyNiDtnpJyayNBkF6cWoYGAMY92U2hXHF/C1M8uP/ZtYdiuj26UdAdQQSXQErwSOMzt/XWRWAz5GuSBIkwG1H3FabJ2OsUOUhGC6tK4EMtJO0ttC6IBD3kM0ve0tJwMdSfjZo+EEISaeTr9P3wYrGjXqyC1krcKdhMpxEnt5JetoulscpyzhXN5FRpuPHvbeQaKxFAEB6EN+cYN6xD7RYGpXpNndMmZgM5Dcs3YSNFDHUo2LGfZuukSWyUYirJAdYbF3MfqEKmjM+I2EfhA94iG3L7uKrR+GdWD73ydlIB+6hgref1QTlmgmbM3/LeX5GI1Ux1RWpgxpLuZ2+I+IjzZ8wqE4nilvQdkUdfhzI5QDWy+kw5Wgg2pGpeEVeCCA7b85BO3F9DzxB3cdqvBzWcmzbyMiqhzuYqtHRVG2y4x+KOlnyqla8AoWWpuBoYRxzXrfKuILl6SfiWCbjxoZJUaCBj1CjH7GIaDbc9kqBY3W/Rgjda1iqQcOJu2WW+76pZC9QG7M00dffe9hNnseupFL53r8F7YHSwJWUKP2q+k7RdsxyOB11n0xtOvnW4irMMFNV4H0uqwS5ExsmP9AxbDTc9JwgneAT5vTiUSm1E7BSflSt3bfa1tv8Di3R8n3Af7MNWzs49hmauE2wP+ttrq+AsWpFG2awvsuOqbipWHgtuvuaAE+A1Z/7gC9hesnr+7wqCwG8c5yAg3AL1fm8T9AZtp/bbJGwl1pNrE7RuOX7PeMRUERVaPpEs+yqeoSmuOlokqw49pgomjLeh7icHNlG19yjs6XXOMedYm5xH2YxpV2tc0Ro2jJfxC50ApuxGob7lMsxfTbeUv07TyYxpeLucEH1gNd4IKH2LAg5TdVhlCafZvpskfncCfx8pOhJzd76bJWeYFnFciwcYfubRc12Ip/ppIhA1/mSZ/RxjFDrJC5xifFjJpY2Xl5zXdguFqYyTR1zSp1Y9p+tktDYYSNflcxI0iyO4TPBdlRcpeqjK/piF5bklq77VSEaA+z8qmJTFzIWiitbnzR794USKBUaT0NTEsVjZqLaFVqJoPN9ODG70IPbfBHKK+/q/AWR0tJzYHRULOa4MP+W/HfGadZUbfw177G7j/OGbIs8TahLyynl4X4RinF793Oz+BU0saXtUHrVBFT/DnA3ctNPoGbs4hRIjTok8i+algT1lTHi4SxFvONKNrgQFAq2/gFnWMXgwffgYMJpiKYkmW3tTg3ZQ9Jq+f8XN+A5eeUKHWvJWJ2sgJ1Sop+wwhqFVijqWaJhwtD8MNlSBeWNNWTa5Z5kPZw5+LbVT99wqTdx29lMUH4OIG/D86ruKEauBjvH5xy6um/Sfj7ei6UUVk4AIl3MyD4MSSTOFgSwsH/QJWaQ5as7ZcmgBZkzjjU1UrQ74ci1gWBCSGHtuV1H2mhSnO3Wp/3fEV5a+4wz//6qy8JxjZsmxxy5+4w9CDNJY09T072iKG0EnOS0arEYgXqYnXcYHwjTtUNAcMelOd4xpkoqiTYICWFq0JSiPfPDQdnt+4/wuqcXY47QILbgAAAABJRU5ErkJggg==)",
+            boxShadow: "0 0 30px rgba(143, 89, 34, 0.15) inset",
+          }}
+        >
           {/* Spine inner shadow overlay */}
           <div
             className="pointer-events-none absolute inset-y-0 left-0 w-8"
@@ -87,7 +94,7 @@ export function StoryCard({
 
             {/* Center: title displayed like printed book cover */}
             <div className="flex flex-1 flex-col items-center justify-center px-1 text-center">
-              <h3 className="font-heading text-base font-bold leading-tight tracking-tight text-[var(--accent-title)] sm:text-lg">
+              <h3 className="font-heading text-base font-bold leading-tight tracking-tight text-accent sm:text-lg">
                 {storyline.title}
               </h3>
               {storyline.language && storyline.language !== "English" && (


### PR DESCRIPTION
## Summary
- **Accent color**: Replaced `--accent: #DAAA63` (light orange) → `#8B4513` (saddle brown), `--accent-dim` → `#6B3410`. Removed redundant `--accent-title` token and all references.
- **Spine hinge**: Replaced flat spine band with realistic hardcover hinge — dark spine with vertical groove/indent at spine-cover junction.
- **Headline**: Restored home page h1 to "Your story is a token." with original tagline.
- **Paper texture**: Applied CSS-only paper texture (noise PNG + subtle inset shadow) to book covers on home page and story content area on detail page. No SVG edges or fold effects.
- **Cleanup**: Fixed hardcoded `#DAAA63` in OG image route. Zero remaining old color values in codebase.

Fixes #412

## Test plan
- [ ] Verify `--accent` renders as vivid brown (`#8B4513`) across all pages
- [ ] Confirm zero occurrences of `#DAAA63`, `rgb(218, 170, 99)`, `#C4944F` in codebase
- [ ] Check spine hinge has visible groove/indent effect on book cards
- [ ] Verify home page headline reads "Your story is a token."
- [ ] Confirm paper texture visible on book covers and story content area
- [ ] Verify no SVG uneven edges or fold effects applied
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)