### PR TITLE
Switch all fonts to Geist Mono (original monospace)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,19 +25,18 @@
   --color-accent-dim: var(--accent-dim);
   --color-border: var(--border);
   --color-error: var(--error);
-  --font-heading: var(--font-montserrat);
-  --font-body: var(--font-libre-caslon);
+  --font-heading: var(--font-geist-mono);
+  --font-body: var(--font-geist-mono);
 }
 
 body {
   background: var(--bg);
   color: var(--text);
-  font-family: var(--font-libre-caslon), "Libre Caslon Text", Georgia,
-    "Times New Roman", serif;
+  font-family: var(--font-geist-mono), "Geist Mono", ui-monospace, monospace;
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: var(--font-montserrat), Montserrat, system-ui, sans-serif;
+  font-family: var(--font-geist-mono), "Geist Mono", ui-monospace, monospace;
 }
 
 /* Selection */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,21 +1,14 @@
 import type { Metadata } from "next";
-import { Montserrat, Libre_Caslon_Text } from "next/font/google";
+import { Geist_Mono } from "next/font/google";
 import { Providers } from "./providers";
 import { NavBar } from "../components/NavBar";
 import { Footer } from "../components/Footer";
 import { FarcasterMiniApp } from "../components/FarcasterMiniApp";
 import "./globals.css";
 
-const montserrat = Montserrat({
-  variable: "--font-montserrat",
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
   subsets: ["latin"],
-  weight: ["500", "600"],
-});
-
-const libreCaslon = Libre_Caslon_Text({
-  variable: "--font-libre-caslon",
-  subsets: ["latin"],
-  weight: "400",
 });
 
 const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
@@ -41,7 +34,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${montserrat.variable} ${libreCaslon.variable} antialiased`}>
+      <body className={`${geistMono.variable} antialiased`}>
         <Providers>
           <FarcasterMiniApp />
           <NavBar />

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -21,8 +21,7 @@ export function NavBar() {
         {/* Logo */}
         <Link
           href="/"
-          className="font-[var(--font-heading)] text-sm font-semibold tracking-tight text-[var(--text)] transition-opacity hover:opacity-80"
-          style={{ fontFamily: "var(--font-montserrat), Montserrat, sans-serif" }}
+          className="text-sm font-semibold tracking-tight text-[var(--text)] transition-opacity hover:opacity-80"
         >
           PlotLink
         </Link>


### PR DESCRIPTION
## Summary
Replace Montserrat + Libre Caslon Text with the original Geist Mono monospace font as the single font for everything.

## Files Changed
| File | Change |
|------|--------|
| `src/app/layout.tsx` | Import Geist_Mono instead of Montserrat + Libre_Caslon_Text |
| `src/app/globals.css` | `--font-heading` and `--font-body` → Geist Mono, body/h* rules updated |
| `src/components/NavBar.tsx` | Remove inline Montserrat style |

🤖 Generated with [Claude Code](https://claude.com/claude-code)