### PR TITLE
[#417] Ruled notebook paper on story detail content

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,6 +11,9 @@
   --accent-dim: #6B3410;
   --border: #D4C5B0;
   --error: #CC3333;
+  --paper-line: hsl(234, 62%, 86%);
+  --paper-margin: hsl(350, 100%, 91%);
+  --paper-bg: hsl(0, 15%, 95%);
 }
 
 @theme inline {
@@ -41,6 +44,61 @@ h1, h2, h3, h4, h5, h6 {
 ::selection {
   background: var(--accent);
   color: var(--bg-surface);
+}
+
+/* Ruled notebook paper */
+.ruled-paper {
+  background: var(--paper-bg);
+  padding: 3.5rem 2rem 1rem 4.5rem;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--text);
+  background-image:
+    linear-gradient(
+      90deg,
+      transparent, transparent 3.5rem,
+      var(--paper-margin) 3.5rem,
+      var(--paper-margin) 3.75rem,
+      transparent 3.75rem
+    ),
+    linear-gradient(
+      var(--paper-bg), var(--paper-bg) 2.5rem,
+      transparent 2.5rem
+    ),
+    repeating-linear-gradient(
+      transparent,
+      transparent calc(1.6em - 2px),
+      var(--paper-line) calc(1.6em - 2px),
+      var(--paper-line) 1.6em,
+      transparent 1.6em
+    );
+  box-shadow: 0 0 1rem rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
+}
+
+@media (max-width: 640px) {
+  .ruled-paper {
+    padding: 2.5rem 1rem 1rem 2.5rem;
+    background-image:
+      linear-gradient(
+        90deg,
+        transparent, transparent 1.75rem,
+        var(--paper-margin) 1.75rem,
+        var(--paper-margin) 2rem,
+        transparent 2rem
+      ),
+      linear-gradient(
+        var(--paper-bg), var(--paper-bg) 1.5rem,
+        transparent 1.5rem
+      ),
+      repeating-linear-gradient(
+        transparent,
+        transparent calc(1.6em - 2px),
+        var(--paper-line) calc(1.6em - 2px),
+        var(--paper-line) 1.6em,
+        transparent 1.6em
+      );
+  }
 }
 
 /* Moleskine notebook cards */

--- a/src/app/story/[storylineId]/[plotIndex]/page.tsx
+++ b/src/app/story/[storylineId]/[plotIndex]/page.tsx
@@ -126,7 +126,7 @@ export default async function PlotDetailPage({ params }: { params: Params }) {
 
       {/* Plot content */}
       {p.content ? (
-        <div className="text-foreground whitespace-pre-wrap text-sm leading-relaxed">
+        <div className="ruled-paper whitespace-pre-wrap">
           {p.content}
         </div>
       ) : (

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -310,14 +310,7 @@ function GenesisSection({ plot }: { plot: Plot }) {
         )}
       </div>
       {plot.content ? (
-        <div
-          className="rounded border border-border px-5 py-4 text-foreground whitespace-pre-wrap text-sm leading-relaxed"
-          style={{
-            backgroundColor: "#FFF8EE",
-            backgroundImage: "url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAUVBMVEWFhYWDg4N3d3dtbW17e3t1dXWBgYGHh4d5eXlzc3OLi4ubm5uVlZWPj4+NjY19fX2JiYl/f39ra2uRkZGZmZlpaWmXl5dvb29xcXGTk5NnZ2c8TV1mAAAAG3RSTlNAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAvEOwtAAAFVklEQVR4XpWWB67c2BUFb3g557T/hRo9/WUMZHlgr4Bg8Z4qQgQJlHI4A8SzFVrapvmTF9O7dmYRFZ60YiBhJRCgh1FYhiLAmdvX0CzTOpNE77ME0Zty/nWWzchDtiqrmQDeuv3powQ5ta2eN0FY0InkqDD73lT9c9lEzwUNqgFHs9VQce3TVClFCQrSTfOiYkVJQBmpbq2L6iZavPnAPcoU0dSw0SUTqz/GtrGuXfbyyBniKykOWQWGqwwMA7QiYAxi+IlPdqo+hYHnUt5ZPfnsHJyNiDtnpJyayNBkF6cWoYGAMY92U2hXHF/C1M8uP/ZtYdiuj26UdAdQQSXQErwSOMzt/XWRWAz5GuSBIkwG1H3FabJ2OsUOUhGC6tK4EMtJO0ttC6IBD3kM0ve0tJwMdSfjZo+EEISaeTr9P3wYrGjXqyC1krcKdhMpxEnt5JetoulscpyzhXN5FRpuPHvbeQaKxFAEB6EN+cYN6xD7RYGpXpNndMmZgM5Dcs3YSNFDHUo2LGfZuukSWyUYirJAdYbF3MfqEKmjM+I2EfhA94iG3L7uKrR+GdWD73ydlIB+6hgref1QTlmgmbM3/LeX5GI1Ux1RWpgxpLuZ2+I+IjzZ8wqE4nilvQdkUdfhzI5QDWy+kw5Wgg2pGpeEVeCCA7b85BO3F9DzxB3cdqvBzWcmzbyMiqhzuYqtHRVG2y4x+KOlnyqla8AoWWpuBoYRxzXrfKuILl6SfiWCbjxoZJUaCBj1CjH7GIaDbc9kqBY3W/Rgjda1iqQcOJu2WW+76pZC9QG7M00dffe9hNnseupFL53r8F7YHSwJWUKP2q+k7RdsxyOB11n0xtOvnW4irMMFNV4H0uqwS5ExsmP9AxbDTc9JwgneAT5vTiUSm1E7BSflSt3bfa1tv8Di3R8n3Af7MNWzs49hmauE2wP+ttrq+AsWpFG2awvsuOqbipWHgtuvuaAE+A1Z/7gC9hesnr+7wqCwG8c5yAg3AL1fm8T9AZtp/bbJGwl1pNrE7RuOX7PeMRUERVaPpEs+yqeoSmuOlokqw49pgomjLeh7icHNlG19yjs6XXOMedYm5xH2YxpV2tc0Ro2jJfxC50ApuxGob7lMsxfTbeUv07TyYxpeLucEH1gNd4IKH2LAg5TdVhlCafZvpskfncCfx8pOhJzd76bJWeYFnFciwcYfubRc12Ip/ppIhA1/mSZ/RxjFDrJC5xifFjJpY2Xl5zXdguFqYyTR1zSp1Y9p+tktDYYSNflcxI0iyO4TPBdlRcpeqjK/piF5bklq77VSEaA+z8qmJTFzIWiitbnzR794USKBUaT0NTEsVjZqLaFVqJoPN9ODG70IPbfBHKK+/q/AWR0tJzYHRULOa4MP+W/HfGadZUbfw177G7j/OGbIs8TahLyynl4X4RinF793Oz+BU0saXtUHrVBFT/DnA3ctNPoGbs4hRIjTok8i+algT1lTHi4SxFvONKNrgQFAq2/gFnWMXgwffgYMJpiKYkmW3tTg3ZQ9Jq+f8XN+A5eeUKHWvJWJ2sgJ1Sop+wwhqFVijqWaJhwtD8MNlSBeWNNWTa5Z5kPZw5+LbVT99wqTdx29lMUH4OIG/D86ruKEauBjvH5xy6um/Sfj7ei6UUVk4AIl3MyD4MSSTOFgSwsH/QJWaQ5as7ZcmgBZkzjjU1UrQ74ci1gWBCSGHtuV1H2mhSnO3Wp/3fEV5a+4wz//6qy8JxjZsmxxy5+4w9CDNJY09T072iKG0EnOS0arEYgXqYnXcYHwjTtUNAcMelOd4xpkoqiTYICWFq0JSiPfPDQdnt+4/wuqcXY47QILbgAAAABJRU5ErkJggg==)",
-            boxShadow: "0 0 30px rgba(143, 89, 34, 0.08) inset",
-          }}
-        >
+        <div className="ruled-paper whitespace-pre-wrap">
           {plot.content}
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- **Ruled paper CSS**: Added `.ruled-paper` class with light blue horizontal ruled lines and subtle pink left margin line
- **CSS variables**: `--paper-line`, `--paper-margin`, `--paper-bg` in globals.css
- **Applied to**: Genesis content area and individual plot content pages
- **Responsive**: Reduced padding on mobile (2.5rem left vs 4.5rem desktop)
- **Replaces**: Previous noise PNG + inset box-shadow paper texture on content areas

Fixes #417

## Test plan
- [ ] Plot content area shows ruled notebook paper lines
- [ ] Pink margin line visible on left side
- [ ] Text aligns closely with ruled lines
- [ ] Lines are subtle, text readability not impacted
- [ ] Mobile: padding adapts, lines still look good
- [ ] Individual chapter pages also have ruled paper
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)