### PR TITLE
Fix white surfaces, restore filter bar, ruled paper on create page

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -344,7 +344,7 @@ function CreatePage() {
                 disabled={newBusy}
                 rows={12}
                 placeholder="Write the genesis plot (500\u201310,000 characters)"
-                className="border-border bg-surface text-foreground placeholder:text-muted w-full resize-y rounded border px-3 py-2 text-sm leading-relaxed focus:border-accent focus:outline-none disabled:opacity-50"
+                className="ruled-paper border-border text-foreground placeholder:text-muted w-full resize-y rounded border focus:border-accent focus:outline-none disabled:opacity-50"
               />
               <div className="mt-1 flex justify-between text-xs">
                 <span className={newContent.length > 0 && !newValid ? "text-error" : "text-muted"}>
@@ -461,7 +461,7 @@ function CreatePage() {
                 disabled={chainBusy || noStoryline}
                 rows={12}
                 placeholder={noStoryline ? "Select a storyline above to chain a plot" : "Write the next plot (500\u201310,000 characters)"}
-                className="border-border bg-surface text-foreground placeholder:text-muted w-full resize-y rounded border px-3 py-2 text-sm leading-relaxed focus:border-accent focus:outline-none disabled:opacity-50"
+                className="ruled-paper border-border text-foreground placeholder:text-muted w-full resize-y rounded border focus:border-accent focus:outline-none disabled:opacity-50"
               />
               <div className="mt-1 text-xs">
                 <span className={chainContent.length > 0 && !chainValid ? "text-error" : "text-muted"}>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,7 @@
 
 :root {
   --bg: #E8DFD0;
-  --bg-surface: #FFFFFF;
+  --bg-surface: #F0EBE1;
   --bg-shelf: #DDD3C2;
   --shelf-shadow: rgba(44, 24, 16, 0.08);
   --text: #2C1810;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,12 +52,6 @@ export default async function Home({
         </p>
       </header>
 
-      {/* Section heading + filter bar */}
-      <div className="mb-2">
-        <h2 className="font-body text-base font-normal italic text-[var(--text-muted)]">
-          {tab === "trending" ? "Trending" : "New & Noteworthy"}
-        </h2>
-      </div>
       <FilterBar writer={writer} genre={genre} lang={lang} tab={tab} />
 
       {/* Story grid — batched multicall for price/TVL */}

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -64,7 +64,7 @@ export function FilterBar({ writer, genre, lang, tab }: FilterBarProps) {
 
   return (
     <div ref={barRef}>
-      <div className="flex min-w-0 items-center gap-x-2 rounded-full border border-[var(--border)] bg-[var(--bg-shelf)]/50 px-4 py-2 text-xs">
+      <div className="border-border flex min-w-0 items-center gap-x-3 rounded border px-3 py-2 text-xs">
         {/* Writer token + dropdown */}
         <div className="relative min-w-0">
           <Token
@@ -196,7 +196,7 @@ function Token({
   return (
     <button
       onClick={onClick}
-      className={`whitespace-nowrap rounded-full px-2.5 py-0.5 transition-colors hover:bg-[var(--accent)]/10 ${active ? "bg-[var(--accent)]/10" : ""}`}
+      className={`whitespace-nowrap px-1 py-0.5 transition-colors hover:bg-[var(--border)]/30 ${active ? "bg-[var(--accent)]/10" : ""}`}
     >
       <span className="text-[var(--text-muted)] sm:hidden">{shortLabel}:</span>
       <span className="text-[var(--text-muted)] hidden sm:inline">{label}:</span>


### PR DESCRIPTION
## Summary
4 design fixes:

1. **White surfaces → light beige**: `--bg-surface: #FFFFFF` → `#F0EBE1` — fixes all white boxes globally (detail page stats, deadline, comment textarea, create page inputs, etc.)
2. **FilterBar**: Restored original shape — plain `rounded` border, no background fill, no `rounded-full` pills. Original `W:All G:All L:English ↕` layout.
3. **Remove "New & Noteworthy"**: Section heading above filter bar removed.
4. **Ruled paper on create page**: Genesis content and Add Plot content textareas now use `ruled-paper` class for notebook paper feel.

## Files Changed
| File | Change |
|------|--------|
| `src/app/globals.css` | `--bg-surface` → `#F0EBE1` |
| `src/components/FilterBar.tsx` | Restore original shape |
| `src/app/page.tsx` | Remove section heading |
| `src/app/create/page.tsx` | `ruled-paper` on both content textareas |

🤖 Generated with [Claude Code](https://claude.com/claude-code)