### PR TITLE
[#538] Update PL_TEST → PLOT token references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,7 @@ NEXT_PUBLIC_CONTRACT_ADDRESS=
 #
 # Base Mainnet:
 # MCV2_Bond: 0xc5a076cad94176c2996B32d8466Be1cE757FAa27
-# PLOT_TOKEN (PL_TEST): 0xF8A2C39111FCEB9C950aAf28A9E34EBaD99b85C1
+# PLOT_TOKEN: 0x4F567DACBF9D15A6acBe4A47FC2Ade0719Fb63C4
 
 # -----------------------------------------------------------------------------
 # Contract Deployment (testnet only — used by Foundry deploy scripts)

--- a/lib/contracts/constants.ts
+++ b/lib/contracts/constants.ts
@@ -39,15 +39,13 @@ export const ZAP_PLOTLINK = (IS_TESTNET
   ? "0x0000000000000000000000000000000000000000"
   : "0xAe50C9444DA2Ac80B209dC8B416d1B4A7D3939B0") as `0x${string}`;
 
-/** $PLOT protocol token
- *  Testnet: PL_TEST ERC-20 on Base Sepolia
- *  Mainnet: $PLOT ERC-20 (backed by $HUNT via Mint Club V2) */
+/** $PLOT protocol token (backed by $HUNT via Mint Club V2) */
 export const PLOT_TOKEN = (IS_TESTNET
   ? "0x6Ef4A3f654F2AfcEa8A8704D61Be5271536c13Fa"
-  : "0xF8A2C39111FCEB9C950aAf28A9E34EBaD99b85C1") as `0x${string}`;
+  : "0x4F567DACBF9D15A6acBe4A47FC2Ade0719Fb63C4") as `0x${string}`;
 
 /** Human-readable label for the reserve token */
-export const RESERVE_LABEL = IS_TESTNET ? "PL_TEST" : "PLOT";
+export const RESERVE_LABEL = "PLOT";
 
 // ---------------------------------------------------------------------------
 // Supported Zap input tokens (Base)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary
- Updated `PLOT_TOKEN` mainnet address from `0xF8A2C39...` to `0x4F567DAC...`
- Simplified `RESERVE_LABEL` to always `"PLOT"` (removed testnet conditional)
- `lib/usd-price.ts` automatically picks up new address via `PLOT_TOKEN` import
- Bumped version to `0.1.10`

## Test plan
- [ ] App displays "PLOT" as reserve label everywhere
- [ ] USD price API returns price for new PLOT token
- [ ] Token page shows correct PLOT data
- [x] All 104 tests pass

Fixes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)