### PR TITLE
[#531] Fix X/Twitter share preview — dynamic OG image

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -84,6 +84,12 @@ export async function generateMetadata({
       description,
       images: [{ url: ogImageUrl, width: 1200, height: 630 }],
     },
+    twitter: {
+      card: "summary_large_image",
+      title: sl.title,
+      description,
+      images: [ogImageUrl],
+    },
     other: {
       "fc:miniapp": fcEmbed,
     },


### PR DESCRIPTION
## Summary
- Added `twitter` metadata object to story page `generateMetadata()`
- `twitter.card = "summary_large_image"` ensures X shows the large preview
- `twitter.images` points to the dynamic OG route (`/story/[id]/og`)
- Both `openGraph` and `twitter` objects now set, preventing fallback to site-level logo
- Bumped version to `0.1.9`

## Test plan
- [ ] Share a story URL on X/Twitter — should show per-story moleskine thumbnail, not site logo
- [ ] Verify with [Twitter Card Validator](https://cards-dev.twitter.com/validator)
- [ ] OpenGraph preview still works on other platforms (Slack, Discord, iMessage)

Fixes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)