### PR TITLE
[#530] Fix OG image — match home page moleskine layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/story/[storylineId]/og/route.tsx
+++ b/src/app/story/[storylineId]/og/route.tsx
@@ -1,18 +1,17 @@
 import { ImageResponse } from "next/og";
 import { type Address } from "viem";
 import { createServerClient, type Storyline } from "../../../../../lib/supabase";
-import { getTokenPrice } from "../../../../../lib/price";
+import { getTokenTVL } from "../../../../../lib/price";
 import { lookupByAddress } from "../../../../../lib/farcaster";
 import { RESERVE_LABEL, STORY_FACTORY } from "../../../../../lib/contracts/constants";
 import { formatPrice } from "../../../../../lib/format";
 import { truncateAddress } from "../../../../../lib/utils";
+import { getPlotUsdPrice, formatUsdValue } from "../../../../../lib/usd-price";
 
 export const runtime = "edge";
 
 async function loadFont(): Promise<ArrayBuffer | null> {
   try {
-    // Fetch with no User-Agent → Google returns TTF (truetype) format
-    // ImageResponse supports ttf/otf/woff but NOT woff2
     const res = await fetch(
       "https://fonts.googleapis.com/css2?family=Lora:wght@700&display=swap",
     );
@@ -58,22 +57,30 @@ export async function GET(
 
   const sl = storyline as Storyline;
 
-  const [priceInfo, farcasterProfile, fontData] = await Promise.all([
-    sl.token_address ? getTokenPrice(sl.token_address as Address) : null,
+  const [tvlInfo, plotUsd, farcasterProfile, fontData] = await Promise.all([
+    sl.token_address ? getTokenTVL(sl.token_address as Address) : null,
+    getPlotUsdPrice(),
     lookupByAddress(sl.writer_address).catch(() => null),
     loadFont(),
   ]);
 
   const reserveLabel = RESERVE_LABEL;
-  const priceDisplay = priceInfo
-    ? `${formatPrice(priceInfo.pricePerToken)} ${reserveLabel}`
-    : null;
   const authorName = farcasterProfile
     ? `@${farcasterProfile.username}`
     : truncateAddress(sl.writer_address);
-  const plotLabel = sl.plot_count === 1 ? "plot" : "plots";
+  const plotLabel = `${sl.plot_count} ${sl.plot_count === 1 ? "plot" : "plots"}`;
   const titleDisplay =
-    sl.title.length > 60 ? `${sl.title.slice(0, 57)}...` : sl.title;
+    sl.title.length > 50 ? `${sl.title.slice(0, 47)}...` : sl.title;
+
+  // TVL display with USD
+  let tvlDisplay: string | null = null;
+  if (tvlInfo) {
+    const tvlNum = parseFloat(tvlInfo.tvl);
+    tvlDisplay = `TVL: ${formatPrice(tvlInfo.tvl)} ${reserveLabel}`;
+    if (plotUsd && tvlNum > 0) {
+      tvlDisplay += ` (${formatUsdValue(tvlNum * plotUsd)})`;
+    }
+  }
 
   const fonts = fontData
     ? [{ name: "Lora", data: fontData, weight: 700 as const }]
@@ -86,18 +93,18 @@ export async function GET(
           width: "100%",
           height: "100%",
           display: "flex",
+          flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
           backgroundColor: "#DDD3C2",
-          padding: "40px 60px",
           fontFamily: fontData ? "Lora" : "Georgia, serif",
         }}
       >
-        {/* Left: Moleskine notebook cover */}
+        {/* Centered moleskine card */}
         <div
           style={{
-            width: "350px",
-            height: "525px",
+            width: "440px",
+            height: "440px",
             display: "flex",
             flexDirection: "column",
             backgroundColor: "#F5EFE6",
@@ -107,7 +114,6 @@ export async function GET(
               "4px 6px 20px rgba(44, 24, 16, 0.18), 1px 1px 4px rgba(44, 24, 16, 0.08)",
             position: "relative",
             overflow: "hidden",
-            flexShrink: 0,
           }}
         >
           {/* Elastic band */}
@@ -116,7 +122,7 @@ export async function GET(
               position: "absolute",
               top: "-1px",
               bottom: "-1px",
-              right: "22px",
+              right: "28px",
               width: "8px",
               borderRadius: "2px",
               background: "rgba(139, 69, 19, 0.18)",
@@ -124,136 +130,25 @@ export async function GET(
             }}
           />
 
-          {/* Ruled lines background */}
-          <div
-            style={{
-              position: "absolute",
-              top: "0",
-              left: "0",
-              right: "0",
-              bottom: "0",
-              display: "flex",
-              flexDirection: "column",
-              paddingTop: "28px",
-            }}
-          >
-            {Array.from({ length: 18 }).map((_, i) => (
-              <div
-                key={i}
-                style={{
-                  width: "100%",
-                  height: "28px",
-                  borderBottom: "1px solid rgba(232, 223, 208, 0.6)",
-                  display: "flex",
-                }}
-              />
-            ))}
-          </div>
-
-          {/* Content inside notebook: title + author */}
+          {/* Top-left: genre tag */}
           <div
             style={{
               display: "flex",
-              flexDirection: "column",
-              justifyContent: "center",
-              alignItems: "center",
-              flex: 1,
-              padding: "40px 32px",
-              position: "relative",
-              textAlign: "center",
-            }}
-          >
-            <div
-              style={{
-                fontSize: titleDisplay.length > 35 ? "32px" : "38px",
-                fontWeight: 700,
-                color: "#8B4513",
-                lineHeight: 1.25,
-                display: "flex",
-                textAlign: "center",
-                justifyContent: "center",
-                maxWidth: "290px",
-              }}
-            >
-              {titleDisplay}
-            </div>
-            <div
-              style={{
-                fontSize: "18px",
-                color: "#8B7355",
-                marginTop: "20px",
-                display: "flex",
-              }}
-            >
-              by {authorName}
-            </div>
-          </div>
-        </div>
-
-        {/* Right: Metadata on dark background */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "space-between",
-            height: "525px",
-            marginLeft: "56px",
-            flex: 1,
-            maxWidth: "580px",
-          }}
-        >
-          {/* Top: PlotLink branding */}
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "16px",
-            }}
-          >
-            <div
-              style={{
-                display: "flex",
-                fontSize: "28px",
-                fontWeight: 700,
-                color: "#8B4513",
-                letterSpacing: "0.08em",
-                textTransform: "uppercase",
-              }}
-            >
-              PlotLink
-            </div>
-            <div
-              style={{
-                display: "flex",
-                fontSize: "16px",
-                color: "#8B7355",
-                letterSpacing: "0.03em",
-              }}
-            >
-              Tokenised collaborative fiction
-            </div>
-          </div>
-
-          {/* Middle: genre + stats */}
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "20px",
+              padding: "24px 28px 0",
             }}
           >
             {sl.genre ? (
               <div
                 style={{
                   display: "flex",
-                  alignSelf: "flex-start",
-                  fontSize: "16px",
-                  color: "#8B7355",
-                  border: "1.5px solid #C4B59E",
-                  borderRadius: "4px",
-                  padding: "6px 16px",
+                  fontSize: "13px",
+                  color: "#8B4513",
+                  backgroundColor: "rgba(139, 69, 19, 0.08)",
+                  borderRadius: "3px",
+                  padding: "4px 12px",
                   textTransform: "uppercase",
-                  letterSpacing: "0.08em",
+                  letterSpacing: "0.1em",
+                  fontWeight: 700,
                 }}
               >
                 {sl.genre}
@@ -261,41 +156,70 @@ export async function GET(
             ) : (
               <div style={{ display: "flex" }} />
             )}
-            <div
-              style={{
-                display: "flex",
-                gap: "28px",
-                fontSize: "22px",
-                color: "#6B5B47",
-              }}
-            >
-              <span style={{ display: "flex" }}>
-                {sl.plot_count} {plotLabel}
-              </span>
-              {priceDisplay && (
-                <span
-                  style={{
-                    display: "flex",
-                    color: "#8B4513",
-                    fontWeight: 700,
-                  }}
-                >
-                  {priceDisplay}
-                </span>
-              )}
-            </div>
           </div>
 
-          {/* Bottom: domain */}
+          {/* Center: title */}
           <div
             style={{
               display: "flex",
-              fontSize: "18px",
-              color: "#A89880",
+              flexDirection: "column",
+              justifyContent: "center",
+              alignItems: "center",
+              flex: 1,
+              padding: "0 36px",
+              textAlign: "center",
             }}
           >
-            plotlink.xyz
+            <div
+              style={{
+                fontSize: titleDisplay.length > 30 ? "32px" : "38px",
+                fontWeight: 700,
+                color: "#8B4513",
+                lineHeight: 1.25,
+                display: "flex",
+                textAlign: "center",
+                justifyContent: "center",
+                maxWidth: "380px",
+              }}
+            >
+              {titleDisplay}
+            </div>
           </div>
+
+          {/* Bottom: plot count + TVL */}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "6px",
+              padding: "0 28px 24px",
+              fontSize: "15px",
+              color: "#6B5B47",
+            }}
+          >
+            <div style={{ display: "flex" }}>{plotLabel}</div>
+            {tvlDisplay && (
+              <div style={{ display: "flex", fontWeight: 700, color: "#8B4513" }}>
+                {tvlDisplay}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Below moleskine: author + branding */}
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            width: "440px",
+            marginTop: "20px",
+            fontSize: "16px",
+            color: "#8B7355",
+          }}
+        >
+          <div style={{ display: "flex" }}>by {authorName}</div>
+          <div style={{ display: "flex", color: "#A89880" }}>plotlink.xyz</div>
         </div>
       </div>
     ),

