### PR TITLE
[#520] Redesign footer to match Dropcast style

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -18,13 +18,13 @@ test.describe("Navigation", () => {
     await expect(page).toHaveURL("/create");
   });
 
-  test("Footer renders with PlotLink branding", async ({ page }) => {
+  test("Footer renders with version and credits", async ({ page }) => {
     await page.goto("/");
-    // Footer contains "PlotLink" copyright text
     const footer = page.locator("footer");
     await expect(footer).toBeVisible({ timeout: 10000 });
-    // Verify footer has expected content
-    await expect(footer.getByText(/PlotLink/)).toBeVisible();
+    // Verify footer has version and credits content
+    await expect(footer.getByText(/Base Mainnet/)).toBeVisible();
+    await expect(footer.getByText(/@project7/)).toBeVisible();
   });
 
   test("no console errors on navigation", async ({ page }) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -36,8 +36,16 @@ export function Footer() {
             built on <span className="text-accent-dim">Base</span>
           </span>
         </div>
-        <div className="text-muted text-xs">
-          PlotLink &copy; {new Date().getFullYear()} &middot; v{version}
+        <div className="text-muted text-xs text-center">
+          v{version} &middot; Base Mainnet &middot; Made by{" "}
+          <a
+            href="https://farcaster.xyz/project7"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-foreground transition-colors"
+          >
+            @project7
+          </a>
         </div>
       </div>
     </footer>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -39,7 +39,7 @@ export function Footer() {
         <div className="text-muted text-xs text-center">
           v{version} &middot; Base Mainnet &middot; Made by{" "}
           <a
-            href="https://farcaster.xyz/project7"
+            href="https://farcaster.com/project7"
             target="_blank"
             rel="noopener noreferrer"
             className="hover:text-foreground transition-colors"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,33 +8,28 @@ const GITHUB_URL = "https://github.com/realproject7/plotlink-contracts";
 export function Footer() {
   return (
     <footer className="border-t border-[var(--border)] bg-[var(--bg)] px-4 py-6 pb-20 lg:pb-6 mt-16">
-      <div className="mx-auto max-w-5xl flex flex-col gap-4 text-xs">
-        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:gap-4">
-          <div className="flex flex-wrap items-center gap-3 sm:gap-4 text-muted">
-            <a
-              href={CONTRACT_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-foreground transition-colors"
-              title={STORY_FACTORY}
-            >
-              contract: {STORY_FACTORY.slice(0, 6)}...{STORY_FACTORY.slice(-4)}
-            </a>
-            <Link href="/token" className="hover:text-foreground transition-colors">
-              $PLOT
-            </Link>
-            <a
-              href={GITHUB_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-foreground transition-colors"
-            >
-              github
-            </a>
-          </div>
-          <span className="text-muted">
-            built on <span className="text-accent-dim">Base</span>
-          </span>
+      <div className="mx-auto max-w-5xl flex flex-col items-center gap-4 text-xs">
+        <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-4 text-muted">
+          <a
+            href={CONTRACT_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-foreground transition-colors"
+            title={STORY_FACTORY}
+          >
+            contract: {STORY_FACTORY.slice(0, 6)}...{STORY_FACTORY.slice(-4)}
+          </a>
+          <Link href="/token" className="hover:text-foreground transition-colors">
+            $PLOT
+          </Link>
+          <a
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-foreground transition-colors"
+          >
+            github
+          </a>
         </div>
         <div className="text-muted text-xs text-center">
           v{version} &middot; Base Mainnet &middot; Made by{" "}


### PR DESCRIPTION
## Summary
- Replaced `PlotLink © 2026` with `v{version} · Base Mainnet · Made by @project7`
- `@project7` links to `https://farcaster.xyz/project7`
- Center-aligned the version/credits line, matching Dropcast footer aesthetic
- Bumped version to `0.1.4`

## Test plan
- [ ] Footer shows `v0.1.4 · Base Mainnet · Made by @project7`
- [ ] `@project7` link opens farcaster.xyz/project7 in new tab
- [ ] Footer is center-aligned
- [ ] Contract, $PLOT, and github links still present above

Fixes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)