### PR TITLE
[#518] Fix home page story card layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -24,10 +24,14 @@ export function StoryCard({
 
   return (
     <div className="flex flex-col">
-      <Link
-        href={`/story/${storyline.storyline_id}`}
-        className="moleskine-notebook group relative block"
-      >
+      <div className="moleskine-notebook group relative block">
+        {/* Stretched link — makes the whole card clickable */}
+        <Link
+          href={`/story/${storyline.storyline_id}`}
+          className="absolute inset-0 z-30"
+          aria-label={storyline.title}
+        />
+
         {/* Page underneath — revealed when cover opens */}
         <div
           className="notebook-page absolute inset-0 z-0 overflow-hidden"
@@ -105,15 +109,15 @@ export function StoryCard({
             )}
           </div>
 
-          {/* Bottom: author name inside cover */}
-          <div className="relative z-10 px-4 py-3 text-[10px] text-[var(--text-muted)]">
+          {/* Bottom: author name inside cover — z-40 so profile link sits above card link */}
+          <div className="relative z-40 px-4 py-3 text-[10px] text-[var(--text-muted)]">
             <span className="inline-flex items-center gap-1">
-              <WriterIdentityClient address={storyline.writer_address} linkProfile={false} />
+              <WriterIdentityClient address={storyline.writer_address} />
               {storyline.writer_type === 1 && <AgentBadge />}
             </span>
           </div>
         </div>
-      </Link>
+      </div>
 
       {/* Metadata below notebook */}
       <div className="mt-2.5 flex flex-col gap-0.5 pl-1 pr-1 text-[10px] text-[var(--text-muted)]">

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -71,12 +71,20 @@ export function StoryCard({
             }}
           />
 
-          {/* Top area: genre badge */}
+          {/* Top area: genre + plot count badges */}
           <div className="relative z-10 px-4 pt-4">
-            <div className="flex items-start justify-between gap-2">
+            <div className="flex flex-wrap items-start gap-1.5">
               <span className="rounded-sm bg-[var(--accent)]/10 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-widest text-[var(--accent)]">
                 {displayGenre || "Uncategorized"}
               </span>
+              <span className="rounded-sm border border-[var(--border)] px-1.5 py-0.5 text-[9px] text-[var(--text-muted)]">
+                {storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"}
+              </span>
+              {isNew && (
+                <span className="rounded-sm bg-[var(--accent)]/10 px-1.5 py-0.5 text-[9px] font-bold text-[var(--accent)]">
+                  NEW
+                </span>
+              )}
               {storyline.sunset && (
                 <span className="rounded-sm border border-[var(--border)] px-1.5 py-0.5 text-[9px] text-[var(--text-muted)]">
                   complete
@@ -97,26 +105,23 @@ export function StoryCard({
             )}
           </div>
 
-          {/* Bottom spacer (author shown below card with profile link) */}
-          <div className="relative z-10 px-4 py-3" />
+          {/* Bottom: author name inside cover */}
+          <div className="relative z-10 px-4 py-3 text-[10px] text-[var(--text-muted)]">
+            <span className="inline-flex items-center gap-1">
+              <WriterIdentityClient address={storyline.writer_address} linkProfile={false} />
+              {storyline.writer_type === 1 && <AgentBadge />}
+            </span>
+          </div>
         </div>
       </Link>
 
       {/* Metadata below notebook */}
       <div className="mt-2.5 flex flex-col gap-0.5 pl-1 pr-1 text-[10px] text-[var(--text-muted)]">
-        <span className="inline-flex items-center gap-1">
-          <WriterIdentityClient address={storyline.writer_address} />
-          {storyline.writer_type === 1 && <AgentBadge />}
-        </span>
         {storyline.token_address && (
           <span className="whitespace-nowrap">
             <StoryCardTVL tokenAddress={storyline.token_address} />
           </span>
         )}
-        <span className="whitespace-nowrap">
-          {storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"} linked
-          {isNew && <span className="ml-1 text-[10px] font-bold text-[var(--accent)]">NEW</span>}
-        </span>
         <RatingSummary storylineId={storyline.storyline_id} />
       </div>
     </div>

--- a/src/components/__tests__/StoryCard.test.tsx
+++ b/src/components/__tests__/StoryCard.test.tsx
@@ -69,14 +69,14 @@ describe("StoryCard", () => {
 
   it("links to correct story page", () => {
     render(<StoryCard storyline={makeStoryline({ storyline_id: 42 })} />);
-    const link = screen.getAllByText("Test Story Title")[0].closest("a");
+    const link = screen.getByRole("link", { name: "Test Story Title" });
     expect(link).toHaveAttribute("href", "/story/42");
   });
 
   it("applies moleskine-notebook class for hover animation", () => {
     render(<StoryCard storyline={makeStoryline()} />);
-    const link = screen.getAllByText("Test Story Title")[0].closest("a");
-    expect(link).toHaveClass("moleskine-notebook");
+    const container = screen.getAllByText("Test Story Title")[0].closest(".moleskine-notebook");
+    expect(container).toBeTruthy();
   });
 
   it("shows plot count", () => {


### PR DESCRIPTION
## Summary
- Moved author name inside the moleskine cover (bottom area), using `linkProfile={false}` to avoid nested `<a>` tags
- Moved plot count inside cover as a compact badge next to the genre tag (e.g. `2 plots`)
- Moved NEW indicator inside cover as an accent badge
- Reduced metadata section below the card from 3 lines to only TVL and rating
- Bumped version to `0.1.2`

## Test plan
- [ ] Home page story cards show author name inside the moleskine cover
- [ ] Plot count appears as a badge next to genre tag on the cover
- [ ] NEW badge shows for stories with plots added in last 24h
- [ ] TVL and rating still display below the card
- [ ] Clicking the card still navigates to story page
- [ ] Mobile layout looks clean (no three-line section below card)

Fixes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)