### PR TITLE
[#242] P5-9a/b: Zap frontend integration

### DIFF
--- a/lib/contracts/constants.ts
+++ b/lib/contracts/constants.ts
@@ -46,7 +46,7 @@ export const PLOT_TOKEN = (IS_TESTNET
   : "0xF8A2C39111FCEB9C950aAf28A9E34EBaD99b85C1") as `0x${string}`;
 
 /** Human-readable label for the reserve token */
-export const RESERVE_LABEL = IS_TESTNET ? "PL_TEST" : "PL_TEST";
+export const RESERVE_LABEL = IS_TESTNET ? "PL_TEST" : "PLOT";
 
 // ---------------------------------------------------------------------------
 // Mint Club V2

--- a/lib/zap.ts
+++ b/lib/zap.ts
@@ -6,9 +6,9 @@
  * tokens on the MCV2 bonding curve in a single transaction.
  */
 
-import { type Address, encodeAbiParameters, decodeFunctionResult, encodeFunctionData, parseAbi } from "viem";
+import { type Address, parseAbi } from "viem";
 import { browserClient as publicClient } from "./rpc";
-import { ZAP_PLOTLINK, UNISWAP_V4_QUOTER, PLOT_TOKEN, UNISWAP_V4_POOL_MANAGER } from "./contracts/constants";
+import { ZAP_PLOTLINK, UNISWAP_V4_QUOTER, PLOT_TOKEN } from "./contracts/constants";
 
 // ---------------------------------------------------------------------------
 // ABI (only the functions we call)
@@ -26,17 +26,71 @@ export const zapPlotLinkAbi = parseAbi([
  *
  * These functions are NOT view — they execute state changes internally and
  * revert with the result. Must be called via eth_call (simulateContract).
- *
- * QuoteExactSingleParams struct:
- *   PoolKey poolKey (currency0, currency1, fee, tickSpacing, hooks)
- *   bool zeroForOne
- *   uint128 exactAmount
- *   bytes hookData
  */
-const quoterAbi = parseAbi([
-  "function quoteExactInputSingle(((address,address,uint24,int24,address),bool,uint128,bytes) params) external returns (uint256 amountOut, uint256 gasEstimate)",
-  "function quoteExactOutputSingle(((address,address,uint24,int24,address),bool,uint128,bytes) params) external returns (uint256 amountIn, uint256 gasEstimate)",
-]);
+const quoterAbi = [
+  {
+    name: "quoteExactInputSingle",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "params",
+        type: "tuple",
+        components: [
+          {
+            name: "poolKey",
+            type: "tuple",
+            components: [
+              { name: "currency0", type: "address" },
+              { name: "currency1", type: "address" },
+              { name: "fee", type: "uint24" },
+              { name: "tickSpacing", type: "int24" },
+              { name: "hooks", type: "address" },
+            ],
+          },
+          { name: "zeroForOne", type: "bool" },
+          { name: "exactAmount", type: "uint128" },
+          { name: "hookData", type: "bytes" },
+        ],
+      },
+    ],
+    outputs: [
+      { name: "amountOut", type: "uint256" },
+      { name: "gasEstimate", type: "uint256" },
+    ],
+  },
+  {
+    name: "quoteExactOutputSingle",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "params",
+        type: "tuple",
+        components: [
+          {
+            name: "poolKey",
+            type: "tuple",
+            components: [
+              { name: "currency0", type: "address" },
+              { name: "currency1", type: "address" },
+              { name: "fee", type: "uint24" },
+              { name: "tickSpacing", type: "int24" },
+              { name: "hooks", type: "address" },
+            ],
+          },
+          { name: "zeroForOne", type: "bool" },
+          { name: "exactAmount", type: "uint128" },
+          { name: "hookData", type: "bytes" },
+        ],
+      },
+    ],
+    outputs: [
+      { name: "amountIn", type: "uint256" },
+      { name: "gasEstimate", type: "uint256" },
+    ],
+  },
+] as const;
 
 const WETH: Address = "0x4200000000000000000000000000000000000006";
 const POOL_FEE = 3000; // 0.30% — must match deployed pool
@@ -85,14 +139,14 @@ async function quoteEthToPlot(ethAmount: bigint): Promise<bigint> {
       functionName: "quoteExactInputSingle",
       args: [
         {
-          0: { 0: currency0, 1: currency1, 2: POOL_FEE, 3: TICK_SPACING, 4: HOOKS },
-          1: zeroForOne,
-          2: BigInt(ethAmount) as unknown as bigint & { readonly _tag: "uint128" },
-          3: "0x" as `0x${string}`,
-        } as any,
+          poolKey: { currency0, currency1, fee: POOL_FEE, tickSpacing: TICK_SPACING, hooks: HOOKS },
+          zeroForOne,
+          exactAmount: ethAmount,
+          hookData: "0x",
+        },
       ],
     });
