### PR TITLE
[#472] Add logo symbol to NavBar, Lora bold brand text

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import Image from "next/image";
 import { ConnectWallet } from "./ConnectWallet";
 
 const NAV_LINKS = [
@@ -23,9 +24,18 @@ export function NavBar() {
         {/* Logo */}
         <Link
           href="/"
-          className="text-sm font-semibold tracking-tight text-[var(--text)] transition-opacity hover:opacity-80"
+          className="flex items-center gap-1.5 transition-opacity hover:opacity-80"
         >
-          PlotLink
+          <Image
+            src="/plotlink-logo-symbol.svg"
+            alt=""
+            width={20}
+            height={24}
+            className="h-5 w-auto"
+          />
+          <span className="font-heading text-sm font-bold tracking-tight text-[var(--text)]">
+            PlotLink
+          </span>
         </Link>
 
         {/* Desktop nav links */}


### PR DESCRIPTION
## Summary

- Added `plotlink-logo-symbol.svg` before "PlotLink" text in NavBar
- Changed brand text to Lora bold via `font-heading font-bold`
- Verified favicon, OG image, and Farcaster manifest references are correct

## Test plan
- [x] Build passes
- [x] `favicon.png` (512x512), `icon.png` (1024x1024), `og-image.png` correctly referenced in `layout.tsx`
- [x] Farcaster manifest `iconUrl`, `splashImageUrl`, `ogImageUrl` point to correct assets
- [ ] Visual check: logo + text don't overflow on mobile

Fixes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)