### PR TITLE
[#492] Improve Trade button visibility on mobile

### DIFF
--- a/src/components/MobileActionBar.tsx
+++ b/src/components/MobileActionBar.tsx
@@ -57,12 +57,12 @@ export function MobileActionBar({
           <button
             key={key}
             onClick={() => setOpen(open === key ? null : key)}
-            className={`rounded border px-3 py-2 text-xs transition-colors ${
+            className={`rounded px-3 py-2 text-xs transition-colors ${
               open === key
-                ? "border-accent text-accent"
+                ? "border-2 border-accent text-accent font-semibold"
                 : key === "trade"
-                  ? "border-accent text-accent hover:opacity-80"
-                  : "border-[var(--border)] text-muted hover:text-foreground"
+                  ? "border-2 border-accent text-accent font-bold hover:opacity-80"
+                  : "border border-[var(--border)] text-muted hover:text-foreground"
             }`}
           >
             {label}


### PR DESCRIPTION
## Summary
- Trade button: `border-2` + `font-bold` to stand out as the primary CTA
- Active/open state: `border-2` + `font-semibold` for all buttons
- Donate/Rate: keep `border` (1px) + regular weight as secondary actions

Fixes #492

## Test plan
- [ ] Build passes
- [ ] Trade button has noticeably thicker border than Donate/Rate
- [ ] Trade button text is bolder
- [ ] Active state styling consistent across all buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)