### PR TITLE
[#502] Profile page — writer stats and story portfolio

### DIFF
--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -2,15 +2,17 @@
 
 import { useState } from "react";
 import { useParams } from "next/navigation";
+import { useAccount } from "wagmi";
 import { useQuery } from "@tanstack/react-query";
-import { formatUnits } from "viem";
+import { formatUnits, type Address } from "viem";
 import Link from "next/link";
 import { supabase, type Storyline, type Donation, type TradeHistory } from "../../../../lib/supabase";
-import { STORY_FACTORY, RESERVE_LABEL, EXPLORER_URL } from "../../../../lib/contracts/constants";
+import { STORY_FACTORY, RESERVE_LABEL, EXPLORER_URL, MCV2_BOND, PLOT_TOKEN } from "../../../../lib/contracts/constants";
 import { getFarcasterProfile, fetchAgentMetadata } from "../../../../lib/actions";
 import { truncateAddress } from "../../../../lib/utils";
-import { formatPrice } from "../../../../lib/format";
-import { AgentBadge } from "../../../components/AgentBadge";
+import { formatPrice, formatSupply } from "../../../../lib/format";
+import { getTokenPrice, mcv2BondAbi, type TokenPriceInfo } from "../../../../lib/price";
+import { browserClient } from "../../../../lib/rpc";
 import type { FarcasterProfile } from "../../../../lib/farcaster";
 import type { AgentMetadata } from "../../../../lib/contracts/erc8004";
 
@@ -19,6 +21,8 @@ type Tab = "stories" | "portfolio" | "activity";
 export default function ProfilePage() {
   const params = useParams<{ address: string }>();
   const address = params.address.toLowerCase();
+  const { address: connectedAddress } = useAccount();
+  const isOwnProfile = connectedAddress?.toLowerCase() === address;
 
   const [tab, setTab] = useState<Tab>("stories");
 
@@ -63,12 +67,23 @@ export default function ProfilePage() {
       </div>
 
       {/* Tab content */}
-      {tab === "stories" && <StoriesTab address={address} />}
+      {tab === "stories" && (
+        <StoriesTab
+          address={address}
+          isAgent={isAgent}
+          agentMeta={agentMeta ?? null}
+          isOwnProfile={isOwnProfile}
+        />
+      )}
       {tab === "portfolio" && <PortfolioTab address={address} />}
       {tab === "activity" && <ActivityTab address={address} />}
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Profile Header (unchanged from #501)
+// ---------------------------------------------------------------------------
 
 function ProfileHeader({
   address,
@@ -186,10 +201,20 @@ function ProfileHeader({
 }
 
 // ---------------------------------------------------------------------------
-// Stories Tab
+// Stories Tab — writer stats + story portfolio
 // ---------------------------------------------------------------------------
 
-function StoriesTab({ address }: { address: string }) {
+function StoriesTab({
+  address,
+  isAgent,
+  agentMeta,
+  isOwnProfile,
+}: {
+  address: string;
+  isAgent: boolean;
+  agentMeta: AgentMetadata | null;
+  isOwnProfile: boolean;
+}) {
   const { data: storylines = [], isLoading, error } = useQuery({
     queryKey: ["profile-storylines", address],
     queryFn: async () => {
@@ -207,53 +232,229 @@ function StoriesTab({ address }: { address: string }) {
     },
   });
 
+  // Fetch donations received as writer (across all storylines)
+  const storylineIds = storylines.map((s) => s.storyline_id);
+  const { data: donationsReceived = [] } = useQuery({
+    queryKey: ["profile-donations-received", address, storylineIds],
+    queryFn: async () => {
+      if (!supabase || storylineIds.length === 0) return [];
+      const { data } = await supabase
+        .from("donations")
+        .select("amount")
+        .in("storyline_id", storylineIds)
+        .eq("contract_address", STORY_FACTORY.toLowerCase());
+      return (data ?? []) as { amount: string }[];
+    },
+    enabled: storylineIds.length > 0,
+  });
+
+  // Claimable royalties (own profile only)
+  const { data: royaltyInfo } = useQuery({
+    queryKey: ["profile-royalties", address],
+    queryFn: async () => {
+      const [balance, claimed] = await browserClient.readContract({
+        address: MCV2_BOND,
+        abi: mcv2BondAbi,
+        functionName: "getRoyaltyInfo",
+        args: [address as Address, PLOT_TOKEN],
+      });
+      return { unclaimed: balance, claimed };
+    },
+    enabled: isOwnProfile,
+  });
+
   if (isLoading) return <p className="text-muted mt-8 text-sm">Loading...</p>;
   if (error) return <p className="mt-8 text-sm text-error">Failed to load storylines.</p>;
   if (storylines.length === 0) {
-    return <p className="text-muted py-8 text-center text-sm">No storylines yet.</p>;
+    return (
+      <div className="py-12 text-center">
+        <p className="text-muted text-sm">No storylines yet.</p>
+        <p className="text-muted mt-1 text-xs">
+          This address hasn&apos;t created any stories on PlotLink.
+        </p>
+      </div>
+    );
   }
 
+  // Compute writer stats
+  const totalPlots = storylines.reduce((sum, s) => sum + s.plot_count, 0);
+  const totalDonations = donationsReceived.reduce(
+    (sum, d) => sum + BigInt(d.amount),
+    BigInt(0),
+  );
+
+  // Agent extras
+  const avgPlotsPerStory = storylines.length > 0
+    ? (totalPlots / storylines.length).toFixed(1)
+    : "0";
+  const genreCounts = new Map<string, number>();
+  for (const s of storylines) {
+    if (s.genre) genreCounts.set(s.genre, (genreCounts.get(s.genre) ?? 0) + 1);
+  }
+  const sortedGenres = Array.from(genreCounts.entries()).sort((a, b) => b[1] - a[1]);
+
   return (
-    <div className="mt-6 space-y-3">
-      {storylines.map((s) => (
-        <div key={s.id} className="border-border rounded border px-4 py-3">
-          <div className="flex items-start justify-between gap-3">
-            <Link
-              href={`/story/${s.storyline_id}`}
-              className="text-foreground hover:text-accent text-sm font-medium transition-colors"
-            >
-              {s.title}
-            </Link>
-            <div className="flex shrink-0 items-center gap-1.5">
-              {s.genre && (
-                <span className="border-border rounded border px-1.5 py-0.5 text-[10px] text-muted">
-                  {s.genre}
-                </span>
-              )}
-              {s.sunset && (
-                <span className="border-border bg-surface rounded border px-1.5 py-0.5 text-[10px] text-muted">
-                  complete
-                </span>
-              )}
-            </div>
-          </div>
-          <div className="text-muted mt-2 flex gap-4 text-xs">
-            <span>
-              {s.plot_count} {s.plot_count === 1 ? "plot" : "plots"}
+    <div className="mt-6 space-y-6">
+      {/* Writer Stats */}
+      <div className="border-border bg-surface rounded border px-4 py-3">
+        <p className="text-muted mb-2 text-[10px] uppercase tracking-wider">Writer Stats</p>
+        <div className="grid grid-cols-2 gap-3 text-xs sm:grid-cols-4">
+          <StatCell label="Storylines" value={String(storylines.length)} />
+          <StatCell label="Total Plots" value={String(totalPlots)} />
+          <StatCell
+            label="Donations"
+            value={totalDonations > BigInt(0)
+              ? `${formatPrice(formatUnits(totalDonations, 18))} ${RESERVE_LABEL}`
+              : "—"}
+          />
+          {isOwnProfile && royaltyInfo ? (
+            <StatCell
+              label="Claimable"
+              value={royaltyInfo.unclaimed > BigInt(0)
+                ? `${formatPrice(formatUnits(royaltyInfo.unclaimed, 18))} ${RESERVE_LABEL}`
+                : "—"}
+            />
+          ) : (
+            <StatCell label="Holders" value="—" />
+          )}
+        </div>
+      </div>
+
+      {/* Agent extras */}
+      {isAgent && (
+        <div className="border-border bg-surface rounded border px-4 py-3">
+          <p className="text-muted mb-2 text-[10px] uppercase tracking-wider">Agent Insights</p>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+            <span className="text-muted">
+              Avg plots/story: <span className="text-foreground font-medium">{avgPlotsPerStory}</span>
             </span>
-            <span>{formatViewCount(s.view_count)} views</span>
-            {s.block_timestamp && (
-              <span>
-                {new Date(s.block_timestamp).toLocaleDateString("en-US", {
-                  month: "short",
-                  day: "numeric",
-                  year: "numeric",
-                })}
+            {agentMeta?.llmModel && (
+              <span className="text-muted">
+                Model: <span className="text-foreground font-medium">{agentMeta.llmModel}</span>
               </span>
             )}
           </div>
+          {sortedGenres.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {sortedGenres.map(([genre, count]) => (
+                <span
+                  key={genre}
+                  className="rounded-sm bg-[var(--accent)]/10 px-2 py-0.5 text-[10px] text-[var(--accent)]"
+                >
+                  {genre} ({count})
+                </span>
+              ))}
+            </div>
+          )}
         </div>
-      ))}
+      )}
+
+      {/* Story portfolio */}
+      <div className="space-y-3">
+        {storylines.map((s) => (
+          <StoryRow key={s.id} storyline={s} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StatCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <span className="text-muted block text-[10px] uppercase tracking-wider">{label}</span>
+      <span className="text-foreground font-medium">{value}</span>
+    </div>
+  );
+}
+
+function StoryRow({ storyline }: { storyline: Storyline }) {
+  const tokenAddr = storyline.token_address as Address;
+
+  const { data: priceInfo } = useQuery({
+    queryKey: ["profile-story-price", storyline.token_address],
+    queryFn: () => getTokenPrice(tokenAddr, browserClient),
+    enabled: !!storyline.token_address,
+    staleTime: 60000,
+  });
+
+  // Count unique holders from trade_history
+  const { data: holderCount } = useQuery({
+    queryKey: ["profile-story-holders", storyline.storyline_id],
+    queryFn: async () => {
+      if (!supabase) return 0;
+      const { data } = await supabase
+        .from("trade_history")
+        .select("user_address, event_type")
+        .eq("storyline_id", storyline.storyline_id)
+        .eq("contract_address", STORY_FACTORY.toLowerCase());
+      if (!data) return 0;
+      // Count net positive holders
+      const balances = new Map<string, number>();
+      for (const t of data) {
+        if (!t.user_address) continue;
+        const cur = balances.get(t.user_address) ?? 0;
+        balances.set(t.user_address, t.event_type === "mint" ? cur + 1 : cur - 1);
+      }
+      return Array.from(balances.values()).filter((b) => b > 0).length;
+    },
+    staleTime: 60000,
+  });
+
+  return (
+    <div className="border-border rounded border px-4 py-3">
+      <div className="flex items-start justify-between gap-3">
+        <Link
+          href={`/story/${storyline.storyline_id}`}
+          className="text-foreground hover:text-accent text-sm font-medium transition-colors"
+        >
+          {storyline.title}
+        </Link>
+        <div className="flex shrink-0 items-center gap-1.5">
+          {storyline.genre && (
+            <span className="border-border rounded border px-1.5 py-0.5 text-[10px] text-muted">
+              {storyline.genre}
+            </span>
+          )}
+          {storyline.sunset ? (
+            <span className="border-border bg-surface rounded border px-1.5 py-0.5 text-[10px] text-muted">
+              complete
+            </span>
+          ) : (
+            <span className="rounded border border-green-700/30 px-1.5 py-0.5 text-[10px] text-green-700">
+              active
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="text-muted mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs sm:grid-cols-4">
+        <span>
+          {storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"}
+        </span>
+        <span>
+          {priceInfo
+            ? `${formatPrice(priceInfo.pricePerToken)} ${RESERVE_LABEL}`
+            : "—"}
+        </span>
+        <span>
+          {holderCount !== undefined ? `${holderCount} holder${holderCount !== 1 ? "s" : ""}` : "—"}
+        </span>
+        <span>
+          {formatViewCount(storyline.view_count)} views
+        </span>
+      </div>
+
+      {storyline.block_timestamp && (
+        <div className="text-muted mt-1 text-[10px]">
+          Created{" "}
+          {new Date(storyline.block_timestamp).toLocaleDateString("en-US", {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -10,7 +10,7 @@ import { supabase, type Storyline, type Donation, type TradeHistory } from "../.
 import { STORY_FACTORY, RESERVE_LABEL, EXPLORER_URL, MCV2_BOND, PLOT_TOKEN } from "../../../../lib/contracts/constants";
 import { getFarcasterProfile, fetchAgentMetadata } from "../../../../lib/actions";
 import { truncateAddress } from "../../../../lib/utils";
-import { formatPrice, formatSupply } from "../../../../lib/format";
+import { formatPrice } from "../../../../lib/format";
 import { getTokenPrice, mcv2BondAbi, type TokenPriceInfo } from "../../../../lib/price";
 import { browserClient } from "../../../../lib/rpc";
 import type { FarcasterProfile } from "../../../../lib/farcaster";
@@ -248,6 +248,28 @@ function StoriesTab({
     enabled: storylineIds.length > 0,
   });
 
+  // Total token holders across all writer's storylines
+  const { data: totalHolders } = useQuery({
+    queryKey: ["profile-total-holders", address, storylineIds],
+    queryFn: async () => {
+      if (!supabase || storylineIds.length === 0) return 0;
+      const { data } = await supabase
+        .from("trade_history")
+        .select("user_address, event_type")
+        .in("storyline_id", storylineIds)
+        .eq("contract_address", STORY_FACTORY.toLowerCase());
+      if (!data) return 0;
+      const balances = new Map<string, number>();
+      for (const t of data as { user_address: string | null; event_type: string }[]) {
+        if (!t.user_address) continue;
+        const cur = balances.get(t.user_address) ?? 0;
+        balances.set(t.user_address, t.event_type === "mint" ? cur + 1 : cur - 1);
+      }
+      return Array.from(balances.values()).filter((b) => b > 0).length;
+    },
+    enabled: storylineIds.length > 0,
+  });
+
   // Claimable royalties (own profile only)
   const { data: royaltyInfo } = useQuery({
     queryKey: ["profile-royalties", address],
@@ -298,24 +320,26 @@ function StoriesTab({
       {/* Writer Stats */}
       <div className="border-border bg-surface rounded border px-4 py-3">
         <p className="text-muted mb-2 text-[10px] uppercase tracking-wider">Writer Stats</p>
-        <div className="grid grid-cols-2 gap-3 text-xs sm:grid-cols-4">
+        <div className={`grid grid-cols-2 gap-3 text-xs ${isOwnProfile && royaltyInfo ? "sm:grid-cols-5" : "sm:grid-cols-4"}`}>
           <StatCell label="Storylines" value={String(storylines.length)} />
           <StatCell label="Total Plots" value={String(totalPlots)} />
+          <StatCell
+            label="Holders"
+            value={totalHolders !== undefined ? String(totalHolders) : "—"}
+          />
           <StatCell
             label="Donations"
             value={totalDonations > BigInt(0)
               ? `${formatPrice(formatUnits(totalDonations, 18))} ${RESERVE_LABEL}`
               : "—"}
           />
-          {isOwnProfile && royaltyInfo ? (
+          {isOwnProfile && royaltyInfo && (
             <StatCell
               label="Claimable"
               value={royaltyInfo.unclaimed > BigInt(0)
                 ? `${formatPrice(formatUnits(royaltyInfo.unclaimed, 18))} ${RESERVE_LABEL}`
                 : "—"}
             />
-          ) : (
-            <StatCell label="Holders" value="—" />
           )}
         </div>
       </div>

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -11,7 +11,7 @@ import { STORY_FACTORY, RESERVE_LABEL, EXPLORER_URL, MCV2_BOND, PLOT_TOKEN } fro
 import { getFarcasterProfile, fetchAgentMetadata } from "../../../../lib/actions";
 import { truncateAddress } from "../../../../lib/utils";
 import { formatPrice } from "../../../../lib/format";
-import { getTokenPrice, mcv2BondAbi, type TokenPriceInfo } from "../../../../lib/price";
+import { getTokenPrice, mcv2BondAbi, erc20Abi, type TokenPriceInfo } from "../../../../lib/price";
 import { browserClient } from "../../../../lib/rpc";
 import type { FarcasterProfile } from "../../../../lib/farcaster";
 import type { AgentMetadata } from "../../../../lib/contracts/erc8004";
@@ -248,26 +248,67 @@ function StoriesTab({
     enabled: storylineIds.length > 0,
   });
 
-  // Total token supply across all writer's storylines (from latest trade per storyline)
-  const { data: totalSupplyAcross } = useQuery({
-    queryKey: ["profile-total-supply", address, storylineIds],
+  // Total token holders across all writer's storylines (on-chain balanceOf)
+  const { data: totalHolders } = useQuery({
+    queryKey: ["profile-total-holders", address, storylineIds],
     queryFn: async () => {
       if (!supabase || storylineIds.length === 0) return 0;
-      // Get the latest trade per storyline to read current total_supply
-      let total = 0;
-      for (const sid of storylineIds) {
-        const { data } = await supabase
-          .from("trade_history")
-          .select("total_supply")
-          .eq("storyline_id", sid)
-          .eq("contract_address", STORY_FACTORY.toLowerCase())
-          .order("block_number", { ascending: false })
-          .limit(1);
-        if (data && data.length > 0) total += data[0].total_supply;
+      // Get unique trader addresses across all storylines
+      const { data: trades } = await supabase
+        .from("trade_history")
+        .select("user_address, storyline_id")
+        .in("storyline_id", storylineIds)
+        .eq("contract_address", STORY_FACTORY.toLowerCase());
+      if (!trades || trades.length === 0) return 0;
+
+      // Build map: token_address -> unique user addresses
+      const tokenByStoryline = new Map<number, string>();
+      for (const s of storylines) {
+        if (s.token_address) tokenByStoryline.set(s.storyline_id, s.token_address);
       }
-      return total;
+
+      // Deduplicate: (user, token) pairs
+      const pairs = new Set<string>();
+      const pairList: { user: string; token: string }[] = [];
+      for (const t of trades as { user_address: string | null; storyline_id: number }[]) {
+        if (!t.user_address) continue;
+        const token = tokenByStoryline.get(t.storyline_id);
+        if (!token) continue;
+        const key = `${t.user_address}:${token}`;
+        if (!pairs.has(key)) {
+          pairs.add(key);
+          pairList.push({ user: t.user_address, token });
+        }
+      }
+      if (pairList.length === 0) return 0;
+
+      // Multicall balanceOf for each (user, token) pair
+      const results = await browserClient.multicall({
+        contracts: pairList.map((p) => ({
+          address: p.token as Address,
+          abi: erc20Abi,
+          functionName: "balanceOf" as const,
+          args: [p.user as Address],
+        })),
+        allowFailure: true,
+      });
+
+      let holders = 0;
+      const counted = new Set<string>();
+      for (let i = 0; i < results.length; i++) {
+        const r = results[i];
+        if (r.status === "success" && (r.result as bigint) > BigInt(0)) {
+          const userKey = pairList[i].user.toLowerCase();
+          if (!counted.has(userKey)) {
+            counted.add(userKey);
+            holders++;
+          }
+        }
+      }
+      return holders;
     },
     enabled: storylineIds.length > 0,
+    staleTime: 60000,
   });
 
   // Claimable royalties (own profile only)
@@ -324,10 +365,8 @@ function StoriesTab({
           <StatCell label="Storylines" value={String(storylines.length)} />
           <StatCell label="Total Plots" value={String(totalPlots)} />
           <StatCell
-            label="Token Supply"
-            value={totalSupplyAcross !== undefined && totalSupplyAcross > 0
-              ? formatSupplyCompact(totalSupplyAcross)
-              : "—"}
+            label="Holders"
+            value={totalHolders !== undefined ? String(totalHolders) : "—"}
           />
           <StatCell
             label="Donations"
@@ -404,21 +443,41 @@ function StoryRow({ storyline }: { storyline: Storyline }) {
     staleTime: 60000,
   });
 
-  // Token supply from latest trade entry
-  const { data: storySupply } = useQuery({
-    queryKey: ["profile-story-supply", storyline.storyline_id],
+  // On-chain holder count via balanceOf multicall
+  const { data: holderCount } = useQuery({
+    queryKey: ["profile-story-holders", storyline.storyline_id, storyline.token_address],
     queryFn: async () => {
-      if (!supabase) return 0;
-      const { data } = await supabase
+      if (!supabase || !storyline.token_address) return 0;
+      const { data: trades } = await supabase
         .from("trade_history")
-        .select("total_supply")
+        .select("user_address")
         .eq("storyline_id", storyline.storyline_id)
-        .eq("contract_address", STORY_FACTORY.toLowerCase())
-        .order("block_number", { ascending: false })
-        .limit(1);
-      return data && data.length > 0 ? data[0].total_supply : 0;
+        .eq("contract_address", STORY_FACTORY.toLowerCase());
+      if (!trades || trades.length === 0) return 0;
+
+      const uniqueUsers = [...new Set(
+        (trades as { user_address: string | null }[])
+          .map((t) => t.user_address)
+          .filter(Boolean) as string[]
+      )];
+      if (uniqueUsers.length === 0) return 0;
+
+      const results = await browserClient.multicall({
+        contracts: uniqueUsers.map((u) => ({
+          address: tokenAddr,
+          abi: erc20Abi,
+          functionName: "balanceOf" as const,
+          args: [u as Address],
+        })),
+        allowFailure: true,
+      });
+
+      return results.filter(
+        (r) => r.status === "success" && (r.result as bigint) > BigInt(0),
+      ).length;
     },
     staleTime: 60000,
+    enabled: !!storyline.token_address,
   });
 
   return (
@@ -458,9 +517,7 @@ function StoryRow({ storyline }: { storyline: Storyline }) {
             : "—"}
         </span>
         <span>
-          {storySupply !== undefined && storySupply > 0
-            ? `${formatSupplyCompact(storySupply)} supply`
-            : "—"}
+          {holderCount !== undefined ? `${holderCount} holder${holderCount !== 1 ? "s" : ""}` : "—"}
         </span>
         <span>
           {formatViewCount(storyline.view_count)} views
@@ -672,14 +729,6 @@ function ActivityTab({ address }: { address: string }) {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatSupplyCompact(n: number): string {
-  if (n === 0) return "0";
-  if (n < 1) return n.toFixed(4);
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return n.toFixed(0);
-}
 
 function formatViewCount(n: number): string {
   if (n < 1000) return String(n);

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -248,24 +248,24 @@ function StoriesTab({
     enabled: storylineIds.length > 0,
   });
 
-  // Total token holders across all writer's storylines
-  const { data: totalHolders } = useQuery({
-    queryKey: ["profile-total-holders", address, storylineIds],
+  // Total token supply across all writer's storylines (from latest trade per storyline)
+  const { data: totalSupplyAcross } = useQuery({
+    queryKey: ["profile-total-supply", address, storylineIds],
     queryFn: async () => {
       if (!supabase || storylineIds.length === 0) return 0;
-      const { data } = await supabase
-        .from("trade_history")
-        .select("user_address, event_type")
-        .in("storyline_id", storylineIds)
-        .eq("contract_address", STORY_FACTORY.toLowerCase());
-      if (!data) return 0;
-      const balances = new Map<string, number>();
-      for (const t of data as { user_address: string | null; event_type: string }[]) {
-        if (!t.user_address) continue;
-        const cur = balances.get(t.user_address) ?? 0;
-        balances.set(t.user_address, t.event_type === "mint" ? cur + 1 : cur - 1);
+      // Get the latest trade per storyline to read current total_supply
+      let total = 0;
+      for (const sid of storylineIds) {
+        const { data } = await supabase
+          .from("trade_history")
+          .select("total_supply")
+          .eq("storyline_id", sid)
+          .eq("contract_address", STORY_FACTORY.toLowerCase())
+          .order("block_number", { ascending: false })
+          .limit(1);
+        if (data && data.length > 0) total += data[0].total_supply;
       }
-      return Array.from(balances.values()).filter((b) => b > 0).length;
+      return total;
     },
     enabled: storylineIds.length > 0,
   });
@@ -324,8 +324,10 @@ function StoriesTab({
           <StatCell label="Storylines" value={String(storylines.length)} />
           <StatCell label="Total Plots" value={String(totalPlots)} />
           <StatCell
-            label="Holders"
-            value={totalHolders !== undefined ? String(totalHolders) : "—"}
+            label="Token Supply"
+            value={totalSupplyAcross !== undefined && totalSupplyAcross > 0
+              ? formatSupplyCompact(totalSupplyAcross)
+              : "—"}
           />
           <StatCell
             label="Donations"
@@ -402,25 +404,19 @@ function StoryRow({ storyline }: { storyline: Storyline }) {
     staleTime: 60000,
   });
 
-  // Count unique holders from trade_history
-  const { data: holderCount } = useQuery({
-    queryKey: ["profile-story-holders", storyline.storyline_id],
+  // Token supply from latest trade entry
+  const { data: storySupply } = useQuery({
+    queryKey: ["profile-story-supply", storyline.storyline_id],
     queryFn: async () => {
       if (!supabase) return 0;
       const { data } = await supabase
         .from("trade_history")
-        .select("user_address, event_type")
+        .select("total_supply")
         .eq("storyline_id", storyline.storyline_id)
-        .eq("contract_address", STORY_FACTORY.toLowerCase());
-      if (!data) return 0;
-      // Count net positive holders
-      const balances = new Map<string, number>();
-      for (const t of data) {
-        if (!t.user_address) continue;
-        const cur = balances.get(t.user_address) ?? 0;
-        balances.set(t.user_address, t.event_type === "mint" ? cur + 1 : cur - 1);
-      }
-      return Array.from(balances.values()).filter((b) => b > 0).length;
+        .eq("contract_address", STORY_FACTORY.toLowerCase())
+        .order("block_number", { ascending: false })
+        .limit(1);
+      return data && data.length > 0 ? data[0].total_supply : 0;
     },
     staleTime: 60000,
   });
@@ -462,7 +458,9 @@ function StoryRow({ storyline }: { storyline: Storyline }) {
             : "—"}
         </span>
         <span>
-          {holderCount !== undefined ? `${holderCount} holder${holderCount !== 1 ? "s" : ""}` : "—"}
+          {storySupply !== undefined && storySupply > 0
+            ? `${formatSupplyCompact(storySupply)} supply`
+            : "—"}
         </span>
         <span>
           {formatViewCount(storyline.view_count)} views
@@ -674,6 +672,14 @@ function ActivityTab({ address }: { address: string }) {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function formatSupplyCompact(n: number): string {
+  if (n === 0) return "0";
+  if (n < 1) return n.toFixed(4);
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return n.toFixed(0);
+}
 
 function formatViewCount(n: number): string {
   if (n < 1000) return String(n);


### PR DESCRIPTION
## Summary
- Added **writer stats section**: total storylines, total plots, total donations received, claimable royalties (own profile only via connected wallet)
- Enhanced **per-story metrics**: title, plot count, token price, holder count (from trade_history), view count, genre, active/complete status, creation date
- **AI agent extras**: average plots per story, genre distribution tags, model info from ERC-8004 agentURI
- Improved **empty state** for addresses with no stories
- Holder count derived from trade_history net position (mints - burns > 0)

## Test plan
- [ ] Visit a writer profile — verify stats section shows storyline count, total plots, donations
- [ ] Visit own profile (connected wallet) — verify claimable royalties appear
- [ ] Visit another writer's profile — verify claimable royalties field not shown
- [ ] Verify per-story rows show token price, holder count, genre, status
- [ ] Visit an AI agent profile — verify Agent Insights section with avg plots/story, genre tags, model
- [ ] Visit an address with no stories — verify empty state message

Fixes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)