### PR TITLE
[#476] Add GitHub Actions deploy workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,81 @@
+# [#476] Production deploy to Vercel via GitHub Actions
+#
+# Triggers on push to main (i.e. merged PRs) or manual dispatch.
+# Uses repository secrets instead of builder identities.
+#
+# Required GitHub repo secrets:
+#   VERCEL_TOKEN      — Vercel personal access token (Settings > Tokens)
+#   VERCEL_ORG_ID     — from .vercel/project.json or Vercel dashboard
+#   VERCEL_PROJECT_ID — from .vercel/project.json or Vercel dashboard
+#
+# Vercel-side configuration required:
+#   Settings > Git > Ignored Build Step: set command to `exit 0`
+#   This prevents Vercel's Git integration from running its own builds
+#   while preserving cron jobs, domains, and other integration features.
+#   If this is not set, both Vercel and Actions will attempt to build on push.
+
+name: Deploy Production
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.repository == 'realproject7/plotlink'
+    timeout-minutes: 15
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@39
+
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Build
+        run: vercel build --prod --token="$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy
+        id: deploy
+        run: |
+          URL=$(vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN")
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Summary
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.url }}
+        run: |
+          echo "### Production Deploy" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Deployed to: $DEPLOY_URL" >> $GITHUB_STEP_SUMMARY
+          echo "Commit: \`$(echo $GITHUB_SHA | cut -c1-7)\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy-production.yml` — deploys to Vercel on push to `main` or manual dispatch
- Based on the Dropcast reference workflow with repo check changed to `realproject7/plotlink`
- `vercel.json` with backfill cron already exists (committed in #12)

Fixes #476

## Operator items (already done per issue)
- Vercel Ignored Build Step set to `exit 0`
- GitHub secrets (`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`) added
- `production` environment created

## Test plan
- [ ] Merge to main triggers the Actions workflow
- [ ] Workflow pulls env, builds, and deploys to Vercel
- [ ] Vercel auto-deploy does NOT trigger (exit 0)
- [ ] Cron job fires every 5 minutes at `/api/cron/backfill`

🤖 Generated with [Claude Code](https://claude.com/claude-code)