### PR TITLE
[#519] Add version number to footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { STORY_FACTORY, EXPLORER_URL } from "../../lib/contracts/constants";
+import { version } from "../../package.json";
 
 const CONTRACT_URL = `${EXPLORER_URL}/address/${STORY_FACTORY}`;
 const GITHUB_URL = "https://github.com/realproject7/plotlink-contracts";
@@ -36,7 +37,7 @@ export function Footer() {
           </span>
         </div>
         <div className="text-muted text-xs">
-          PlotLink &copy; {new Date().getFullYear()}
+          PlotLink &copy; {new Date().getFullYear()} &middot; v{version}
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- Import `version` from `package.json` in the Footer component
- Display `v{version}` next to the copyright line (e.g. `PlotLink © 2026 · v0.1.3`)
- Bumped version to `0.1.3`

## Test plan
- [ ] Footer shows version number (e.g. `v0.1.3`)
- [ ] Version updates when package.json version changes
- [ ] Footer layout unchanged otherwise

Fixes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)