-    return (result as readonly [bigint, bigint])[0];
+    return result[0];
   } catch {
     // Fallback: if quoter call fails, return 0 to indicate unavailable
     return BigInt(0);
@@ -114,14 +168,14 @@ async function quotePlotToEth(plotAmount: bigint): Promise<bigint> {
       functionName: "quoteExactOutputSingle",
       args: [
         {
-          0: { 0: currency0, 1: currency1, 2: POOL_FEE, 3: TICK_SPACING, 4: HOOKS },
-          1: zeroForOne,
-          2: BigInt(plotAmount) as unknown as bigint & { readonly _tag: "uint128" },
-          3: "0x" as `0x${string}`,
-        } as any,
+          poolKey: { currency0, currency1, fee: POOL_FEE, tickSpacing: TICK_SPACING, hooks: HOOKS },
+          zeroForOne,
+          exactAmount: plotAmount,
+          hookData: "0x",
+        },
       ],
     });
-    return (result as readonly [bigint, bigint])[0];
+    return result[0];
   } catch {
     return BigInt(0);
   }
@@ -228,4 +282,33 @@ export function buildZapMintTx(
       gas: BigInt(3_000_000),
     };
   }
+}
+
+/**
+ * Execute a zap mint end-to-end: get quote, then submit transaction.
+ *
+ * @param tokenAddress Storyline token address
+ * @param amount Token amount (exact-output) or ETH amount in wei (exact-input)
+ * @param mode Zap mode
+ * @param receiver Address to receive minted tokens
+ * @param writeContractAsync wagmi writeContractAsync function
+ * @returns Transaction hash
+ */
+export async function executeZapMint(
+  tokenAddress: Address,
+  amount: bigint,
+  mode: ZapMode,
+  receiver: Address,
+  writeContractAsync: (args: ReturnType<typeof buildZapMintTx>) => Promise<Address>,
+): Promise<Address> {
+  const quote = await getZapQuote(tokenAddress, amount, mode);
+  const tx = buildZapMintTx(
+    tokenAddress,
+    amount,
+    mode,
+    receiver,
+    quote.ethCost,
+    quote.tokensOut,
+  );
+  return writeContractAsync(tx);
 }

--- a/lib/zap.ts
+++ b/lib/zap.ts
@@ -6,9 +6,9 @@
  * tokens on the MCV2 bonding curve in a single transaction.
  */
 
-import { type Address, parseAbi } from "viem";
+import { type Address, encodeAbiParameters, decodeFunctionResult, encodeFunctionData, parseAbi } from "viem";
 import { browserClient as publicClient } from "./rpc";
-import { ZAP_PLOTLINK, UNISWAP_V4_QUOTER, PLOT_TOKEN } from "./contracts/constants";
+import { ZAP_PLOTLINK, UNISWAP_V4_QUOTER, PLOT_TOKEN, UNISWAP_V4_POOL_MANAGER } from "./contracts/constants";
 
 // ---------------------------------------------------------------------------
 // ABI (only the functions we call)
@@ -21,15 +21,38 @@ export const zapPlotLinkAbi = parseAbi([
   "function estimateMintReverseFromPlot(address storylineToken, uint256 plotAmount) external view returns (uint256 tokensOut)",
 ]);
 
-// Uniswap V4 Quoter — for ETH ↔ PLOT price estimates
+/**
+ * V4 Quoter ABI — quoteExactInputSingle and quoteExactOutputSingle.
+ *
+ * These functions are NOT view — they execute state changes internally and
+ * revert with the result. Must be called via eth_call (simulateContract).
+ *
+ * QuoteExactSingleParams struct:
+ *   PoolKey poolKey (currency0, currency1, fee, tickSpacing, hooks)
+ *   bool zeroForOne
+ *   uint128 exactAmount
+ *   bytes hookData
+ */
 const quoterAbi = parseAbi([
-  "struct QuoteExactSingleParams { address tokenIn; address tokenOut; uint128 amountIn; uint24 fee; uint160 sqrtPriceLimitX96; }",
-  "function quoteExactInputSingle((address tokenIn, address tokenOut, uint128 amountIn, uint24 fee, uint160 sqrtPriceLimitX96) params) external returns (uint256 amountOut, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)",
+  "function quoteExactInputSingle(((address,address,uint24,int24,address),bool,uint128,bytes) params) external returns (uint256 amountOut, uint256 gasEstimate)",
+  "function quoteExactOutputSingle(((address,address,uint24,int24,address),bool,uint128,bytes) params) external returns (uint256 amountIn, uint256 gasEstimate)",
 ]);
 
 const WETH: Address = "0x4200000000000000000000000000000000000006";
 const POOL_FEE = 3000; // 0.30% — must match deployed pool
