### PR TITLE
[#490] Add native Farcaster miniapp install + notification modal

### DIFF
--- a/src/components/FarcasterMiniApp.tsx
+++ b/src/components/FarcasterMiniApp.tsx
@@ -4,8 +4,12 @@ import { useEffect } from "react";
 import { usePlatformDetection } from "../hooks/usePlatformDetection";
 
 /**
- * Calls `sdk.actions.ready()` to dismiss the splash screen — only in Farcaster clients.
- * After Base App migration (April 2026), Base App operates as standard web app.
+ * Farcaster Mini App lifecycle — only runs in Farcaster clients.
+ *
+ * 1. Calls `sdk.actions.ready()` to dismiss the splash screen.
+ * 2. If the user hasn't added the app yet, triggers `sdk.actions.addMiniApp()`
+ *    which shows the native Farcaster modal for install + notification permission.
+ *    The SDK/client handles "already added" state — no re-prompting.
  *
  * Renders nothing — mount once near the root of the component tree.
  */
@@ -19,7 +23,20 @@ export function FarcasterMiniApp() {
 
     import("@farcaster/miniapp-sdk").then(async ({ sdk }) => {
       if (cancelled) return;
+
+      // Dismiss splash screen
       sdk.actions.ready();
+
+      // Check if user has already added the miniapp
+      const context = await sdk.context;
+      if (cancelled || !context?.client) return;
+
+      if (!context.client.added) {
+        // Trigger native add/notification modal — SDK handles dismissal gracefully
+        sdk.actions.addMiniApp().catch(() => {
+          // User dismissed or SDK error — no action needed
+        });
+      }
     }).catch(() => {
       // Not in a Farcaster context — silently ignore
     });


### PR DESCRIPTION
## Summary
- After `sdk.actions.ready()` dismisses the splash, checks `context.client.added`
- If user hasn't added PlotLink yet, triggers `sdk.actions.addMiniApp()` which shows the native Farcaster modal for install + notification permission
- Only fires when `platform === 'farcaster'` (not web or Base App)
- SDK/client handles "already added" and dismissal states — no re-prompting
- Matches Dropcast's FrameProvider pattern

Fixes #490

## Test plan
- [ ] Build passes
- [ ] In Warpcast (new user): native modal appears after splash asking to add PlotLink
- [ ] In Warpcast (existing user): no modal re-prompt
- [ ] On web: no modal, no errors
- [ ] Dismissing modal: no errors, app continues normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)