--- a/src/app/story/[storylineId]/og/route.tsx
+++ b/src/app/story/[storylineId]/og/route.tsx
@@ -103,8 +103,8 @@ export async function GET(
         {/* Centered moleskine card */}
         <div
           style={{
-            width: "440px",
-            height: "440px",
+            width: "360px",
+            height: "540px",
             display: "flex",
             flexDirection: "column",
             backgroundColor: "#F5EFE6",
@@ -212,8 +212,8 @@ export async function GET(
             display: "flex",
             justifyContent: "space-between",
             alignItems: "center",
-            width: "440px",
-            marginTop: "20px",
+            width: "360px",
+            marginTop: "16px",
             fontSize: "16px",
             color: "#8B7355",
           }}


### PR DESCRIPTION
## Summary
- Redesigned OG image from notebook-left + metadata-right to **single centered moleskine card**
- Layout matches home page StoryCard:
  - **Top-left inside**: genre tag
  - **Center inside**: story title
  - **Bottom inside**: plot count + TVL with USD value
  - **Below moleskine**: author name + plotlink.xyz branding
- Added TVL with USD display (via `getPlotUsdPrice` + `formatUsdValue`)
- Bumped version to `0.1.8`

## Test plan
- [ ] Visit `/story/[id]/og` — image shows centered moleskine card
- [ ] Genre tag at top-left of card
- [ ] Title centered in card
- [ ] Plot count + TVL at bottom of card
- [ ] Author name + plotlink.xyz below card
- [ ] Image renders at 1200x630 (OG standard)

Fixes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)