### PR TITLE
[#470] Update ZAP_PLOTLINK to fixed USDC deployment

### DIFF
--- a/lib/contracts/constants.ts
+++ b/lib/contracts/constants.ts
@@ -37,7 +37,7 @@ export const STORY_FACTORY = (process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ??
  *  Testnet: disabled (V1 contract incompatible with V2 ABI) */
 export const ZAP_PLOTLINK = (IS_TESTNET
   ? "0x0000000000000000000000000000000000000000"
-  : "0x952606df750C01e0a12458C3F814598B94AD5C5f") as `0x${string}`;
+  : "0xAe50C9444DA2Ac80B209dC8B416d1B4A7D3939B0") as `0x${string}`;
 
 /** $PLOT protocol token
  *  Testnet: PL_TEST ERC-20 on Base Sepolia


### PR DESCRIPTION
## Summary

- Updates `ZAP_PLOTLINK` constant to the new deployment `0xAe50C9444DA2Ac80B209dC8B416d1B4A7D3939B0` which fixes USDC zap minting
- Contract fix details in [plotlink-contracts PR #65](https://github.com/realproject7/plotlink-contracts/pull/65)

## Test plan
- [x] Mainnet USDC mint tx confirmed: [`0x417378c8...`](https://basescan.org/tx/0x417378c881237fbbd9bbfd59225c643ebc26851d9151af58b2a1047d5cc70ac5)
- [ ] Verify trading widget works with new contract on staging

Fixes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)