### PR TITLE
Update ZAP_PLOTLINK to fixed routing contract

### DIFF
--- a/lib/contracts/constants.ts
+++ b/lib/contracts/constants.ts
@@ -37,7 +37,7 @@ export const STORY_FACTORY = (process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ??
  *  Testnet: disabled (V1 contract incompatible with V2 ABI) */
 export const ZAP_PLOTLINK = (IS_TESTNET
   ? "0x0000000000000000000000000000000000000000"
-  : "0xEF6a8640c836b16Eb8cCD8016Ead4C8517aC3033") as `0x${string}`;
+  : "0x7bC192848003ab1Ba286C66AFD0dd8a1729c6b02") as `0x${string}`;
 
 /** $PLOT protocol token
  *  Testnet: PL_TEST ERC-20 on Base Sepolia


### PR DESCRIPTION
## Summary
- Update `ZAP_PLOTLINK` mainnet address to `0x7bC192848003ab1Ba286C66AFD0dd8a1729c6b02` (new contract with fixed HUNT/USDC routing)

Fixes #443

## Test plan
- [x] Constant updated in `lib/contracts/constants.ts`
- [ ] Frontend quote and mint flows work with new contract address

🤖 Generated with [Claude Code](https://claude.com/claude-code)