### PR TITLE
[#504] Profile page — activity feed and on-chain history

### DIFF
--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -1010,7 +1010,15 @@ function ActivityTab({ address }: { address: string }) {
           toBlock: "latest",
         });
 
+        // Exclude Transfer events that are sell refunds (same tx as a trade)
+        const tradeTxHashes = new Set(
+          (tradesRes.data ?? []).map((t: { tx_hash: string }) => t.tx_hash.toLowerCase()),
+        );
+
         for (const log of claimLogs) {
+          const txHash = log.transactionHash?.toLowerCase();
+          if (txHash && tradeTxHashes.has(txHash)) continue; // sell refund, not a claim
+
           const blockTimestamp = await browserClient.getBlock({ blockNumber: log.blockNumber! });
           const ts = new Date(Number(blockTimestamp.timestamp) * 1000).toISOString();
           entries.push({

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -989,28 +989,50 @@ function ActivityTab({ address }: { address: string }) {
         });
       }
 
+      // Claimed royalties — derive from ERC-20 Transfer events on PLOT_TOKEN
+      // where from=MCV2_BOND and to=address (royalty payouts)
+      try {
+        const transferEventAbi = [{
+          type: "event",
+          name: "Transfer",
+          inputs: [
+            { name: "from", type: "address", indexed: true },
+            { name: "to", type: "address", indexed: true },
+            { name: "value", type: "uint256", indexed: false },
+          ],
+        }] as const;
+
+        const claimLogs = await browserClient.getLogs({
+          address: PLOT_TOKEN,
+          event: transferEventAbi[0],
+          args: { from: MCV2_BOND, to: address as Address },
+          fromBlock: BigInt(0),
+          toBlock: "latest",
+        });
+
+        for (const log of claimLogs) {
+          const blockTimestamp = await browserClient.getBlock({ blockNumber: log.blockNumber! });
+          const ts = new Date(Number(blockTimestamp.timestamp) * 1000).toISOString();
+          entries.push({
+            type: "claimed_royalties",
+            timestamp: ts,
+            storylineId: 0,
+            detail: `${formatPrice(formatUnits(log.args.value ?? BigInt(0), 18))} ${RESERVE_LABEL}`,
+            txHash: log.transactionHash ?? undefined,
+          });
+        }
+      } catch {
+        // Claim log query unavailable — skip
+      }
+
       // Sort reverse-chronological
       entries.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
       return entries;
     },
   });
 
-  // Claimed royalties (on-chain cumulative — shown as summary, not feed entry)
-  const { data: claimedRoyalties } = useQuery({
-    queryKey: ["profile-claimed-royalties", address],
-    queryFn: async () => {
-      const [, claimed] = await browserClient.readContract({
-        address: MCV2_BOND,
-        abi: mcv2BondAbi,
-        functionName: "getRoyaltyInfo",
-        args: [address as Address, PLOT_TOKEN],
-      });
-      return claimed;
-    },
-  });
-
   if (isLoading) return <p className="text-muted mt-8 text-sm">Loading...</p>;
