### PR TITLE
Fix USDC multi-hop encoding, redeploy Zap, re-enable USDC

### DIFF
--- a/lib/contracts/constants.ts
+++ b/lib/contracts/constants.ts
@@ -37,7 +37,7 @@ export const STORY_FACTORY = (process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ??
  *  Testnet: disabled (V1 contract incompatible with V2 ABI) */
 export const ZAP_PLOTLINK = (IS_TESTNET
   ? "0x0000000000000000000000000000000000000000"
-  : "0x04f557F8D2806B34FC832a534c08DF514D4dfEeF") as `0x${string}`;
+  : "0x952606df750C01e0a12458C3F814598B94AD5C5f") as `0x${string}`;
 
 /** $PLOT protocol token
  *  Testnet: PL_TEST ERC-20 on Base Sepolia
@@ -62,14 +62,10 @@ export const HUNT = "0x37f0c2915CeCC7e977183B8543Fc0864d03E064C" as const;
 /** ETH represented as address(0) in the Zap contract */
 export const ETH_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
 
-/** Supported input tokens for the Zap UI selector.
- *  USDC disabled: ZapPlotLinkV2's multi-hop SWAP_EXACT_IN encoding reverts
- *  inside Universal Router's unlockCallback. The USDC/ETH V4 pool exists,
- *  but the contract's _executeV4MultiHopSwapExactIn ABI encoding doesn't
- *  match the deployed Router's expected format. Re-enable after contract
- *  fix + redeployment (see #464 for full investigation). */
+/** Supported input tokens for the Zap UI selector */
 export const SUPPORTED_ZAP_TOKENS = [
   { symbol: "ETH", address: ETH_ADDRESS as `0x${string}`, decimals: 18 },
+  { symbol: "USDC", address: USDC as `0x${string}`, decimals: 6 },
   { symbol: "HUNT", address: HUNT as `0x${string}`, decimals: 18 },
 ] as const;
 


### PR DESCRIPTION
## Summary
- Updates `ZAP_PLOTLINK` to newly deployed contract: `0x952606df750C01e0a12458C3F814598B94AD5C5f`
- Re-enables USDC in `SUPPORTED_ZAP_TOKENS` (was disabled in PR #466)
- Contract verified on Sourcify (exact match)

Fixes #468

## Root Cause
`abi.encode(field1, field2, ...)` produces flat tuple encoding, but the V4 Router's `CalldataDecoder.decodeSwapExactInParams()` expects struct-style encoding with an outer `0x20` offset word. The single-hop `ExactInputSingleParams` worked because Forge's `abi.encode(struct)` naturally includes this offset, while our manual multi-hop encoding did not.

## Contract Fix (in plotlink-contracts)
Added `_encodeAsStruct()` helper that prepends `0x20` offset to flat-encoded multi-hop params, matching what the Router expects. Applied to both `_executeV4MultiHopSwapExactIn` and `_executeV4MultiHopSwapExactOut`.

## Successful USDC Trade (Base Mainnet)
**TX: [`0x22298421d03be8f4459c03141b10148b1b0c28e34e78e943e0a4b1995c43ea7f`](https://basescan.org/tx/0x22298421d03be8f4459c03141b10148b1b0c28e34e78e943e0a4b1995c43ea7f)**
- 1 USDC → storyline tokens via USDC→ETH→PLOT multi-hop
- Gas used: ~2M (V4 multi-hop is gas-intensive)

## Test plan
- [ ] Verify TradingWidget shows ETH, USDC, and HUNT options
- [ ] Verify USDC zap quote works (estimateMint)
- [ ] Verify ETH zap still works with new contract
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)