-const SLIPPAGE_BPS = 50; // 0.5% slippage buffer for swap leg
+const TICK_SPACING = 60;
+const HOOKS: Address = "0x0000000000000000000000000000000000000000";
+const SLIPPAGE_BPS = 50; // 0.5% slippage buffer
+
+// Pool key tokens sorted (currency0 < currency1)
+function getPoolKey(): { currency0: Address; currency1: Address } {
+  const wethNum = BigInt(WETH);
+  const plotNum = BigInt(PLOT_TOKEN);
+  if (wethNum < plotNum) {
+    return { currency0: WETH, currency1: PLOT_TOKEN };
+  }
+  return { currency0: PLOT_TOKEN, currency1: WETH };
+}
 
 // ---------------------------------------------------------------------------
 // Quote helpers
@@ -45,6 +68,63 @@ export interface ZapQuote {
   /** For exact-input: estimated storyline tokens out */
   tokensOut?: bigint;
   mode: ZapMode;
+}
+
+/**
+ * Quote how much PLOT is received for a given ETH input via Uniswap V4.
+ * Uses the V4 Quoter's quoteExactInputSingle (called via eth_call).
+ */
+async function quoteEthToPlot(ethAmount: bigint): Promise<bigint> {
+  const { currency0, currency1 } = getPoolKey();
+  const zeroForOne = currency0 === WETH; // true if WETH is currency0
+
+  try {
+    const { result } = await publicClient.simulateContract({
+      address: UNISWAP_V4_QUOTER as Address,
+      abi: quoterAbi,
+      functionName: "quoteExactInputSingle",
+      args: [
+        {
+          0: { 0: currency0, 1: currency1, 2: POOL_FEE, 3: TICK_SPACING, 4: HOOKS },
+          1: zeroForOne,
+          2: BigInt(ethAmount) as unknown as bigint & { readonly _tag: "uint128" },
+          3: "0x" as `0x${string}`,
+        } as any,
+      ],
+    });
+    return (result as readonly [bigint, bigint])[0];
+  } catch {
+    // Fallback: if quoter call fails, return 0 to indicate unavailable
+    return BigInt(0);
+  }
+}
+
+/**
+ * Quote how much ETH is needed to buy a given amount of PLOT via Uniswap V4.
+ * Uses the V4 Quoter's quoteExactOutputSingle (called via eth_call).
+ */
+async function quotePlotToEth(plotAmount: bigint): Promise<bigint> {
+  const { currency0, currency1 } = getPoolKey();
+  const zeroForOne = currency0 === WETH; // swapping WETH in for PLOT out
+
+  try {
+    const { result } = await publicClient.simulateContract({
+      address: UNISWAP_V4_QUOTER as Address,
+      abi: quoterAbi,
+      functionName: "quoteExactOutputSingle",
+      args: [
+        {
+          0: { 0: currency0, 1: currency1, 2: POOL_FEE, 3: TICK_SPACING, 4: HOOKS },
+          1: zeroForOne,
+          2: BigInt(plotAmount) as unknown as bigint & { readonly _tag: "uint128" },
+          3: "0x" as `0x${string}`,
+        } as any,
+      ],
+    });
+    return (result as readonly [bigint, bigint])[0];
+  } catch {
+    return BigInt(0);
+  }
 }
 
 /**
@@ -72,27 +152,31 @@ export async function getZapQuote(
     });
 
     // Step 2: How much ETH to buy that much PLOT on Uniswap V4?
-    // We estimate by simulating a swap of WETH→PLOT for `plotRequired`
-    // Since we can't easily do exact-output quote, we use a conservative
-    // estimate: assume the swap ratio and add slippage buffer
-    const ethCost = applySwapSlippage(plotRequired);
+    const ethNeeded = await quotePlotToEth(plotRequired);
+
+    // Add 0.5% slippage buffer
+    const ethCost = ethNeeded > BigInt(0)
+      ? ethNeeded + (ethNeeded * BigInt(SLIPPAGE_BPS)) / BigInt(10000)
+      : BigInt(0);
 
     return { plotAmount: plotRequired, ethCost, mode };
   } else {
     // exact-input: user sends `amount` ETH
-    // Step 1: Estimate how much PLOT we get for `amount` ETH
-    // Use the same ratio assumption with inverse slippage
-    const plotEstimate = removeSwapSlippage(amount);
+    // Step 1: How much PLOT do we get for `amount` ETH via Uniswap V4?
+    const plotReceived = await quoteEthToPlot(amount);
 
     // Step 2: How many storyline tokens for that PLOT?
-    const tokensOut = await publicClient.readContract({
-      address: ZAP_PLOTLINK,
-      abi: zapPlotLinkAbi,
-      functionName: "estimateMintReverseFromPlot",
-      args: [tokenAddress, plotEstimate],
-    });
+    let tokensOut = BigInt(0);
+    if (plotReceived > BigInt(0)) {
+      tokensOut = await publicClient.readContract({
+        address: ZAP_PLOTLINK,
+        abi: zapPlotLinkAbi,
+        functionName: "estimateMintReverseFromPlot",
+        args: [tokenAddress, plotReceived],
+      });
+    }
 
-    return { plotAmount: plotEstimate, ethCost: amount, tokensOut, mode };
+    return { plotAmount: plotReceived, ethCost: amount, tokensOut, mode };
   }
 }
 
@@ -108,7 +192,8 @@ export async function getZapQuote(
  * @param amount Token amount (exact-output) or ETH wei (exact-input)
  * @param mode Zap mode
  * @param receiver Address to receive minted tokens
- * @param ethValue ETH to send (from quote.ethCost for exact-output, or the input amount for exact-input)
+ * @param ethValue ETH to send (from quote.ethCost)
+ * @param minTokensOut Minimum tokens for exact-input slippage protection
  */
 export function buildZapMintTx(
   tokenAddress: Address,
@@ -116,6 +201,7 @@ export function buildZapMintTx(
   mode: ZapMode,
   receiver: Address,
   ethValue: bigint,
+  minTokensOut?: bigint,
 ) {
   if (mode === "exact-output") {
     return {
@@ -127,29 +213,19 @@ export function buildZapMintTx(
       gas: BigInt(3_000_000),
     };
   } else {
-    // For exact-input, minTokensOut = 0 (slippage handled by contract revert)
-    // In production, pass a real minTokensOut from the quote
+    // Apply 3% slippage to minTokensOut for exact-input protection
+    const minOut = minTokensOut ?? BigInt(0);
+    const slippageProtected = minOut > BigInt(0)
+      ? minOut - (minOut * BigInt(300)) / BigInt(10000)
+      : BigInt(0);
+
     return {
       address: ZAP_PLOTLINK,
       abi: zapPlotLinkAbi,
       functionName: "mintReverse" as const,
-      args: [tokenAddress, BigInt(0), receiver] as const,
+      args: [tokenAddress, slippageProtected, receiver] as const,
       value: ethValue,
       gas: BigInt(3_000_000),
     };
   }
-}
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-/** Add 0.5% slippage buffer (user pays more ETH to account for swap price impact) */
-function applySwapSlippage(amount: bigint): bigint {
-  return amount + (amount * BigInt(SLIPPAGE_BPS)) / BigInt(10000);
-}
-
-/** Remove 0.5% slippage buffer (user receives less PLOT from swap) */
-function removeSwapSlippage(amount: bigint): bigint {
-  return amount - (amount * BigInt(SLIPPAGE_BPS)) / BigInt(10000);
 }

--- a/lib/zap.ts
+++ b/lib/zap.ts
@@ -1,0 +1,155 @@
+/**
+ * ZapPlotLink frontend wrappers.
+ *
+ * Provides quote estimation and transaction helpers for the ZapPlotLink
+ * contract, which swaps ETH → PLOT via Uniswap V4 and mints storyline
+ * tokens on the MCV2 bonding curve in a single transaction.
+ */
+
+import { type Address, parseAbi } from "viem";
+import { browserClient as publicClient } from "./rpc";
+import { ZAP_PLOTLINK, UNISWAP_V4_QUOTER, PLOT_TOKEN } from "./contracts/constants";
+
+// ---------------------------------------------------------------------------
+// ABI (only the functions we call)
+// ---------------------------------------------------------------------------
+
+export const zapPlotLinkAbi = parseAbi([
+  "function mint(address storylineToken, uint256 tokensToMint, address receiver) external payable returns (uint256 reserveUsed)",
+  "function mintReverse(address storylineToken, uint256 minTokensOut, address receiver) external payable returns (uint256 tokensMinted)",
+  "function estimateMintCostInPlot(address storylineToken, uint256 tokensToMint) external view returns (uint256 plotRequired)",
+  "function estimateMintReverseFromPlot(address storylineToken, uint256 plotAmount) external view returns (uint256 tokensOut)",
+]);
+
+// Uniswap V4 Quoter — for ETH ↔ PLOT price estimates
+const quoterAbi = parseAbi([
+  "struct QuoteExactSingleParams { address tokenIn; address tokenOut; uint128 amountIn; uint24 fee; uint160 sqrtPriceLimitX96; }",
+  "function quoteExactInputSingle((address tokenIn, address tokenOut, uint128 amountIn, uint24 fee, uint160 sqrtPriceLimitX96) params) external returns (uint256 amountOut, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)",
+]);
+
+const WETH: Address = "0x4200000000000000000000000000000000000006";
+const POOL_FEE = 3000; // 0.30% — must match deployed pool
+const SLIPPAGE_BPS = 50; // 0.5% slippage buffer for swap leg
+
+// ---------------------------------------------------------------------------
+// Quote helpers
+// ---------------------------------------------------------------------------
+
+export type ZapMode = "exact-output" | "exact-input";
+
+export interface ZapQuote {
+  /** PLOT tokens needed/received (bonding curve side) */
+  plotAmount: bigint;
+  /** Estimated ETH cost (including 0.5% swap slippage buffer) */
+  ethCost: bigint;
+  /** For exact-input: estimated storyline tokens out */
+  tokensOut?: bigint;
+  mode: ZapMode;
+}
+
+/**
+ * Get a quote for a zap mint.
+ *
+ * - exact-output: "I want N storyline tokens — how much ETH?"
+ * - exact-input: "I have N ETH — how many storyline tokens?"
+ *
+ * @param tokenAddress Storyline token address
+ * @param amount Token amount (exact-output) or ETH amount in wei (exact-input)
+ * @param mode Quote mode
+ */
+export async function getZapQuote(
+  tokenAddress: Address,
+  amount: bigint,
+  mode: ZapMode,
+): Promise<ZapQuote> {
+  if (mode === "exact-output") {
+    // Step 1: How much PLOT needed to mint `amount` storyline tokens?
+    const plotRequired = await publicClient.readContract({
+      address: ZAP_PLOTLINK,
+      abi: zapPlotLinkAbi,
+      functionName: "estimateMintCostInPlot",
+      args: [tokenAddress, amount],
+    });
+
+    // Step 2: How much ETH to buy that much PLOT on Uniswap V4?
+    // We estimate by simulating a swap of WETH→PLOT for `plotRequired`
+    // Since we can't easily do exact-output quote, we use a conservative
+    // estimate: assume the swap ratio and add slippage buffer
+    const ethCost = applySwapSlippage(plotRequired);
+
+    return { plotAmount: plotRequired, ethCost, mode };
+  } else {
+    // exact-input: user sends `amount` ETH
+    // Step 1: Estimate how much PLOT we get for `amount` ETH
+    // Use the same ratio assumption with inverse slippage
+    const plotEstimate = removeSwapSlippage(amount);
+
+    // Step 2: How many storyline tokens for that PLOT?
+    const tokensOut = await publicClient.readContract({
+      address: ZAP_PLOTLINK,
+      abi: zapPlotLinkAbi,
+      functionName: "estimateMintReverseFromPlot",
+      args: [tokenAddress, plotEstimate],
+    });
+
+    return { plotAmount: plotEstimate, ethCost: amount, tokensOut, mode };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Transaction helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the transaction parameters for a zap mint.
+ * Returns args suitable for wagmi's writeContract.
+ *
+ * @param tokenAddress Storyline token address
+ * @param amount Token amount (exact-output) or ETH wei (exact-input)
+ * @param mode Zap mode
+ * @param receiver Address to receive minted tokens
+ * @param ethValue ETH to send (from quote.ethCost for exact-output, or the input amount for exact-input)
+ */
+export function buildZapMintTx(
+  tokenAddress: Address,
+  amount: bigint,
+  mode: ZapMode,
+  receiver: Address,
+  ethValue: bigint,
+) {
+  if (mode === "exact-output") {
+    return {
+      address: ZAP_PLOTLINK,
+      abi: zapPlotLinkAbi,
+      functionName: "mint" as const,
+      args: [tokenAddress, amount, receiver] as const,
+      value: ethValue,
+      gas: BigInt(3_000_000),
+    };
+  } else {
+    // For exact-input, minTokensOut = 0 (slippage handled by contract revert)
+    // In production, pass a real minTokensOut from the quote
+    return {
+      address: ZAP_PLOTLINK,
+      abi: zapPlotLinkAbi,
+      functionName: "mintReverse" as const,
+      args: [tokenAddress, BigInt(0), receiver] as const,
+      value: ethValue,
+      gas: BigInt(3_000_000),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Add 0.5% slippage buffer (user pays more ETH to account for swap price impact) */
+function applySwapSlippage(amount: bigint): bigint {
+  return amount + (amount * BigInt(SLIPPAGE_BPS)) / BigInt(10000);
+}
+
+/** Remove 0.5% slippage buffer (user receives less PLOT from swap) */
+function removeSwapSlippage(amount: bigint): bigint {
+  return amount - (amount * BigInt(SLIPPAGE_BPS)) / BigInt(10000);
+}

--- a/src/components/TradingWidget.tsx
+++ b/src/components/TradingWidget.tsx
@@ -1,49 +1,64 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { useAccount, useWriteContract } from "wagmi";
+import { useAccount, useBalance, useWriteContract } from "wagmi";
 import { useQuery } from "@tanstack/react-query";
 import { parseUnits, formatUnits, type Address } from "viem";
 import { browserClient as publicClient } from "../../lib/rpc";
 import { mcv2BondAbi, erc20Abi } from "../../lib/price";
-import { MCV2_BOND, PLOT_TOKEN, RESERVE_LABEL, EXPLORER_URL } from "../../lib/contracts/constants";
+import { MCV2_BOND, PLOT_TOKEN, RESERVE_LABEL, EXPLORER_URL, ZAP_PLOTLINK } from "../../lib/contracts/constants";
+import { getZapQuote, buildZapMintTx, type ZapMode } from "../../lib/zap";
 
 type Tab = "buy" | "sell";
 type TxState = "idle" | "approving" | "confirming" | "pending" | "done" | "error";
+type PayToken = "ETH" | "PLOT";
 
 const SLIPPAGE_BPS = 300; // 3% slippage tolerance
 
 function applySlippage(amount: bigint, isBuy: boolean): bigint {
   if (isBuy) {
-    // Max cost = estimate * (1 + slippage)
     return amount + (amount * BigInt(SLIPPAGE_BPS)) / BigInt(10000);
   }
-  // Min refund = estimate * (1 - slippage)
   return amount - (amount * BigInt(SLIPPAGE_BPS)) / BigInt(10000);
 }
+
+const isZapAvailable = ZAP_PLOTLINK !== "0x0000000000000000000000000000000000000000";
 
 export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
   const { address, isConnected } = useAccount();
   const [tab, setTab] = useState<Tab>("buy");
+  const [payToken, setPayToken] = useState<PayToken>(isZapAvailable ? "ETH" : "PLOT");
   const [amount, setAmount] = useState("");
   const [txState, setTxState] = useState<TxState>("idle");
   const [error, setError] = useState<string | null>(null);
   const [txHash, setTxHash] = useState<string | null>(null);
 
   const { writeContractAsync } = useWriteContract();
+  const { data: ethBalanceData, refetch: refetchEthBalance } = useBalance({ address });
 
   const parsedAmount =
     amount && !isNaN(Number(amount)) && Number(amount) > 0
       ? parseUnits(amount, 18)
       : BigInt(0);
 
-  // Batch balance + estimate into a single multicall
+  const isEthMode = tab === "buy" && payToken === "ETH" && isZapAvailable;
+
+  // Batch balance + estimate into a single multicall (PLOT mode / sell)
   const balanceToken = tab === "buy" ? PLOT_TOKEN : tokenAddress;
   const hasAmount = parsedAmount > BigInt(0);
 
   const { data: tradeData, refetch: refetchTradeData } = useQuery({
-    queryKey: ["trade-data", balanceToken, address, tab, tokenAddress, amount],
+    queryKey: ["trade-data", balanceToken, address, tab, tokenAddress, amount, payToken],
     queryFn: async () => {
+      if (isEthMode) {
+        // ETH mode: use zap quote instead of multicall
+        let zapQuote = null;
+        if (hasAmount) {
+          zapQuote = await getZapQuote(tokenAddress, parsedAmount, "exact-output");
+        }
+        return { balance: undefined, estimate: null, zapQuote };
+      }
+
       const contracts: Array<{ address: Address; abi: typeof erc20Abi | typeof mcv2BondAbi; functionName: string; args?: readonly unknown[] }> = [
         {
           address: balanceToken,
@@ -70,29 +85,41 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
         est = (results[1].result as unknown as readonly [bigint, bigint])[0];
       }
 
-      return { balance: bal, estimate: est };
+      return { balance: bal, estimate: est, zapQuote: null };
     },
     enabled: !!address,
     refetchInterval: 60000,
   });
 
-  const balance = tradeData?.balance;
+  const balance = isEthMode ? ethBalanceData?.value : tradeData?.balance;
   const estimate = tradeData?.estimate ?? null;
-  const refetchBalance = refetchTradeData;
+  const zapQuote = tradeData?.zapQuote ?? null;
+  const refetchBalance = useCallback(() => {
+    refetchTradeData();
+    if (isEthMode) refetchEthBalance();
+  }, [refetchTradeData, refetchEthBalance, isEthMode]);
 
   const executeTrade = useCallback(async () => {
-    if (!address || parsedAmount === BigInt(0) || !estimate) return;
+    if (!address || parsedAmount === BigInt(0)) return;
 
     try {
       setError(null);
       setTxHash(null);
       let tradeHash: string | null = null;
 
-      if (tab === "buy") {
-        // Buy: approve PLOT_TOKEN → mint
+      if (isEthMode && zapQuote) {
+        // ETH mode: use ZapPlotLink
+        setTxState("confirming");
+        const tx = buildZapMintTx(tokenAddress, parsedAmount, "exact-output", address, zapQuote.ethCost);
+        const hash = await writeContractAsync(tx);
+        setTxHash(hash);
+        tradeHash = hash;
+        setTxState("pending");
+        await publicClient.waitForTransactionReceipt({ hash });
+      } else if (tab === "buy" && estimate) {
+        // PLOT mode: approve PLOT_TOKEN → mint
         const maxCost = applySlippage(estimate, true);
 
-        // Check allowance
         const allowance = await publicClient.readContract({
           address: PLOT_TOKEN,
           abi: erc20Abi,
@@ -111,7 +138,6 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
           await publicClient.waitForTransactionReceipt({ hash: approveHash });
         }
 
-        // Mint
         setTxState("confirming");
         const hash = await writeContractAsync({
           address: MCV2_BOND,
@@ -124,11 +150,10 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
         tradeHash = hash;
         setTxState("pending");
         await publicClient.waitForTransactionReceipt({ hash });
-      } else {
+      } else if (tab === "sell" && estimate) {
         // Sell: approve storyline token → burn → receive PLOT_TOKEN
         const minRefund = applySlippage(estimate, false);
 
-        // Check allowance for storyline token
         const allowance = await publicClient.readContract({
           address: tokenAddress,
           abi: erc20Abi,
@@ -159,6 +184,8 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
         tradeHash = hash;
         setTxState("pending");
         await publicClient.waitForTransactionReceipt({ hash });
+      } else {
+        return;
       }
 
       setTxState("done");
@@ -177,7 +204,7 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
       setError(err instanceof Error ? err.message : "Transaction failed");
       setTxState("error");
     }
-  }, [address, parsedAmount, estimate, tab, tokenAddress, writeContractAsync, refetchBalance]);
+  }, [address, parsedAmount, estimate, zapQuote, tab, isEthMode, tokenAddress, writeContractAsync, refetchBalance]);
 
   const reset = useCallback(() => {
     setTxState("idle");
@@ -189,9 +216,11 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
   const insufficientBalance =
     balance !== undefined &&
     parsedAmount > BigInt(0) &&
-    (tab === "buy"
-      ? estimate != null && applySlippage(estimate, true) > balance
-      : parsedAmount > balance);
+    (isEthMode
+      ? zapQuote != null && zapQuote.ethCost > balance
+      : tab === "buy"
+        ? estimate != null && applySlippage(estimate, true) > balance
+        : parsedAmount > balance);
 
   if (!isConnected) return null;
 
@@ -219,6 +248,30 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
           </button>
         ))}
       </div>
+
+      {/* Pay token selector (buy tab only) */}
+      {tab === "buy" && isZapAvailable && (
+        <div className="mt-2 flex items-center gap-1">
+          <span className="text-muted text-[10px] uppercase tracking-wider">Pay with</span>
+          {(["ETH", "PLOT"] as const).map((t) => (
+            <button
+              key={t}
+              onClick={() => {
+                setPayToken(t);
+                setAmount("");
+                reset();
+              }}
+              className={`rounded px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                payToken === t
+                  ? "bg-accent text-background"
+                  : "border-border text-muted hover:text-foreground border"
+              }`}
+            >
+              {t === "PLOT" ? RESERVE_LABEL : "ETH"}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* Amount input */}
       <div className="mt-3">
@@ -250,7 +303,7 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
         </div>
         {balance !== undefined && (
           <p className="text-muted mt-1 text-[10px]">
-            Balance: {formatUnits(balance, 18)} {tab === "buy" ? RESERVE_LABEL : "tokens"}
+            Balance: {formatUnits(balance, 18)} {isEthMode ? "ETH" : tab === "buy" ? RESERVE_LABEL : "tokens"}
           </p>
         )}
         {insufficientBalance && (
@@ -259,7 +312,16 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
       </div>
 
       {/* Estimate */}
-      {estimate != null && parsedAmount > BigInt(0) && (
+      {isEthMode && zapQuote && parsedAmount > BigInt(0) && (
+        <div className="text-muted mt-2 text-xs">
+          Est. cost:{" "}
+          <span className="font-semibold text-accent">
+            {formatUnits(zapQuote.ethCost, 18)} ETH
+          </span>
+          <span className="ml-2">(incl. 0.5% swap slippage)</span>
+        </div>
+      )}
+      {!isEthMode && estimate != null && parsedAmount > BigInt(0) && (
         <div className="text-muted mt-2 text-xs">
           {tab === "buy" ? "Max cost" : "Min return"}:{" "}
           <span className="font-semibold text-accent">
@@ -273,12 +335,16 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
       <button
         onClick={txState === "done" || txState === "error" ? reset : executeTrade}
         disabled={
-          (txState === "idle" && (parsedAmount === BigInt(0) || !estimate || insufficientBalance)) ||
+          (txState === "idle" && (
+            parsedAmount === BigInt(0) ||
+            (isEthMode ? !zapQuote : !estimate) ||
+            insufficientBalance
+          )) ||
           (txState !== "idle" && txState !== "done" && txState !== "error")
         }
         className="bg-accent text-background mt-3 w-full rounded py-2 text-xs font-medium transition-opacity disabled:opacity-40"
       >
-        {txState === "idle" && (tab === "buy" ? "Buy Tokens" : "Sell Tokens")}
+        {txState === "idle" && (tab === "buy" ? `Buy with ${isEthMode ? "ETH" : RESERVE_LABEL}` : "Sell Tokens")}
         {txState === "approving" && "Approving..."}
         {txState === "confirming" && "Confirm in wallet..."}
         {txState === "pending" && "Pending..."}

--- a/src/components/TradingWidget.tsx
+++ b/src/components/TradingWidget.tsx
@@ -7,7 +7,7 @@ import { parseUnits, formatUnits, type Address } from "viem";
 import { browserClient as publicClient } from "../../lib/rpc";
 import { mcv2BondAbi, erc20Abi } from "../../lib/price";
 import { MCV2_BOND, PLOT_TOKEN, RESERVE_LABEL, EXPLORER_URL, ZAP_PLOTLINK } from "../../lib/contracts/constants";
-import { getZapQuote, buildZapMintTx, type ZapMode } from "../../lib/zap";
+import { getZapQuote, buildZapMintTx } from "../../lib/zap";
 
 type Tab = "buy" | "sell";
 type TxState = "idle" | "approving" | "confirming" | "pending" | "done" | "error";


### PR DESCRIPTION
## Summary
- **P5-9a**: Created `lib/zap.ts` with ZapPlotLink contract wrappers (`getZapQuote`, `buildZapMintTx`, ABI subset)
- **P5-9b**: Added ETH/PL_TEST input selector to `TradingWidget.tsx` buy tab. Default: ETH. Sell tab unchanged.
- Fixed `RESERVE_LABEL` mainnet value from `"PL_TEST"` to `"PLOT"`

## Details
- ETH mode uses ZapPlotLink payable `mint()` — no token approval needed
- PLOT mode keeps existing `approve → MCV2_Bond.mint` flow
- Zap selector auto-hidden when `ZAP_PLOTLINK` is zero address (mainnet)
- Trade indexing (`/api/index/trade`) fires for both ETH and PLOT trades
- 0.5% swap slippage buffer on ETH→PLOT conversion estimates

## Test plan
- [ ] Verify TypeScript compiles cleanly
- [ ] Verify ETH/PLOT toggle renders on buy tab
- [ ] Verify PLOT mode still works (existing behavior)
- [ ] Test ETH mode quote estimation on testnet
- [ ] Test ETH mode mint execution on testnet
- [ ] Verify sell tab is unchanged

Fixes realproject7/agent-os#242

🤖 Generated with [Claude Code](https://claude.com/claude-code)