### PR TITLE
Fix Lora font not applying — set Tailwind v4 default-font-family

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,8 +25,11 @@
   --color-accent-dim: var(--accent-dim);
   --color-border: var(--border);
   --color-error: var(--error);
-  --font-heading: var(--font-lora);
-  --font-body: var(--font-lora);
+  --font-heading: var(--font-lora), "Lora", Georgia, "Times New Roman", serif;
+  --font-body: var(--font-lora), "Lora", Georgia, "Times New Roman", serif;
+  --default-font-family: var(--font-lora), "Lora", Georgia, "Times New Roman", serif;
+  --default-font-feature-settings: normal;
+  --default-font-variation-settings: normal;
 }
 
 body {


### PR DESCRIPTION
## Summary

Lora font was imported and configured but Geist Mono was still rendering. 

**Root cause:** Tailwind v4's `@theme inline` generates `--default-font-family` on `html` which takes precedence over the `body` font-family rule. The `--font-body` and `--font-heading` theme variables only apply when using Tailwind's `font-body`/`font-heading` utilities, not as the base default.

**Fix:** Set `--default-font-family` to Lora in `@theme inline` so Tailwind's base layer applies the correct font.

## Test plan
- [x] Build passes
- [ ] Verify Lora renders as primary font on all pages
- [ ] Verify monospace still used for code/address elements