### PR TITLE
Fix Farcaster profile links — farcaster.xyz not .com

### DIFF
--- a/src/components/FarcasterAvatar.tsx
+++ b/src/components/FarcasterAvatar.tsx
@@ -54,7 +54,7 @@ export function FarcasterAvatar({
       )}
       {linkProfile ? (
         <a
-          href={`https://farcaster.com/${profile.username}`}
+          href={`https://farcaster.xyz/${profile.username}`}
           target="_blank"
           rel="noopener noreferrer"
           className="text-foreground hover:text-accent transition-colors"

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -39,7 +39,7 @@ export function ShareButtons({ storylineId, title }: ShareButtonsProps) {
     }
     const fullText = `${shareText}\n${storyUrl}`;
     window.open(
-      `https://farcaster.com/~/compose?text=${encodeURIComponent(fullText)}`,
+      `https://farcaster.xyz/~/compose?text=${encodeURIComponent(fullText)}`,
       "_blank",
     );
   }, [platform, shareText, storyUrl]);

--- a/src/components/WriterIdentity.tsx
+++ b/src/components/WriterIdentity.tsx
@@ -25,7 +25,7 @@ export async function WriterIdentity({ address }: { address: string }) {
         />
       )}
       <a
-        href={`https://farcaster.com/${profile.username}`}
+        href={`https://farcaster.xyz/${profile.username}`}
         target="_blank"
         rel="noopener noreferrer"
         className="text-foreground hover:text-accent transition-colors"

--- a/src/components/WriterIdentityClient.tsx
+++ b/src/components/WriterIdentityClient.tsx
@@ -44,7 +44,7 @@ export function WriterIdentityClient({ address, linkProfile = true }: { address:
       )}
       {linkProfile ? (
         <a
-          href={`https://farcaster.com/${profile.username}`}
+          href={`https://farcaster.xyz/${profile.username}`}
           target="_blank"
           rel="noopener noreferrer"
           className="text-foreground hover:text-accent transition-colors"


### PR DESCRIPTION
## Summary
- All Farcaster profile/compose links used `farcaster.com` (wrong domain)
- Changed to `farcaster.xyz` across 4 components: WriterIdentity, WriterIdentityClient, FarcasterAvatar, ShareButtons

## Test plan
- [ ] Click author username on story page → opens farcaster.xyz profile
- [ ] Share to Farcaster → opens farcaster.xyz compose

🤖 Generated with [Claude Code](https://claude.com/claude-code)