### PR TITLE
[#516] Set story title character limit to 60 characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -109,7 +109,8 @@ function CreatePage() {
     attemptRetry: newAttemptRetry,
   } = usePublishIntent();
   const { valid: newValid, charCount: newCharCount } = validateContentLength(newContent);
-  const newTitleValid = newTitle.trim().length > 0;
+  const MAX_TITLE_LENGTH = 60;
+  const newTitleValid = newTitle.trim().length > 0 && newTitle.length <= MAX_TITLE_LENGTH;
   const newGenreValid = genre.length > 0;
   const newCanSubmit =
     newState === "idle" || newState === "error"
@@ -307,11 +308,20 @@ function CreatePage() {
               <input
                 type="text"
                 value={newTitle}
-                onChange={(e) => setNewTitle(e.target.value)}
+                onChange={(e) => setNewTitle(e.target.value.slice(0, MAX_TITLE_LENGTH))}
                 disabled={newBusy}
                 placeholder="Enter storyline title"
+                maxLength={MAX_TITLE_LENGTH}
                 className="border-border bg-surface text-foreground placeholder:text-muted w-full rounded border px-3 py-2 text-sm focus:border-accent focus:outline-none disabled:opacity-50"
               />
+              <div className="mt-1 flex justify-between text-xs">
+                {newTitle.length > 0 && !newTitleValid ? (
+                  <span className="text-error">Title is required</span>
+                ) : (
+                  <span />
+                )}
+                <span className="text-muted">{newTitle.length} / {MAX_TITLE_LENGTH}</span>
+              </div>
             </div>
 
             <div className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- Added 60-character max validation on the create storyline title input using `maxLength` and `.slice(0, 60)`
- Added character counter below the title field showing `{length} / 60`
- Submission is prevented when title exceeds 60 characters (validation gates the submit button)
- Bumped version to `0.1.1`

## Test plan
- [ ] Open /create page, type a storyline title — counter should show `X / 60`
- [ ] Paste text longer than 60 chars — input should truncate at 60
- [ ] Verify submit button is disabled when title is empty
- [ ] Verify existing "Add Plot" tab chapter title (100-char limit) still works

Fixes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)