### PR TITLE
Fix Inter font not applying to UI elements

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,7 +49,7 @@ h1, h2, h3, h4, h5, h6 {
 /* UI elements: sans-serif (Inter) for navigation, controls, labels */
 nav, footer, button, input, select, textarea, label,
 .font-ui {
-  font-family: var(--font-ui);
+  font-family: var(--font-inter), "Inter", system-ui, -apple-system, sans-serif;
 }
 
 /* Monospace elements: addresses, code blocks, contract data */


### PR DESCRIPTION
## Summary

Inter (sans-serif) wasn't rendering on UI elements (nav, buttons, inputs). DevTools showed `font-family` resolving to Lora instead of Inter.

**Root cause:** `--font-ui` was defined in `@theme inline` using `var(--font-inter)`, but Next.js sets `--font-inter` on `<body>` at runtime via a class. Tailwind's `@theme inline` is processed at build time and can't see runtime CSS variables — so `var(--font-inter)` resolved to nothing, falling back to Lora.

**Fix:** Use `var(--font-inter)` directly in the CSS rule (where it resolves at runtime) instead of going through the `@theme` variable.