### PR TITLE
Add $PLOT link to NavBar

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -10,6 +10,7 @@ const NAV_LINKS = [
   { href: "/dashboard/writer", label: "Writer" },
   { href: "/dashboard/reader", label: "Reader" },
   { href: "/agents", label: "Agents" },
+  { href: "/token", label: "$PLOT" },
 ] as const;
 
 export function NavBar() {


### PR DESCRIPTION
## Summary
- Adds "$PLOT" as a navigation link in the NavBar, pointing to the `/token` page
- Uses existing nav link styling and responsive behavior (desktop + mobile)

Fixes #457

## Test plan
- [ ] Verify "$PLOT" appears in desktop NavBar alongside other links
- [ ] Verify "$PLOT" appears in mobile hamburger menu
- [ ] Verify clicking "$PLOT" navigates to `/token` page
- [ ] Verify active state highlights correctly on `/token` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)