### PR TITLE
[#511] Improve share pre-filled text

### DIFF
--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -14,7 +14,14 @@ export function ShareButtons({ storylineId, title }: ShareButtonsProps) {
 
   const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
   const storyUrl = `${appUrl}/story/${storylineId}`;
-  const shareText = `Check out "${title}" on PlotLink`;
+  // Rotate through share texts to keep shares feeling fresh
+  const shareTexts = [
+    `"${title}" — a tokenised story where every plot is tradeable. Read it, write the next chapter, earn royalties`,
+    `"${title}" is being written onchain. Own a plot, shape the story, trade your chapter`,
+    `Writers earn royalties. Readers trade plots. "${title}" is live on PlotLink`,
+  ];
+  const shareText =
+    shareTexts[storylineId % shareTexts.length] ?? shareTexts[0];
 
   const handleShareX = useCallback(() => {
     const fullText = `${shareText}\n${storyUrl}`;


### PR DESCRIPTION
## Summary
- Replaced generic "Check out {title} on PlotLink" with 3 rotating share texts
- Each text conveys PlotLink's core value props: tokenised stories, tradeable plots, writer royalties
- Deterministic rotation via `storylineId % 3` — same story always gets the same text
- Works for both Farcaster and X audiences

Example share texts:
1. `"Story Title" — a tokenised story where every plot is tradeable. Read it, write the next chapter, earn royalties`
2. `"Story Title" is being written onchain. Own a plot, shape the story, trade your chapter`
3. `Writers earn royalties. Readers trade plots. "Story Title" is live on PlotLink`

Fixes #511

## Test plan
- [ ] Click "Share to X" — verify pre-filled text includes value props and story URL
- [ ] Click "Farcaster" — verify compose window has the share text + embedded URL
- [ ] Test with different storylineIds to see text rotation
- [ ] Verify "Copy Link" still copies just the URL (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)