### PR TITLE
Disable USDC zap pending contract fix (#464)

### DIFF
--- a/lib/contracts/constants.ts
+++ b/lib/contracts/constants.ts
@@ -63,11 +63,11 @@ export const HUNT = "0x37f0c2915CeCC7e977183B8543Fc0864d03E064C" as const;
 export const ETH_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
 
 /** Supported input tokens for the Zap UI selector.
- *  USDC disabled: no USDC/ETH Uniswap V4 pool exists on Base mainnet with
- *  the contract's configured params (fee=500, tickSpacing=10). The V4 Quoter
- *  returns garbage values for uninitialized pools, making estimates appear
- *  valid while actual swaps revert. Re-enable when a V4 pool is deployed
- *  and ZapPlotLinkV2.setUsdcPoolKey() is updated to match. */
+ *  USDC disabled: ZapPlotLinkV2's multi-hop SWAP_EXACT_IN encoding reverts
+ *  inside Universal Router's unlockCallback. The USDC/ETH V4 pool exists,
+ *  but the contract's _executeV4MultiHopSwapExactIn ABI encoding doesn't
+ *  match the deployed Router's expected format. Re-enable after contract
+ *  fix + redeployment (see #464 for full investigation). */
 export const SUPPORTED_ZAP_TOKENS = [
   { symbol: "ETH", address: ETH_ADDRESS as `0x${string}`, decimals: 18 },
   { symbol: "HUNT", address: HUNT as `0x${string}`, decimals: 18 },

--- a/lib/contracts/constants.ts
+++ b/lib/contracts/constants.ts
@@ -62,10 +62,14 @@ export const HUNT = "0x37f0c2915CeCC7e977183B8543Fc0864d03E064C" as const;
 /** ETH represented as address(0) in the Zap contract */
 export const ETH_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
 
-/** Supported input tokens for the Zap UI selector */
+/** Supported input tokens for the Zap UI selector.
+ *  USDC disabled: no USDC/ETH Uniswap V4 pool exists on Base mainnet with
+ *  the contract's configured params (fee=500, tickSpacing=10). The V4 Quoter
+ *  returns garbage values for uninitialized pools, making estimates appear
+ *  valid while actual swaps revert. Re-enable when a V4 pool is deployed
+ *  and ZapPlotLinkV2.setUsdcPoolKey() is updated to match. */
 export const SUPPORTED_ZAP_TOKENS = [
   { symbol: "ETH", address: ETH_ADDRESS as `0x${string}`, decimals: 18 },
-  { symbol: "USDC", address: USDC as `0x${string}`, decimals: 6 },
   { symbol: "HUNT", address: HUNT as `0x${string}`, decimals: 18 },
 ] as const;
 

--- a/src/app/token/page.tsx
+++ b/src/app/token/page.tsx
@@ -126,7 +126,7 @@ export default function TokenPage() {
           <div className="flex items-start gap-3">
             <span className="text-accent text-sm">&#8226;</span>
             <p className="text-muted text-sm">
-              <span className="text-foreground font-semibold">Use the Zap</span> — buy story tokens with ETH, USDC, or HUNT and the zap contract handles PLOT conversion automatically.
+              <span className="text-foreground font-semibold">Use the Zap</span> — buy story tokens with ETH or HUNT and the zap contract handles PLOT conversion automatically.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Temporary frontend mitigation for #464 — disables USDC as a payment option until the contract-level multi-hop encoding bug is fixed and ZapPlotLinkV2 is redeployed.

- Removes USDC from `SUPPORTED_ZAP_TOKENS`
- Updates /token page copy to remove USDC mention

**Note**: This PR does NOT close #464. The full fix requires a contract redeployment in `plotlink-contracts` with corrected multi-hop ABI encoding.

## Root Cause (documented for #464)

The USDC→ETH→PLOT multi-hop swap reverts inside Universal Router's `unlockCallback` with empty revert data (1618 gas consumed). The bug is in `ZapPlotLinkV2._executeV4MultiHopSwapExactIn` — the `SWAP_EXACT_IN` action params are ABI-encoded differently from what the deployed Router expects. ETH single-hop and HUNT routes are unaffected.

Full investigation details in #464.

## Test plan
- [ ] Verify TradingWidget only shows ETH and HUNT options
- [ ] Verify ETH zap still works
- [ ] Verify HUNT zap still works
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)