### PR TITLE
Redesign footer with contract, token, and GitHub links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,8 @@
 import Link from "next/link";
+import { STORY_FACTORY, EXPLORER_URL } from "../../lib/contracts/constants";
+
+const CONTRACT_URL = `${EXPLORER_URL}/address/${STORY_FACTORY}`;
+const GITHUB_URL = "https://github.com/realproject7/plotlink-contracts";
 
 export function Footer() {
   return (
@@ -6,14 +10,20 @@ export function Footer() {
       <div className="mx-auto max-w-5xl flex flex-col gap-4 text-xs">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="flex items-center gap-4 text-muted">
-            <Link href="/" className="hover:text-foreground transition-colors">
-              stories
-            </Link>
-            <Link href="/create" className="hover:text-foreground transition-colors">
-              create
+            <a
+              href={CONTRACT_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-foreground transition-colors"
+              title={STORY_FACTORY}
+            >
+              contract: {STORY_FACTORY.slice(0, 6)}...{STORY_FACTORY.slice(-4)}
+            </a>
+            <Link href="/token" className="hover:text-foreground transition-colors">
+              $PLOT
             </Link>
             <a
-              href="https://github.com/realproject7/plotlink"
+              href={GITHUB_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="hover:text-foreground transition-colors"


### PR DESCRIPTION
## Summary
- Remove Stories and Create links (duplicated in NavBar)
- Add StoryFactory contract address with Basescan link (truncated with full address on hover)
- Add $PLOT link to `/token` page
- Update GitHub link to plotlink-contracts repo

Fixes #254

## Test plan
- [x] `next build` passes
- [ ] Visual: footer shows contract, $PLOT, github links
- [ ] Contract link opens Basescan
- [ ] $PLOT link navigates to /token
- [ ] Mobile responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)