### PR TITLE
[#501] Profile page — layout, routing, and identity resolution

### DIFF
--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -1,6 +1,11 @@
 "use server";
 
 import { lookupByAddress, type FarcasterProfile } from "./farcaster";
+import {
+  getAgentMetadata as _getAgentMetadata,
+  type AgentMetadata,
+} from "./contracts/erc8004";
+import type { Address } from "viem";
 
 /**
  * Server action that resolves an Ethereum address to a Farcaster profile.
@@ -10,4 +15,13 @@ export async function getFarcasterProfile(
   address: string,
 ): Promise<FarcasterProfile | null> {
   return lookupByAddress(address);
+}
+
+/**
+ * Server action that resolves ERC-8004 agent metadata from a wallet address.
+ */
+export async function fetchAgentMetadata(
+  address: string,
+): Promise<AgentMetadata | null> {
+  return _getAgentMetadata(address as Address);
 }

--- a/lib/contracts/erc8004.ts
+++ b/lib/contracts/erc8004.ts
@@ -123,7 +123,7 @@ export async function getAgentMetadata(
       name: (parsed.name as string) || "Unknown Agent",
       description: (parsed.description as string) || "",
       genre: (parsed.genre as string) || undefined,
-      llmModel: (parsed.llmModel as string) || undefined,
+      llmModel: (parsed.llmModel as string) || (parsed.model as string) || undefined,
       registeredBy: (parsed.registeredBy as string) || undefined,
       registeredAt: (parsed.registeredAt as string) || undefined,
     };

--- a/lib/contracts/erc8004.ts
+++ b/lib/contracts/erc8004.ts
@@ -10,6 +10,15 @@ import { ERC8004_REGISTRY } from "./constants";
  * ERC-8004 Agent Registry ABI — agent registration, wallet binding, and
  * reverse lookup.
  */
+export interface AgentMetadata {
+  name: string;
+  description: string;
+  genre?: string;
+  llmModel?: string;
+  registeredBy?: string;
+  registeredAt?: string;
+}
+
 export const erc8004Abi = [
   // View
   {
@@ -18,6 +27,13 @@ export const erc8004Abi = [
     stateMutability: "view",
     inputs: [{ name: "wallet", type: "address" }],
     outputs: [{ name: "agentId", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "agentURI",
+    stateMutability: "view",
+    inputs: [{ name: "agentId", type: "uint256" }],
+    outputs: [{ name: "", type: "string" }],
   },
   // Write — register a new agent
   {
@@ -75,5 +91,43 @@ export async function detectWriterType(
   } catch {
     // Best-effort: default to human if registry query fails
     return 0;
+  }
+}
+
+/**
+ * Resolve ERC-8004 agent metadata from an Ethereum address.
+ * Returns null if the address is not a registered agent or on any error.
+ */
+export async function getAgentMetadata(
+  walletAddress: Address,
+): Promise<AgentMetadata | null> {
+  try {
+    const agentId = await publicClient.readContract({
+      address: ERC8004_REGISTRY,
+      abi: erc8004Abi,
+      functionName: "agentIdByWallet",
+      args: [walletAddress],
+    });
+    if (agentId <= BigInt(0)) return null;
+
+    const uri = await publicClient.readContract({
+      address: ERC8004_REGISTRY,
+      abi: erc8004Abi,
+      functionName: "agentURI",
+      args: [agentId],
+    });
+    if (!uri) return null;
+
+    const parsed = JSON.parse(uri as string) as Record<string, unknown>;
+    return {
+      name: (parsed.name as string) || "Unknown Agent",
+      description: (parsed.description as string) || "",
+      genre: (parsed.genre as string) || undefined,
+      llmModel: (parsed.llmModel as string) || undefined,
+      registeredBy: (parsed.registeredBy as string) || undefined,
+      registeredAt: (parsed.registeredAt as string) || undefined,
+    };
+  } catch {
+    return null;
   }
 }

--- a/lib/farcaster.ts
+++ b/lib/farcaster.ts
@@ -12,6 +12,7 @@ export interface FarcasterProfile {
   username: string;
   displayName: string;
   pfpUrl: string | null;
+  bio: string | null;
 }
 
 const STEEMHUNT_BASE = "https://fc.hunt.town";
@@ -40,6 +41,7 @@ async function steemhuntLookup(address: string): Promise<LookupResult> {
     username: data.username,
     displayName: data.displayName ?? data.username,
     pfpUrl: data.pfpUrl ?? null,
+    bio: data.bio ?? data.profile?.bio?.text ?? null,
   };
 }
 
@@ -63,6 +65,7 @@ async function neynarLookup(address: string): Promise<LookupResult> {
     username: user.username,
     displayName: user.display_name ?? user.username,
     pfpUrl: user.pfp_url ?? null,
+    bio: user.profile?.bio?.text ?? null,
   };
 }
 

--- a/src/app/dashboard/writer/page.tsx
+++ b/src/app/dashboard/writer/page.tsx
@@ -233,9 +233,12 @@ function WriterDonationHistory({ storylineId }: { storylineId: number }) {
             className="text-muted flex items-center justify-between text-[10px]"
           >
             <div className="flex gap-2">
-              <span className="text-foreground">
+              <a
+                href={`/profile/${d.donor_address}`}
+                className="text-foreground hover:text-accent transition-colors"
+              >
                 {truncateAddress(d.donor_address)}
-              </span>
+              </a>
               {d.block_timestamp && (
                 <time dateTime={d.block_timestamp}>
                   {new Date(d.block_timestamp).toLocaleDateString("en-US", {

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -166,9 +166,9 @@ function ProfileHeader({
             </div>
           )}
 
-          {/* Farcaster bio (only show for humans without agent description) */}
-          {!agentMeta?.description && fcProfile?.displayName && fcProfile.displayName !== fcProfile.username && (
-            <p className="text-muted mt-1 text-xs">{fcProfile.displayName}</p>
+          {/* Farcaster bio (only show when no agent description is present) */}
+          {!agentMeta?.description && fcProfile?.bio && (
+            <p className="text-muted mt-1 text-xs">{fcProfile.bio}</p>
           )}
         </div>
       </div>

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState } from "react";
 import { useParams } from "next/navigation";
-import { useQuery, useInfiniteQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { formatUnits } from "viem";
 import Link from "next/link";
 import { supabase, type Storyline, type Donation, type TradeHistory } from "../../../../lib/supabase";
@@ -32,7 +32,7 @@ export default function ProfilePage() {
     queryFn: () => fetchAgentMetadata(address),
   });
 
-  const isAgent = agentMeta !== null && agentMeta !== undefined;
+  const isAgent = !agentLoading && agentMeta !== null && agentMeta !== undefined;
 
   return (
     <div className="mx-auto max-w-2xl px-6 py-12">
@@ -114,14 +114,16 @@ function ProfileHeader({
                 ? truncateAddress(address)
                 : displayName ?? truncateAddress(address)}
             </h1>
-            {isAgent ? (
-              <span className="border-accent-dim text-accent-dim rounded border px-1.5 py-0.5 text-[10px]">
-                AI Agent
-              </span>
-            ) : (
-              <span className="border-border text-muted rounded border px-1.5 py-0.5 text-[10px]">
-                Human
-              </span>
+            {!agentLoading && (
+              isAgent ? (
+                <span className="border-accent-dim text-accent-dim rounded border px-1.5 py-0.5 text-[10px]">
+                  AI Agent
+                </span>
+              ) : (
+                <span className="border-border text-muted rounded border px-1.5 py-0.5 text-[10px]">
+                  Human
+                </span>
+              )
             )}
           </div>
 

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { useParams } from "next/navigation";
+import { useQuery, useInfiniteQuery } from "@tanstack/react-query";
+import { formatUnits } from "viem";
+import Link from "next/link";
+import { supabase, type Storyline, type Donation, type TradeHistory } from "../../../../lib/supabase";
+import { STORY_FACTORY, RESERVE_LABEL, EXPLORER_URL } from "../../../../lib/contracts/constants";
+import { getFarcasterProfile, fetchAgentMetadata } from "../../../../lib/actions";
+import { truncateAddress } from "../../../../lib/utils";
+import { formatPrice } from "../../../../lib/format";
+import { AgentBadge } from "../../../components/AgentBadge";
+import type { FarcasterProfile } from "../../../../lib/farcaster";
+import type { AgentMetadata } from "../../../../lib/contracts/erc8004";
+
+type Tab = "stories" | "portfolio" | "activity";
+
+export default function ProfilePage() {
+  const params = useParams<{ address: string }>();
+  const address = params.address.toLowerCase();
+
+  const [tab, setTab] = useState<Tab>("stories");
+
+  const { data: fcProfile, isLoading: fcLoading } = useQuery({
+    queryKey: ["fc-profile", address],
+    queryFn: () => getFarcasterProfile(address),
+  });
+
+  const { data: agentMeta, isLoading: agentLoading } = useQuery({
+    queryKey: ["agent-meta", address],
+    queryFn: () => fetchAgentMetadata(address),
+  });
+
+  const isAgent = agentMeta !== null && agentMeta !== undefined;
+
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-12">
+      <ProfileHeader
+        address={address}
+        fcProfile={fcProfile ?? null}
+        fcLoading={fcLoading}
+        agentMeta={agentMeta ?? null}
+        agentLoading={agentLoading}
+        isAgent={isAgent}
+      />
+
+      {/* Tab navigation */}
+      <div className="mt-8 flex gap-2 border-b border-[var(--border)] pb-2">
+        {(["stories", "portfolio", "activity"] as const).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`rounded-t px-3 py-1.5 text-xs font-medium capitalize transition-colors ${
+              tab === t
+                ? "bg-accent/15 text-accent"
+                : "text-muted hover:text-foreground"
+            }`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {tab === "stories" && <StoriesTab address={address} />}
+      {tab === "portfolio" && <PortfolioTab address={address} />}
+      {tab === "activity" && <ActivityTab address={address} />}
+    </div>
+  );
+}
+
+function ProfileHeader({
+  address,
+  fcProfile,
+  fcLoading,
+  agentMeta,
+  agentLoading,
+  isAgent,
+}: {
+  address: string;
+  fcProfile: FarcasterProfile | null;
+  fcLoading: boolean;
+  agentMeta: AgentMetadata | null;
+  agentLoading: boolean;
+  isAgent: boolean;
+}) {
+  const displayName = agentMeta?.name ?? fcProfile?.displayName ?? null;
+
+  return (
+    <header className="border-border border-b pb-6">
+      <div className="flex items-start gap-4">
+        {/* Avatar */}
+        {fcProfile?.pfpUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={fcProfile.pfpUrl}
+            alt=""
+            width={56}
+            height={56}
+            className="rounded-full"
+          />
+        ) : (
+          <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-[var(--border)] text-lg font-bold text-[var(--text-muted)]">
+            {address.slice(2, 4).toUpperCase()}
+          </div>
+        )}
+
+        <div className="min-w-0 flex-1">
+          {/* Name + badge */}
+          <div className="flex items-center gap-2">
+            <h1 className="font-body text-2xl font-bold tracking-tight text-accent truncate">
+              {fcLoading && agentLoading
+                ? truncateAddress(address)
+                : displayName ?? truncateAddress(address)}
+            </h1>
+            {isAgent ? (
+              <span className="border-accent-dim text-accent-dim rounded border px-1.5 py-0.5 text-[10px]">
+                AI Agent
+              </span>
+            ) : (
+              <span className="border-border text-muted rounded border px-1.5 py-0.5 text-[10px]">
+                Human
+              </span>
+            )}
+          </div>
+
+          {/* Secondary identity line */}
+          <div className="text-muted mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+            {fcProfile && (
+              <a
+                href={`https://farcaster.xyz/${fcProfile.username}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-foreground hover:text-accent transition-colors"
+              >
+                @{fcProfile.username}
+              </a>
+            )}
+            <a
+              href={`${EXPLORER_URL}/address/${address}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono text-[11px] hover:text-accent transition-colors"
+            >
+              {truncateAddress(address)}
+            </a>
+          </div>
+
+          {/* Agent metadata */}
+          {agentMeta && (
+            <div className="text-muted mt-2 space-y-0.5 text-xs">
+              {agentMeta.description && (
+                <p>{agentMeta.description}</p>
+              )}
+              <div className="flex flex-wrap gap-x-3 gap-y-0.5">
+                {agentMeta.llmModel && (
+                  <span>Model: <span className="text-foreground">{agentMeta.llmModel}</span></span>
+                )}
+                {agentMeta.genre && (
+                  <span>Genre: <span className="text-foreground">{agentMeta.genre}</span></span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Farcaster bio (only show for humans without agent description) */}
+          {!agentMeta?.description && fcProfile?.displayName && fcProfile.displayName !== fcProfile.username && (
+            <p className="text-muted mt-1 text-xs">{fcProfile.displayName}</p>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stories Tab
+// ---------------------------------------------------------------------------
+
+function StoriesTab({ address }: { address: string }) {
+  const { data: storylines = [], isLoading, error } = useQuery({
+    queryKey: ["profile-storylines", address],
+    queryFn: async () => {
+      if (!supabase) return [];
+      const { data, error } = await supabase
+        .from("storylines")
+        .select("*")
+        .eq("writer_address", address)
+        .eq("hidden", false)
+        .eq("contract_address", STORY_FACTORY.toLowerCase())
+        .order("block_timestamp", { ascending: false })
+        .returns<Storyline[]>();
+      if (error) throw error;
+      return data ?? [];
+    },
+  });
+
+  if (isLoading) return <p className="text-muted mt-8 text-sm">Loading...</p>;
+  if (error) return <p className="mt-8 text-sm text-error">Failed to load storylines.</p>;
+  if (storylines.length === 0) {
+    return <p className="text-muted py-8 text-center text-sm">No storylines yet.</p>;
+  }
+
+  return (
+    <div className="mt-6 space-y-3">
+      {storylines.map((s) => (
+        <div key={s.id} className="border-border rounded border px-4 py-3">
+          <div className="flex items-start justify-between gap-3">
+            <Link
+              href={`/story/${s.storyline_id}`}
+              className="text-foreground hover:text-accent text-sm font-medium transition-colors"
+            >
+              {s.title}
+            </Link>
+            <div className="flex shrink-0 items-center gap-1.5">
+              {s.genre && (
+                <span className="border-border rounded border px-1.5 py-0.5 text-[10px] text-muted">
+                  {s.genre}
+                </span>
+              )}
+              {s.sunset && (
+                <span className="border-border bg-surface rounded border px-1.5 py-0.5 text-[10px] text-muted">
+                  complete
+                </span>
+              )}
+            </div>
+          </div>
+          <div className="text-muted mt-2 flex gap-4 text-xs">
+            <span>
+              {s.plot_count} {s.plot_count === 1 ? "plot" : "plots"}
+            </span>
+            <span>{formatViewCount(s.view_count)} views</span>
+            {s.block_timestamp && (
+              <span>
+                {new Date(s.block_timestamp).toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                })}
+              </span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Portfolio Tab
+// ---------------------------------------------------------------------------
+
+function PortfolioTab({ address }: { address: string }) {
+  const { data: trades = [], isLoading, error } = useQuery({
+    queryKey: ["profile-portfolio", address],
+    queryFn: async () => {
+      if (!supabase) return [];
+      const { data, error } = await supabase
+        .from("trade_history")
+        .select("*")
+        .eq("user_address", address)
+        .eq("contract_address", STORY_FACTORY.toLowerCase())
+        .order("block_timestamp", { ascending: false })
+        .limit(50)
+        .returns<TradeHistory[]>();
+      if (error) throw error;
+      return data ?? [];
+    },
+  });
+
+  if (isLoading) return <p className="text-muted mt-8 text-sm">Loading...</p>;
+  if (error) return <p className="mt-8 text-sm text-error">Failed to load portfolio.</p>;
+  if (trades.length === 0) {
+    return <p className="text-muted py-8 text-center text-sm">No trading activity yet.</p>;
+  }
+
+  // Group trades by storyline to show net position
+  const positions = new Map<number, { storylineId: number; mints: number; burns: number; lastTrade: string }>();
+  for (const t of trades) {
+    const pos = positions.get(t.storyline_id) ?? { storylineId: t.storyline_id, mints: 0, burns: 0, lastTrade: t.block_timestamp };
+    if (t.event_type === "mint") pos.mints++;
+    else if (t.event_type === "burn") pos.burns++;
+    positions.set(t.storyline_id, pos);
+  }
+
+  return (
+    <div className="mt-6 space-y-3">
+      <p className="text-muted text-xs uppercase tracking-wider">Trading Activity</p>
+      {Array.from(positions.values()).map((pos) => (
+        <div key={pos.storylineId} className="border-border rounded border px-4 py-3">
+          <div className="flex items-center justify-between">
+            <Link
+              href={`/story/${pos.storylineId}`}
+              className="text-foreground hover:text-accent text-sm font-medium transition-colors"
+            >
+              Story #{pos.storylineId}
+            </Link>
+            <span className="text-muted text-xs">
+              {new Date(pos.lastTrade).toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+              })}
+            </span>
+          </div>
+          <div className="text-muted mt-1 flex gap-4 text-xs">
+            <span className="text-green-700">{pos.mints} mint{pos.mints !== 1 ? "s" : ""}</span>
+            <span className="text-red-700">{pos.burns} burn{pos.burns !== 1 ? "s" : ""}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Activity Tab
+// ---------------------------------------------------------------------------
+
+const ACTIVITY_PAGE_SIZE = 20;
+
+function ActivityTab({ address }: { address: string }) {
+  const { data: donations = [], isLoading: donLoading } = useQuery({
+    queryKey: ["profile-donations", address],
+    queryFn: async () => {
+      if (!supabase) return [];
+      const { data } = await supabase
+        .from("donations")
+        .select("*")
+        .eq("donor_address", address)
+        .eq("contract_address", STORY_FACTORY.toLowerCase())
+        .order("block_timestamp", { ascending: false })
+        .limit(ACTIVITY_PAGE_SIZE)
+        .returns<Donation[]>();
+      return data ?? [];
+    },
+  });
+
+  const { data: ratings = [], isLoading: ratLoading } = useQuery({
+    queryKey: ["profile-ratings", address],
+    queryFn: async () => {
+      if (!supabase) return [];
+      const { data } = await supabase
+        .from("ratings")
+        .select("*")
+        .eq("rater_address", address)
+        .eq("contract_address", STORY_FACTORY.toLowerCase())
+        .order("created_at", { ascending: false })
+        .limit(ACTIVITY_PAGE_SIZE);
+      return data ?? [];
+    },
+  });
+
+  const isLoading = donLoading || ratLoading;
+  const hasActivity = donations.length > 0 || ratings.length > 0;
+
+  if (isLoading) return <p className="text-muted mt-8 text-sm">Loading...</p>;
+  if (!hasActivity) {
+    return <p className="text-muted py-8 text-center text-sm">No activity yet.</p>;
+  }
+
+  return (
+    <div className="mt-6 space-y-6">
+      {donations.length > 0 && (
+        <div>
+          <p className="text-muted text-xs uppercase tracking-wider">Donations</p>
+          <div className="mt-2 space-y-1">
+            {donations.map((d) => (
+              <div key={d.id} className="text-muted flex items-center justify-between text-xs">
+                <div className="flex items-center gap-2">
+                  <Link
+                    href={`/story/${d.storyline_id}`}
+                    className="text-foreground hover:text-accent transition-colors"
+                  >
+                    Story #{d.storyline_id}
+                  </Link>
+                  {d.block_timestamp && (
+                    <time dateTime={d.block_timestamp} className="text-[10px]">
+                      {new Date(d.block_timestamp).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                      })}
+                    </time>
+                  )}
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <span className="text-accent font-medium">
+                    {formatPrice(formatUnits(BigInt(d.amount), 18))} {RESERVE_LABEL}
+                  </span>
+                  {d.tx_hash && (
+                    <a
+                      href={`${EXPLORER_URL}/tx/${d.tx_hash}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-muted hover:text-accent transition-colors"
+                      title="View on Basescan"
+                    >
+                      &#x2197;
+                    </a>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {ratings.length > 0 && (
+        <div>
+          <p className="text-muted text-xs uppercase tracking-wider">Ratings</p>
+          <div className="mt-2 space-y-1">
+            {ratings.map((r: { id: number; storyline_id: number; rating: number; comment: string | null; created_at: string }) => (
+              <div key={r.id} className="text-muted flex items-center justify-between text-xs">
+                <div className="flex items-center gap-2">
+                  <Link
+                    href={`/story/${r.storyline_id}`}
+                    className="text-foreground hover:text-accent transition-colors"
+                  >
+                    Story #{r.storyline_id}
+                  </Link>
+                  <span className="text-accent">{"★".repeat(r.rating)}{"☆".repeat(5 - r.rating)}</span>
+                </div>
+                <time dateTime={r.created_at} className="text-[10px]">
+                  {new Date(r.created_at).toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </time>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatViewCount(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 10000) return `${(n / 1000).toFixed(1)}k`;
+  if (n < 1000000) return `${Math.round(n / 1000)}k`;
+  return `${(n / 1000000).toFixed(1)}M`;
+}

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -162,6 +162,15 @@ function ProfileHeader({
                 {agentMeta.genre && (
                   <span>Genre: <span className="text-foreground">{agentMeta.genre}</span></span>
                 )}
+                {agentMeta.registeredAt && (
+                  <span>Registered: <span className="text-foreground">
+                    {new Date(agentMeta.registeredAt).toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    })}
+                  </span></span>
+                )}
               </div>
             </div>
           )}

--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useAccount, useConnect, useDisconnect } from "wagmi";
+import Link from "next/link";
 import { isFarcasterMiniApp } from "../../lib/farcaster-detect";
 import { truncateAddress } from "../../lib/utils";
 import { useConnectedIdentity } from "../hooks/useConnectedIdentity";
@@ -38,7 +39,10 @@ export function ConnectWallet() {
   if (isConnected && address) {
     return (
       <div className="border-border flex items-center gap-3 rounded border px-3 py-2 text-sm">
-        <span className="text-accent inline-flex items-center gap-1.5 font-medium">
+        <Link
+          href={`/profile/${address}`}
+          className="text-accent inline-flex items-center gap-1.5 font-medium hover:opacity-80 transition-opacity"
+        >
           {profile?.pfpUrl && (
             // eslint-disable-next-line @next/next/no-img-element
             <img
@@ -50,7 +54,7 @@ export function ConnectWallet() {
             />
           )}
           {profile ? `@${profile.username}` : truncateAddress(address)}
-        </span>
+        </Link>
         <button
           onClick={() => disconnect()}
           className="text-muted hover:text-error transition-colors"

--- a/src/components/DonateWidget.tsx
+++ b/src/components/DonateWidget.tsx
@@ -168,7 +168,7 @@ export function DonateWidget({ storylineId, writerAddress }: DonateWidgetProps) 
           <span className="font-semibold text-accent">
             {formatUnits(parsedAmount, 18)} {RESERVE_LABEL}
           </span>{" "}
-          to {writerAddress ? <FarcasterAvatar address={writerAddress} size={12} linkProfile={false} /> : `story #${storylineId}`}
+          to {writerAddress ? <FarcasterAvatar address={writerAddress} size={12} /> : `story #${storylineId}`}
         </p>
       )}
 

--- a/src/components/FarcasterAvatar.tsx
+++ b/src/components/FarcasterAvatar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { getFarcasterProfile } from "../../lib/actions";
 import { truncateAddress } from "../../lib/utils";
 import type { FarcasterProfile } from "../../lib/farcaster";
@@ -8,6 +9,7 @@ import type { FarcasterProfile } from "../../lib/farcaster";
 /**
  * Resolves an Ethereum address to a Farcaster identity via server action.
  * Shows avatar + @username with link, or falls back to truncated address.
+ * Links to the internal profile page at /profile/[address].
  */
 export function FarcasterAvatar({
   address,
@@ -37,11 +39,19 @@ export function FarcasterAvatar({
   }, [address]);
 
   if (!loaded || !profile) {
-    return <span className={className}>{truncateAddress(address)}</span>;
+    if (!linkProfile) return <span className={className}>{truncateAddress(address)}</span>;
+    return (
+      <Link
+        href={`/profile/${address}`}
+        className={`hover:text-accent transition-colors ${className ?? ""}`}
+      >
+        {truncateAddress(address)}
+      </Link>
+    );
   }
 
-  return (
-    <span className={`inline-flex items-center gap-1 ${className ?? ""}`}>
+  const inner = (
+    <>
       {profile.pfpUrl && (
         // eslint-disable-next-line @next/next/no-img-element
         <img
@@ -52,18 +62,24 @@ export function FarcasterAvatar({
           className="rounded-full"
         />
       )}
-      {linkProfile ? (
-        <a
-          href={`https://farcaster.xyz/${profile.username}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-foreground hover:text-accent transition-colors"
-        >
-          @{profile.username}
-        </a>
-      ) : (
-        <span>@{profile.username}</span>
-      )}
-    </span>
+      <span>@{profile.username}</span>
+    </>
+  );
+
+  if (!linkProfile) {
+    return (
+      <span className={`inline-flex items-center gap-1 ${className ?? ""}`}>
+        {inner}
+      </span>
+    );
+  }
+
+  return (
+    <Link
+      href={`/profile/${address}`}
+      className={`inline-flex items-center gap-1 text-foreground hover:text-accent transition-colors ${className ?? ""}`}
+    >
+      {inner}
+    </Link>
   );
 }

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -107,6 +107,10 @@ export function StoryCard({
 
       {/* Metadata below notebook */}
       <div className="mt-2.5 flex flex-col gap-0.5 pl-1 pr-1 text-[10px] text-[var(--text-muted)]">
+        <span className="inline-flex items-center gap-1">
+          <WriterIdentityClient address={storyline.writer_address} />
+          {storyline.writer_type === 1 && <AgentBadge />}
+        </span>
         {storyline.token_address && (
           <span className="whitespace-nowrap">
             <StoryCardTVL tokenAddress={storyline.token_address} />

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -97,11 +97,8 @@ export function StoryCard({
             )}
           </div>
 
-          {/* Bottom: author */}
-          <div className="relative z-10 flex items-center justify-center gap-1 px-4 py-3 text-xs text-[var(--text-muted)]">
-            <WriterIdentityClient address={storyline.writer_address} linkProfile={false} />
-            {storyline.writer_type === 1 && <AgentBadge />}
-          </div>
+          {/* Bottom spacer (author shown below card with profile link) */}
+          <div className="relative z-10 px-4 py-3" />
         </div>
       </Link>
 

--- a/src/components/WriterIdentity.tsx
+++ b/src/components/WriterIdentity.tsx
@@ -1,19 +1,31 @@
+import Link from "next/link";
 import { lookupByAddress } from "../../lib/farcaster";
 import { truncateAddress } from "../../lib/utils";
 
 /**
  * Server component that displays a Farcaster identity (avatar + username)
  * when available, falling back to a truncated Ethereum address.
+ * Links to the internal profile page at /profile/[address].
  */
 export async function WriterIdentity({ address }: { address: string }) {
   const profile = await lookupByAddress(address);
 
   if (!profile) {
-    return <span>{truncateAddress(address)}</span>;
+    return (
+      <Link
+        href={`/profile/${address}`}
+        className="text-foreground hover:text-accent transition-colors"
+      >
+        {truncateAddress(address)}
+      </Link>
+    );
   }
 
   return (
-    <span className="inline-flex items-center gap-1">
+    <Link
+      href={`/profile/${address}`}
+      className="inline-flex items-center gap-1 text-foreground hover:text-accent transition-colors"
+    >
       {profile.pfpUrl && (
         // eslint-disable-next-line @next/next/no-img-element
         <img
@@ -24,14 +36,7 @@ export async function WriterIdentity({ address }: { address: string }) {
           className="rounded-full"
         />
       )}
-      <a
-        href={`https://farcaster.xyz/${profile.username}`}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-foreground hover:text-accent transition-colors"
-      >
-        @{profile.username}
-      </a>
-    </span>
+      @{profile.username}
+    </Link>
   );
 }

--- a/src/components/WriterIdentityClient.tsx
+++ b/src/components/WriterIdentityClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { getFarcasterProfile } from "../../lib/actions";
 import { truncateAddress } from "../../lib/utils";
 import type { FarcasterProfile } from "../../lib/farcaster";
@@ -8,6 +9,7 @@ import type { FarcasterProfile } from "../../lib/farcaster";
 /**
  * Client component that resolves a Farcaster identity via server action.
  * Shows a truncated address while loading, then replaces with avatar + username.
+ * Links to the internal profile page at /profile/[address].
  */
 export function WriterIdentityClient({ address, linkProfile = true }: { address: string; linkProfile?: boolean }) {
   const [profile, setProfile] = useState<FarcasterProfile | null>(null);
@@ -26,11 +28,23 @@ export function WriterIdentityClient({ address, linkProfile = true }: { address:
     };
   }, [address]);
 
+  const label = !loaded || !profile
+    ? truncateAddress(address)
+    : null;
+
   if (!loaded || !profile) {
-    return <span>{truncateAddress(address)}</span>;
+    if (!linkProfile) return <span>{label}</span>;
+    return (
+      <Link
+        href={`/profile/${address}`}
+        className="text-foreground hover:text-accent transition-colors"
+      >
+        {label}
+      </Link>
+    );
   }
 
-  return (
+  const inner = (
     <span className="inline-flex items-center gap-1">
       {profile.pfpUrl && (
         // eslint-disable-next-line @next/next/no-img-element
@@ -42,18 +56,18 @@ export function WriterIdentityClient({ address, linkProfile = true }: { address:
           className="rounded-full"
         />
       )}
-      {linkProfile ? (
-        <a
-          href={`https://farcaster.xyz/${profile.username}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-foreground hover:text-accent transition-colors"
-        >
-          @{profile.username}
-        </a>
-      ) : (
-        <span>@{profile.username}</span>
-      )}
+      <span>@{profile.username}</span>
     </span>
+  );
+
+  if (!linkProfile) return inner;
+
+  return (
+    <Link
+      href={`/profile/${address}`}
+      className="text-foreground hover:text-accent transition-colors"
+    >
+      {inner}
+    </Link>
   );
 }


### PR DESCRIPTION
## Summary
- New `/profile/[address]` route with identity header resolving both Farcaster (avatar, @username) and ERC-8004 agent metadata (name, description, model, genre)
- Header shows Human/AI Agent badge distinction, Farcaster profile link, and Basescan address link
- Three navigation tabs: Stories (writer's storylines), Portfolio (trading activity), Activity (donations + ratings)
- Added `getAgentMetadata()` to `lib/contracts/erc8004.ts` — reads `agentIdByWallet` → `agentURI` and parses the JSON metadata
- Updated `WriterIdentity`, `WriterIdentityClient`, and `FarcasterAvatar` components to link every displayed wallet name/username to `/profile/[address]`
- Donor addresses in writer dashboard now link to profile pages

## Test plan
- [ ] Navigate to `/profile/<known-address>` — verify identity header renders with Farcaster avatar/username
- [ ] Navigate to `/profile/<agent-address>` — verify AI Agent badge and agent metadata (model, genre) display
- [ ] Verify Stories tab loads writer's storylines
- [ ] Verify Portfolio tab shows trading activity
- [ ] Verify Activity tab shows donations and ratings
- [ ] Click author name on story card → redirects to `/profile/[address]`
- [ ] Click author name on story detail page → redirects to `/profile/[address]`
- [ ] Click donor address in writer dashboard → redirects to `/profile/[address]`

Fixes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)