### PR TITLE
Increase NavBar logo + story card title font sizes

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -33,7 +33,7 @@ export function NavBar() {
             height={24}
             className="h-5 w-auto"
           />
-          <span className="font-heading text-sm font-bold tracking-tight text-[var(--text)]">
+          <span className="font-heading text-lg font-bold tracking-tight text-[var(--accent)]">
             PlotLink
           </span>
         </Link>

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -87,7 +87,7 @@ export function StoryCard({
 
           {/* Center: title */}
           <div className="relative z-10 flex flex-1 flex-col items-center justify-center px-5 text-center">
-            <h3 className="font-heading text-sm font-bold leading-tight tracking-tight text-[var(--accent)] sm:text-base">
+            <h3 className="font-heading text-lg font-bold leading-tight tracking-tight text-[var(--accent)] sm:text-xl">
               {storyline.title}
             </h3>
             {storyline.language && storyline.language !== "English" && (


### PR DESCRIPTION
NavBar PlotLink: text-lg + accent color. Story card titles: text-lg/text-xl.