### PR TITLE
Switch system font to Lora (revertible)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,17 +25,22 @@
   --color-accent-dim: var(--accent-dim);
   --color-border: var(--border);
   --color-error: var(--error);
-  --font-heading: var(--font-geist-mono);
-  --font-body: var(--font-geist-mono);
+  --font-heading: var(--font-lora);
+  --font-body: var(--font-lora);
 }
 
 body {
   background: var(--bg);
   color: var(--text);
-  font-family: var(--font-geist-mono), "Geist Mono", ui-monospace, monospace;
+  font-family: var(--font-lora), "Lora", Georgia, "Times New Roman", serif;
 }
 
 h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-lora), "Lora", Georgia, "Times New Roman", serif;
+}
+
+/* Monospace elements: addresses, code blocks, contract data */
+code, pre, .font-mono {
   font-family: var(--font-geist-mono), "Geist Mono", ui-monospace, monospace;
 }
 
@@ -47,7 +52,7 @@ h1, h2, h3, h4, h5, h6 {
 
 /* Ruled notebook paper */
 .ruled-paper {
-  --line-height: 26px;
+  --line-height: 28px;
   background: var(--paper-bg);
   padding: calc(var(--line-height) * 2) 2rem var(--line-height) 4.5rem;
   font-size: 1rem;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,15 @@
 import type { Metadata } from "next";
-import { Geist_Mono } from "next/font/google";
+import { Lora, Geist_Mono } from "next/font/google";
 import { Providers } from "./providers";
 import { NavBar } from "../components/NavBar";
 import { Footer } from "../components/Footer";
 import { FarcasterMiniApp } from "../components/FarcasterMiniApp";
 import "./globals.css";
+
+const lora = Lora({
+  variable: "--font-lora",
+  subsets: ["latin"],
+});
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
@@ -34,7 +39,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistMono.variable} antialiased`}>
+      <body className={`${lora.variable} ${geistMono.variable} antialiased`}>
         <Providers>
           <FarcasterMiniApp />
           <NavBar />


### PR DESCRIPTION
## Summary
- Switch body and heading font from Geist Mono to Lora (serif)
- Geist Mono retained for code/pre/monospace elements (addresses, contract data)
- Ruled paper line-height adjusted from 26px to 28px for better serif alignment

Fixes #450

## Revert Point
```
git reset --hard 47c5df7258e1d2ba34c934f5a72feb66356ed4cd
```

## Test plan
- [x] `next build` passes
- [ ] Visual: Lora renders on all pages
- [ ] Visual: Ruled paper lines align with text
- [ ] Visual: Code/address elements still use monospace
- [ ] Mobile responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)