### PR TITLE
Fix footer Farcaster link — farcaster.xyz not .com

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -34,7 +34,7 @@ export function Footer() {
         <div className="text-muted text-xs text-center">
           v{version} &middot; Base Mainnet &middot; Made by{" "}
           <a
-            href="https://farcaster.com/project7"
+            href="https://farcaster.xyz/project7"
             target="_blank"
             rel="noopener noreferrer"
             className="hover:text-foreground transition-colors"


### PR DESCRIPTION
## Summary
- Footer redesign PR #525 introduced `farcaster.com/project7` — should be `farcaster.xyz/project7`
- Same fix as #500 but for the new footer

## Test plan
- [ ] "Made by @project7" link in footer opens farcaster.xyz