-  if (feed.length === 0 && (!claimedRoyalties || claimedRoyalties === BigInt(0))) {
+  if (feed.length === 0) {
     return (
       <div className="py-12 text-center">
         <p className="text-muted text-sm">No activity yet.</p>
@@ -1026,17 +1048,6 @@ function ActivityTab({ address }: { address: string }) {
 
   return (
     <div className="mt-6">
-      {/* Claimed royalties summary (on-chain, no per-event history available) */}
-      {claimedRoyalties && claimedRoyalties > BigInt(0) && (
-        <div className="border-border bg-surface mb-4 rounded border px-4 py-3">
-          <p className="text-muted text-[10px] uppercase tracking-wider">Claimed Royalties</p>
-          <span className="text-green-700 text-sm font-medium">
-            {formatPrice(formatUnits(claimedRoyalties, 18))} {RESERVE_LABEL}
-          </span>
-          <span className="text-muted ml-2 text-xs">total claimed to date</span>
-        </div>
-      )}
-
       <div className="space-y-1.5">
         {visible.map((entry, i) => (
           <FeedRow key={`${entry.type}-${entry.timestamp}-${i}`} entry={entry} />

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -859,7 +859,7 @@ function PortfolioTab({ address }: { address: string }) {
 // ---------------------------------------------------------------------------
 
 interface FeedEntry {
-  type: "created_storyline" | "published_plot" | "bought" | "sold" | "donated" | "rated";
+  type: "created_storyline" | "published_plot" | "bought" | "sold" | "donated" | "rated" | "claimed_royalties";
   timestamp: string;
   storylineId: number;
   storyTitle?: string;
@@ -877,7 +877,9 @@ function ActivityTab({ address }: { address: string }) {
     queryFn: async (): Promise<FeedEntry[]> => {
       if (!supabase) return [];
 
-      // Fetch all event sources in parallel
+      const PER_SOURCE_LIMIT = 200;
+
+      // Fetch all event sources in parallel (bounded per source)
       const [storylinesRes, plotsRes, tradesRes, donationsRes, ratingsRes] = await Promise.all([
         // Storylines created by this address
         supabase
@@ -886,7 +888,8 @@ function ActivityTab({ address }: { address: string }) {
           .eq("writer_address", address)
           .eq("hidden", false)
           .eq("contract_address", STORY_FACTORY.toLowerCase())
-          .order("block_timestamp", { ascending: false }),
+          .order("block_timestamp", { ascending: false })
+          .limit(PER_SOURCE_LIMIT),
         // Plots published by this address
         supabase
           .from("plots")
@@ -894,28 +897,32 @@ function ActivityTab({ address }: { address: string }) {
           .eq("writer_address", address)
           .eq("hidden", false)
           .eq("contract_address", STORY_FACTORY.toLowerCase())
-          .order("block_timestamp", { ascending: false }),
+          .order("block_timestamp", { ascending: false })
+          .limit(PER_SOURCE_LIMIT),
         // Trades by this address
         supabase
           .from("trade_history")
           .select("storyline_id, event_type, reserve_amount, price_per_token, block_timestamp, tx_hash")
           .eq("user_address", address)
           .eq("contract_address", STORY_FACTORY.toLowerCase())
-          .order("block_timestamp", { ascending: false }),
+          .order("block_timestamp", { ascending: false })
+          .limit(PER_SOURCE_LIMIT),
         // Donations by this address
         supabase
           .from("donations")
           .select("storyline_id, amount, block_timestamp, tx_hash")
           .eq("donor_address", address)
           .eq("contract_address", STORY_FACTORY.toLowerCase())
-          .order("block_timestamp", { ascending: false }),
+          .order("block_timestamp", { ascending: false })
+          .limit(PER_SOURCE_LIMIT),
         // Ratings by this address
         supabase
           .from("ratings")
           .select("storyline_id, rating, created_at")
           .eq("rater_address", address)
           .eq("contract_address", STORY_FACTORY.toLowerCase())
-          .order("created_at", { ascending: false }),
+          .order("created_at", { ascending: false })
+          .limit(PER_SOURCE_LIMIT),
       ]);
 
       const entries: FeedEntry[] = [];
@@ -982,6 +989,26 @@ function ActivityTab({ address }: { address: string }) {
         });
       }
 
+      // Claimed royalties (on-chain — summary entry if claimed > 0)
+      try {
+        const [, claimed] = await browserClient.readContract({
+          address: MCV2_BOND,
+          abi: mcv2BondAbi,
+          functionName: "getRoyaltyInfo",
+          args: [address as Address, PLOT_TOKEN],
+        });
+        if (claimed > BigInt(0)) {
+          entries.push({
+            type: "claimed_royalties",
+            timestamp: new Date().toISOString(),
+            storylineId: 0,
+            detail: `${formatPrice(formatUnits(claimed, 18))} ${RESERVE_LABEL} total claimed`,
+          });
+        }
+      } catch {
+        // Royalty info unavailable — skip
+      }
+
       // Sort reverse-chronological
       entries.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
       return entries;
@@ -1029,6 +1056,7 @@ const EVENT_LABELS: Record<FeedEntry["type"], string> = {
   sold: "Sold",
   donated: "Donated",
   rated: "Rated",
+  claimed_royalties: "Claimed",
 };
 
 const EVENT_COLORS: Record<FeedEntry["type"], string> = {
@@ -1038,6 +1066,7 @@ const EVENT_COLORS: Record<FeedEntry["type"], string> = {
   sold: "text-red-700",
   donated: "text-accent",
   rated: "text-muted",
+  claimed_royalties: "text-green-700",
 };
 
 function FeedRow({ entry }: { entry: FeedEntry }) {
@@ -1047,12 +1076,16 @@ function FeedRow({ entry }: { entry: FeedEntry }) {
         <span className={`font-medium shrink-0 w-16 ${EVENT_COLORS[entry.type]}`}>
           {EVENT_LABELS[entry.type]}
         </span>
-        <Link
-          href={`/story/${entry.storylineId}`}
-          className="text-foreground hover:text-accent truncate transition-colors"
-        >
-          {entry.storyTitle ?? `Story #${entry.storylineId}`}
-        </Link>
+        {entry.storylineId > 0 ? (
+          <Link
+            href={`/story/${entry.storylineId}`}
+            className="text-foreground hover:text-accent truncate transition-colors"
+          >
+            {entry.storyTitle ?? `Story #${entry.storylineId}`}
+          </Link>
+        ) : (
+          <span className="text-foreground truncate">Royalties</span>
+        )}
         {entry.detail && (
           <span className="text-muted shrink-0">{entry.detail}</span>
         )}

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -989,34 +989,28 @@ function ActivityTab({ address }: { address: string }) {
         });
       }
 
-      // Claimed royalties (on-chain — summary entry if claimed > 0)
-      try {
-        const [, claimed] = await browserClient.readContract({
-          address: MCV2_BOND,
-          abi: mcv2BondAbi,
-          functionName: "getRoyaltyInfo",
-          args: [address as Address, PLOT_TOKEN],
-        });
-        if (claimed > BigInt(0)) {
-          entries.push({
-            type: "claimed_royalties",
-            timestamp: new Date().toISOString(),
-            storylineId: 0,
-            detail: `${formatPrice(formatUnits(claimed, 18))} ${RESERVE_LABEL} total claimed`,
-          });
-        }
-      } catch {
-        // Royalty info unavailable — skip
-      }
-
       // Sort reverse-chronological
       entries.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
       return entries;
     },
   });
 
+  // Claimed royalties (on-chain cumulative — shown as summary, not feed entry)
+  const { data: claimedRoyalties } = useQuery({
+    queryKey: ["profile-claimed-royalties", address],
+    queryFn: async () => {
+      const [, claimed] = await browserClient.readContract({
+        address: MCV2_BOND,
+        abi: mcv2BondAbi,
+        functionName: "getRoyaltyInfo",
+        args: [address as Address, PLOT_TOKEN],
+      });
+      return claimed;
+    },
+  });
+
   if (isLoading) return <p className="text-muted mt-8 text-sm">Loading...</p>;
-  if (feed.length === 0) {
+  if (feed.length === 0 && (!claimedRoyalties || claimedRoyalties === BigInt(0))) {
     return (
       <div className="py-12 text-center">
         <p className="text-muted text-sm">No activity yet.</p>
@@ -1032,6 +1026,17 @@ function ActivityTab({ address }: { address: string }) {
 
   return (
     <div className="mt-6">
+      {/* Claimed royalties summary (on-chain, no per-event history available) */}
+      {claimedRoyalties && claimedRoyalties > BigInt(0) && (
+        <div className="border-border bg-surface mb-4 rounded border px-4 py-3">
+          <p className="text-muted text-[10px] uppercase tracking-wider">Claimed Royalties</p>
+          <span className="text-green-700 text-sm font-medium">
+            {formatPrice(formatUnits(claimedRoyalties, 18))} {RESERVE_LABEL}
+          </span>
+          <span className="text-muted ml-2 text-xs">total claimed to date</span>
+        </div>
+      )}
+
       <div className="space-y-1.5">
         {visible.map((entry, i) => (
           <FeedRow key={`${entry.type}-${entry.timestamp}-${i}`} entry={entry} />

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -1010,9 +1010,14 @@ function ActivityTab({ address }: { address: string }) {
           toBlock: "latest",
         });
 
-        // Exclude Transfer events that are sell refunds (same tx as a trade)
+        // Fetch ALL trade tx hashes (unbounded) to filter sell refunds accurately
+        const { data: allTradeTxRows } = await supabase
+          .from("trade_history")
+          .select("tx_hash")
+          .eq("user_address", address)
+          .eq("contract_address", STORY_FACTORY.toLowerCase());
         const tradeTxHashes = new Set(
-          (tradesRes.data ?? []).map((t: { tx_hash: string }) => t.tx_hash.toLowerCase()),
+          (allTradeTxRows ?? []).map((t: { tx_hash: string }) => t.tx_hash.toLowerCase()),
         );
 
         for (const log of claimLogs) {

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -258,7 +258,7 @@ function StoriesTab({
         .from("trade_history")
         .select("user_address, storyline_id")
         .in("storyline_id", storylineIds)
-        .eq("contract_address", STORY_FACTORY.toLowerCase());
+        .eq("contract_address", MCV2_BOND.toLowerCase());
       if (!trades || trades.length === 0) return 0;
 
       // Build map: token_address -> unique user addresses
@@ -452,7 +452,7 @@ function StoryRow({ storyline }: { storyline: Storyline }) {
         .from("trade_history")
         .select("user_address")
         .eq("storyline_id", storyline.storyline_id)
-        .eq("contract_address", STORY_FACTORY.toLowerCase());
+        .eq("contract_address", MCV2_BOND.toLowerCase());
       if (!trades || trades.length === 0) return 0;
 
       const uniqueUsers = [...new Set(
@@ -609,7 +609,7 @@ function PortfolioTab({ address }: { address: string }) {
                 .eq("user_address", address)
                 .eq("storyline_id", sl.storyline_id)
                 .eq("event_type", "mint")
-                .eq("contract_address", STORY_FACTORY.toLowerCase())
+                .eq("contract_address", MCV2_BOND.toLowerCase())
                 .order("block_timestamp", { ascending: true })
                 .limit(1);
               if (firstMint && firstMint.length > 0) {
@@ -620,7 +620,7 @@ function PortfolioTab({ address }: { address: string }) {
                 .select("block_timestamp")
                 .eq("user_address", address)
                 .eq("storyline_id", sl.storyline_id)
-                .eq("contract_address", STORY_FACTORY.toLowerCase())
+                .eq("contract_address", MCV2_BOND.toLowerCase())
                 .order("block_timestamp", { ascending: false })
                 .limit(1);
               if (lastTrade && lastTrade.length > 0) {
@@ -899,12 +899,12 @@ function ActivityTab({ address }: { address: string }) {
           .eq("contract_address", STORY_FACTORY.toLowerCase())
           .order("block_timestamp", { ascending: false })
           .limit(PER_SOURCE_LIMIT),
-        // Trades by this address
+        // Trades by this address (trade_history uses MCV2_BOND as contract_address)
         supabase
           .from("trade_history")
           .select("storyline_id, event_type, reserve_amount, price_per_token, block_timestamp, tx_hash")
           .eq("user_address", address)
-          .eq("contract_address", STORY_FACTORY.toLowerCase())
+          .eq("contract_address", MCV2_BOND.toLowerCase())
           .order("block_timestamp", { ascending: false })
           .limit(PER_SOURCE_LIMIT),
         // Donations by this address
@@ -1015,7 +1015,7 @@ function ActivityTab({ address }: { address: string }) {
           .from("trade_history")
           .select("tx_hash")
           .eq("user_address", address)
-          .eq("contract_address", STORY_FACTORY.toLowerCase());
+          .eq("contract_address", MCV2_BOND.toLowerCase());
         const tradeTxHashes = new Set(
           (allTradeTxRows ?? []).map((t: { tx_hash: string }) => t.tx_hash.toLowerCase()),
         );

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -855,123 +855,227 @@ function PortfolioTab({ address }: { address: string }) {
 }
 
 // ---------------------------------------------------------------------------
-// Activity Tab
+// Activity Tab — unified reverse-chronological feed
 // ---------------------------------------------------------------------------
 
-const ACTIVITY_PAGE_SIZE = 20;
+interface FeedEntry {
+  type: "created_storyline" | "published_plot" | "bought" | "sold" | "donated" | "rated";
+  timestamp: string;
+  storylineId: number;
+  storyTitle?: string;
+  txHash?: string;
+  detail?: string;
+}
+
+const FEED_PAGE_SIZE = 30;
 
 function ActivityTab({ address }: { address: string }) {
-  const { data: donations = [], isLoading: donLoading } = useQuery({
-    queryKey: ["profile-donations", address],
-    queryFn: async () => {
+  const [visibleCount, setVisibleCount] = useState(FEED_PAGE_SIZE);
+
+  const { data: feed = [], isLoading } = useQuery({
+    queryKey: ["profile-activity-feed", address],
+    queryFn: async (): Promise<FeedEntry[]> => {
       if (!supabase) return [];
-      const { data } = await supabase
-        .from("donations")
-        .select("*")
-        .eq("donor_address", address)
-        .eq("contract_address", STORY_FACTORY.toLowerCase())
-        .order("block_timestamp", { ascending: false })
-        .limit(ACTIVITY_PAGE_SIZE)
-        .returns<Donation[]>();
-      return data ?? [];
+
+      // Fetch all event sources in parallel
+      const [storylinesRes, plotsRes, tradesRes, donationsRes, ratingsRes] = await Promise.all([
+        // Storylines created by this address
+        supabase
+          .from("storylines")
+          .select("storyline_id, title, block_timestamp, tx_hash")
+          .eq("writer_address", address)
+          .eq("hidden", false)
+          .eq("contract_address", STORY_FACTORY.toLowerCase())
+          .order("block_timestamp", { ascending: false }),
+        // Plots published by this address
+        supabase
+          .from("plots")
+          .select("storyline_id, plot_index, title, block_timestamp, tx_hash")
+          .eq("writer_address", address)
+          .eq("hidden", false)
+          .eq("contract_address", STORY_FACTORY.toLowerCase())
+          .order("block_timestamp", { ascending: false }),
+        // Trades by this address
+        supabase
+          .from("trade_history")
+          .select("storyline_id, event_type, reserve_amount, price_per_token, block_timestamp, tx_hash")
+          .eq("user_address", address)
+          .eq("contract_address", STORY_FACTORY.toLowerCase())
+          .order("block_timestamp", { ascending: false }),
+        // Donations by this address
+        supabase
+          .from("donations")
+          .select("storyline_id, amount, block_timestamp, tx_hash")
+          .eq("donor_address", address)
+          .eq("contract_address", STORY_FACTORY.toLowerCase())
+          .order("block_timestamp", { ascending: false }),
+        // Ratings by this address
+        supabase
+          .from("ratings")
+          .select("storyline_id, rating, created_at")
+          .eq("rater_address", address)
+          .eq("contract_address", STORY_FACTORY.toLowerCase())
+          .order("created_at", { ascending: false }),
+      ]);
+
+      const entries: FeedEntry[] = [];
+
+      // Created storylines
+      for (const s of (storylinesRes.data ?? []) as { storyline_id: number; title: string; block_timestamp: string | null; tx_hash: string }[]) {
+        if (!s.block_timestamp) continue;
+        entries.push({
+          type: "created_storyline",
+          timestamp: s.block_timestamp,
+          storylineId: s.storyline_id,
+          storyTitle: s.title,
+          txHash: s.tx_hash,
+        });
+      }
+
+      // Published plots (skip genesis plot_index=0, already covered by created_storyline)
+      for (const p of (plotsRes.data ?? []) as { storyline_id: number; plot_index: number; title: string; block_timestamp: string | null; tx_hash: string }[]) {
+        if (!p.block_timestamp || p.plot_index === 0) continue;
+        entries.push({
+          type: "published_plot",
+          timestamp: p.block_timestamp,
+          storylineId: p.storyline_id,
+          detail: p.title || `Chapter ${p.plot_index}`,
+          txHash: p.tx_hash,
+        });
+      }
+
+      // Trades
+      for (const t of (tradesRes.data ?? []) as { storyline_id: number; event_type: string; reserve_amount: number; price_per_token: number; block_timestamp: string; tx_hash: string }[]) {
+        const tokenAmount = t.price_per_token > 0
+          ? formatPrice(t.reserve_amount / t.price_per_token)
+          : null;
+        entries.push({
+          type: t.event_type === "mint" ? "bought" : "sold",
+          timestamp: t.block_timestamp,
+          storylineId: t.storyline_id,
+          detail: tokenAmount
+            ? `${tokenAmount} tokens for ${formatPrice(t.reserve_amount)} ${RESERVE_LABEL}`
+            : `${formatPrice(t.reserve_amount)} ${RESERVE_LABEL}`,
+          txHash: t.tx_hash,
+        });
+      }
+
+      // Donations
+      for (const d of (donationsRes.data ?? []) as { storyline_id: number; amount: string; block_timestamp: string | null; tx_hash: string }[]) {
+        if (!d.block_timestamp) continue;
+        entries.push({
+          type: "donated",
+          timestamp: d.block_timestamp,
+          storylineId: d.storyline_id,
+          detail: `${formatPrice(formatUnits(BigInt(d.amount), 18))} ${RESERVE_LABEL}`,
+          txHash: d.tx_hash,
+        });
+      }
+
+      // Ratings
+      for (const r of (ratingsRes.data ?? []) as { storyline_id: number; rating: number; created_at: string }[]) {
+        entries.push({
+          type: "rated",
+          timestamp: r.created_at,
+          storylineId: r.storyline_id,
+          detail: `${"★".repeat(r.rating)}${"☆".repeat(5 - r.rating)}`,
+        });
+      }
+
+      // Sort reverse-chronological
+      entries.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+      return entries;
     },
   });
-
-  const { data: ratings = [], isLoading: ratLoading } = useQuery({
-    queryKey: ["profile-ratings", address],
-    queryFn: async () => {
-      if (!supabase) return [];
-      const { data } = await supabase
-        .from("ratings")
-        .select("*")
-        .eq("rater_address", address)
-        .eq("contract_address", STORY_FACTORY.toLowerCase())
-        .order("created_at", { ascending: false })
-        .limit(ACTIVITY_PAGE_SIZE);
-      return data ?? [];
-    },
-  });
-
-  const isLoading = donLoading || ratLoading;
-  const hasActivity = donations.length > 0 || ratings.length > 0;
 
   if (isLoading) return <p className="text-muted mt-8 text-sm">Loading...</p>;
-  if (!hasActivity) {
-    return <p className="text-muted py-8 text-center text-sm">No activity yet.</p>;
+  if (feed.length === 0) {
+    return (
+      <div className="py-12 text-center">
+        <p className="text-muted text-sm">No activity yet.</p>
+        <p className="text-muted mt-1 text-xs">
+          This address has no on-chain activity on PlotLink.
+        </p>
+      </div>
+    );
   }
 
-  return (
-    <div className="mt-6 space-y-6">
-      {donations.length > 0 && (
-        <div>
-          <p className="text-muted text-xs uppercase tracking-wider">Donations</p>
-          <div className="mt-2 space-y-1">
-            {donations.map((d) => (
-              <div key={d.id} className="text-muted flex items-center justify-between text-xs">
-                <div className="flex items-center gap-2">
-                  <Link
-                    href={`/story/${d.storyline_id}`}
-                    className="text-foreground hover:text-accent transition-colors"
-                  >
-                    Story #{d.storyline_id}
-                  </Link>
-                  {d.block_timestamp && (
-                    <time dateTime={d.block_timestamp} className="text-[10px]">
-                      {new Date(d.block_timestamp).toLocaleDateString("en-US", {
-                        month: "short",
-                        day: "numeric",
-                      })}
-                    </time>
-                  )}
-                </div>
-                <div className="flex items-center gap-1.5">
-                  <span className="text-accent font-medium">
-                    {formatPrice(formatUnits(BigInt(d.amount), 18))} {RESERVE_LABEL}
-                  </span>
-                  {d.tx_hash && (
-                    <a
-                      href={`${EXPLORER_URL}/tx/${d.tx_hash}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-muted hover:text-accent transition-colors"
-                      title="View on Basescan"
-                    >
-                      &#x2197;
-                    </a>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
+  const visible = feed.slice(0, visibleCount);
+  const hasMore = visibleCount < feed.length;
 
-      {ratings.length > 0 && (
-        <div>
-          <p className="text-muted text-xs uppercase tracking-wider">Ratings</p>
-          <div className="mt-2 space-y-1">
-            {ratings.map((r: { id: number; storyline_id: number; rating: number; comment: string | null; created_at: string }) => (
-              <div key={r.id} className="text-muted flex items-center justify-between text-xs">
-                <div className="flex items-center gap-2">
-                  <Link
-                    href={`/story/${r.storyline_id}`}
-                    className="text-foreground hover:text-accent transition-colors"
-                  >
-                    Story #{r.storyline_id}
-                  </Link>
-                  <span className="text-accent">{"★".repeat(r.rating)}{"☆".repeat(5 - r.rating)}</span>
-                </div>
-                <time dateTime={r.created_at} className="text-[10px]">
-                  {new Date(r.created_at).toLocaleDateString("en-US", {
-                    month: "short",
-                    day: "numeric",
-                  })}
-                </time>
-              </div>
-            ))}
-          </div>
-        </div>
+  return (
+    <div className="mt-6">
+      <div className="space-y-1.5">
+        {visible.map((entry, i) => (
+          <FeedRow key={`${entry.type}-${entry.timestamp}-${i}`} entry={entry} />
+        ))}
+      </div>
+      {hasMore && (
+        <button
+          onClick={() => setVisibleCount((c) => c + FEED_PAGE_SIZE)}
+          className="text-accent hover:text-foreground mt-4 w-full text-center text-xs transition-colors"
+        >
+          Load more ({feed.length - visibleCount} remaining)
+        </button>
       )}
+    </div>
+  );
+}
+
+const EVENT_LABELS: Record<FeedEntry["type"], string> = {
+  created_storyline: "Created",
+  published_plot: "Published",
+  bought: "Bought",
+  sold: "Sold",
+  donated: "Donated",
+  rated: "Rated",
+};
+
+const EVENT_COLORS: Record<FeedEntry["type"], string> = {
+  created_storyline: "text-accent",
+  published_plot: "text-accent",
+  bought: "text-green-700",
+  sold: "text-red-700",
+  donated: "text-accent",
+  rated: "text-muted",
+};
+
+function FeedRow({ entry }: { entry: FeedEntry }) {
+  return (
+    <div className="border-border flex items-center justify-between rounded border px-3 py-2 text-xs">
+      <div className="flex items-center gap-2 min-w-0">
+        <span className={`font-medium shrink-0 w-16 ${EVENT_COLORS[entry.type]}`}>
+          {EVENT_LABELS[entry.type]}
+        </span>
+        <Link
+          href={`/story/${entry.storylineId}`}
+          className="text-foreground hover:text-accent truncate transition-colors"
+        >
+          {entry.storyTitle ?? `Story #${entry.storylineId}`}
+        </Link>
+        {entry.detail && (
+          <span className="text-muted shrink-0">{entry.detail}</span>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center gap-1.5 ml-2">
+        <time dateTime={entry.timestamp} className="text-muted text-[10px]">
+          {new Date(entry.timestamp).toLocaleDateString("en-US", {
+            month: "short",
+            day: "numeric",
+          })}
+        </time>
+        {entry.txHash && (
+          <a
+            href={`${EXPLORER_URL}/tx/${entry.txHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted hover:text-accent transition-colors"
+            title="View on Basescan"
+          >
+            &#x2197;
+          </a>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -38,6 +38,20 @@ export default function ProfilePage() {
 
   const isAgent = !agentLoading && agentMeta !== null && agentMeta !== undefined;
 
+  // Cumulative claimed royalties (on-chain)
+  const { data: claimedRoyalties } = useQuery({
+    queryKey: ["profile-claimed-royalties", address],
+    queryFn: async () => {
+      const [, claimed] = await browserClient.readContract({
+        address: MCV2_BOND,
+        abi: mcv2BondAbi,
+        functionName: "getRoyaltyInfo",
+        args: [address as Address, PLOT_TOKEN],
+      });
+      return claimed;
+    },
+  });
+
   return (
     <div className="mx-auto max-w-2xl px-6 py-12">
       <ProfileHeader
@@ -47,6 +61,7 @@ export default function ProfilePage() {
         agentMeta={agentMeta ?? null}
         agentLoading={agentLoading}
         isAgent={isAgent}
+        claimedRoyalties={claimedRoyalties ?? null}
       />
 
       {/* Tab navigation */}
@@ -92,6 +107,7 @@ function ProfileHeader({
   agentMeta,
   agentLoading,
   isAgent,
+  claimedRoyalties,
 }: {
   address: string;
   fcProfile: FarcasterProfile | null;
@@ -99,6 +115,7 @@ function ProfileHeader({
   agentMeta: AgentMetadata | null;
   agentLoading: boolean;
   isAgent: boolean;
+  claimedRoyalties: bigint | null;
 }) {
   const displayName = agentMeta?.name ?? fcProfile?.displayName ?? null;
 
@@ -193,6 +210,13 @@ function ProfileHeader({
           {/* Farcaster bio (only show when no agent description is present) */}
           {!agentMeta?.description && fcProfile?.bio && (
             <p className="text-muted mt-1 text-xs">{fcProfile.bio}</p>
+          )}
+
+          {/* Cumulative claimed royalties */}
+          {claimedRoyalties && claimedRoyalties > BigInt(0) && (
+            <div className="text-muted mt-2 text-xs">
+              Royalties claimed: <span className="text-green-700 font-medium">{formatPrice(formatUnits(claimedRoyalties, 18))} {RESERVE_LABEL}</span>
+            </div>
           )}
         </div>
       </div>
@@ -989,54 +1013,9 @@ function ActivityTab({ address }: { address: string }) {
         });
       }
 
-      // Claimed royalties — derive from ERC-20 Transfer events on PLOT_TOKEN
-      // where from=MCV2_BOND and to=address (royalty payouts)
-      try {
-        const transferEventAbi = [{
-          type: "event",
-          name: "Transfer",
-          inputs: [
-            { name: "from", type: "address", indexed: true },
-            { name: "to", type: "address", indexed: true },
-            { name: "value", type: "uint256", indexed: false },
-          ],
-        }] as const;
-
-        const claimLogs = await browserClient.getLogs({
-          address: PLOT_TOKEN,
-          event: transferEventAbi[0],
-          args: { from: MCV2_BOND, to: address as Address },
-          fromBlock: BigInt(0),
-          toBlock: "latest",
-        });
-
-        // Fetch ALL trade tx hashes (unbounded) to filter sell refunds accurately
-        const { data: allTradeTxRows } = await supabase
-          .from("trade_history")
-          .select("tx_hash")
-          .eq("user_address", address)
-          .eq("contract_address", MCV2_BOND.toLowerCase());
-        const tradeTxHashes = new Set(
-          (allTradeTxRows ?? []).map((t: { tx_hash: string }) => t.tx_hash.toLowerCase()),
-        );
-
-        for (const log of claimLogs) {
-          const txHash = log.transactionHash?.toLowerCase();
-          if (txHash && tradeTxHashes.has(txHash)) continue; // sell refund, not a claim
-
-          const blockTimestamp = await browserClient.getBlock({ blockNumber: log.blockNumber! });
-          const ts = new Date(Number(blockTimestamp.timestamp) * 1000).toISOString();
-          entries.push({
-            type: "claimed_royalties",
-            timestamp: ts,
-            storylineId: 0,
-            detail: `${formatPrice(formatUnits(log.args.value ?? BigInt(0), 18))} ${RESERVE_LABEL}`,
-            txHash: log.transactionHash ?? undefined,
-          });
-        }
-      } catch {
-        // Claim log query unavailable — skip
-      }
+      // TODO: Claimed royalties feed entries require a dedicated claim event
+      // indexer. For now, cumulative claimed amount is shown in the profile header
+      // via on-chain getRoyaltyInfo.
 
       // Sort reverse-chronological
       entries.sort((a, b) => b.timestamp.localeCompare(a.timestamp));


### PR DESCRIPTION
## Summary
- Replaced separate Donations/Ratings sections with a unified reverse-chronological activity feed
- Event types: Created storyline, Published plot, Bought tokens, Sold tokens, Donated, Rated
- Data from 5 tables (storylines, plots, trade_history, donations, ratings) fetched in parallel
- Each entry shows color-coded event label, story link, detail (amounts/prices/stars), timestamp, and Basescan tx link
- Pagination via "Load more" button (30 entries per page)
- Genesis plots deduplicated with created_storyline events
- Enhanced empty state

## Test plan
- [ ] Visit a writer profile — verify "Created" and "Published" events appear
- [ ] Visit a trader profile — verify "Bought" and "Sold" events with token amounts
- [ ] Visit a donor profile — verify "Donated" events with amounts
- [ ] Verify feed is sorted reverse-chronologically across all event types
- [ ] Verify pagination — click "Load more" to see additional entries
- [ ] Verify tx links open correct Basescan pages
- [ ] Visit an inactive profile — verify empty state
- [ ] Verify genesis plots don't duplicate with created storyline events

Fixes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)