### PR TITLE
Apply Claude-style two-font typography

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,8 +25,12 @@
   --color-accent-dim: var(--accent-dim);
   --color-border: var(--border);
   --color-error: var(--error);
+  /* Two-font system: serif for content, sans-serif for UI */
+  /* REVERT POINT: To revert typography, restore all --font-* and --default-font-family
+     to use --font-lora instead of --font-inter for UI lines below */
   --font-heading: var(--font-lora), "Lora", Georgia, "Times New Roman", serif;
   --font-body: var(--font-lora), "Lora", Georgia, "Times New Roman", serif;
+  --font-ui: var(--font-inter), "Inter", system-ui, -apple-system, sans-serif;
   --default-font-family: var(--font-lora), "Lora", Georgia, "Times New Roman", serif;
   --default-font-feature-settings: normal;
   --default-font-variation-settings: normal;
@@ -40,6 +44,12 @@ body {
 
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-lora), "Lora", Georgia, "Times New Roman", serif;
+}
+
+/* UI elements: sans-serif (Inter) for navigation, controls, labels */
+nav, footer, button, input, select, textarea, label,
+.font-ui {
+  font-family: var(--font-inter), "Inter", system-ui, -apple-system, sans-serif;
 }
 
 /* Monospace elements: addresses, code blocks, contract data */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,7 +49,7 @@ h1, h2, h3, h4, h5, h6 {
 /* UI elements: sans-serif (Inter) for navigation, controls, labels */
 nav, footer, button, input, select, textarea, label,
 .font-ui {
-  font-family: var(--font-inter), "Inter", system-ui, -apple-system, sans-serif;
+  font-family: var(--font-ui);
 }
 
 /* Monospace elements: addresses, code blocks, contract data */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Lora, Geist_Mono } from "next/font/google";
+import { Lora, Inter, Geist_Mono } from "next/font/google";
 import { Providers } from "./providers";
 import { NavBar } from "../components/NavBar";
 import { Footer } from "../components/Footer";
@@ -8,6 +8,11 @@ import "./globals.css";
 
 const lora = Lora({
   variable: "--font-lora",
+  subsets: ["latin"],
+});
+
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
 });
 
@@ -39,7 +44,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${lora.variable} ${geistMono.variable} antialiased`}>
+      <body className={`${lora.variable} ${inter.variable} ${geistMono.variable} antialiased`}>
         <Providers>
           <FarcasterMiniApp />
           <NavBar />


### PR DESCRIPTION
## Summary
- Adds **Inter** (Google Fonts, sans-serif) for UI elements: nav, footer, buttons, inputs, form controls
- Keeps **Lora** (serif) for content: body text, headings, story prose
- Defines `--font-ui` CSS variable in the Tailwind `@theme` block and a `.font-ui` utility class
- UI element rule references `var(--font-ui)` for single-point revert
- Revert point clearly documented in `globals.css` — change `--font-ui` back to Lora stack to restore previous single-font system

Fixes #458

## Typography mapping
| Element | Font | Family |
|---------|------|--------|
| Body text, headings, prose | Lora | Serif |
| Nav, footer, buttons, inputs, labels | Inter | Sans-serif |
| Code, addresses, contract data | Geist Mono | Monospace |

## Test plan
- [ ] Verify NavBar and Footer render in Inter (sans-serif)
- [ ] Verify story content and headings render in Lora (serif)
- [ ] Verify buttons and form inputs use Inter
- [ ] Verify responsive layout unchanged on mobile and desktop
- [ ] Verify `.font-ui` utility class applies Inter when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)