### PR TITLE
[#491] Fix mobile footer layout and bottom nav spacing

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,10 +6,10 @@ const GITHUB_URL = "https://github.com/realproject7/plotlink-contracts";
 
 export function Footer() {
   return (
-    <footer className="border-t border-[var(--border)] bg-[var(--bg)] px-4 py-6 mt-16">
+    <footer className="border-t border-[var(--border)] bg-[var(--bg)] px-4 py-6 pb-20 lg:pb-6 mt-16">
       <div className="mx-auto max-w-5xl flex flex-col gap-4 text-xs">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div className="flex items-center gap-4 text-muted">
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:gap-4">
+          <div className="flex flex-wrap items-center gap-3 sm:gap-4 text-muted">
             <a
               href={CONTRACT_URL}
               target="_blank"

--- a/src/components/MobileActionBar.tsx
+++ b/src/components/MobileActionBar.tsx
@@ -52,7 +52,7 @@ export function MobileActionBar({
       )}
 
       {/* Fixed bottom bar */}
-      <div className="fixed inset-x-0 bottom-0 z-30 grid grid-cols-3 gap-2 border-t border-[var(--border)] bg-[var(--bg)]/95 p-3 backdrop-blur-sm">
+      <div className="fixed inset-x-0 bottom-0 z-30 grid grid-cols-3 gap-2 border-t border-[var(--border)] bg-[var(--bg)]/95 px-3 pt-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] backdrop-blur-sm">
         {buttons.map(({ key, label }) => (
           <button
             key={key}


### PR DESCRIPTION
## Summary
- **Footer**: Adds `pb-20` on mobile for clearance above the fixed bottom nav bar (reverts to `pb-6` on desktop via `lg:pb-6`). Stacks footer elements vertically on small screens (`flex-col` → `sm:flex-row`) for better mobile layout.
- **MobileActionBar**: Adds `env(safe-area-inset-bottom)` padding to the fixed bottom bar so buttons don't overlap the home indicator on notched devices (iPhone X+, etc.).

Fixes #491

## Test plan
- [ ] Build passes (`next build`)
- [ ] Footer has visible gap above bottom nav on mobile
- [ ] Footer elements stack cleanly on narrow viewports
- [ ] Bottom nav buttons have comfortable tap targets on notched devices
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)