### PR TITLE
[#539] Update StoryFactory to new v4 contract

### DIFF
--- a/lib/contracts/constants.ts
+++ b/lib/contracts/constants.ts
@@ -24,14 +24,14 @@ export const EXPLORER_URL = IS_TESTNET
 // PlotLink contracts
 // ---------------------------------------------------------------------------
 
-/** Deployment block for the v3 StoryFactory on Base mainnet */
-export const DEPLOYMENT_BLOCK = BigInt(43_609_150);
+/** Deployment block for the v4 StoryFactory (J-curve + real PLOT) on Base mainnet */
+export const DEPLOYMENT_BLOCK = BigInt(43_824_790);
 
 /** StoryFactory — storyline + plot management */
 export const STORY_FACTORY = (process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ??
   (IS_TESTNET
     ? "0xfa5489b6710Ba2f8406b37fA8f8c3018e51FA229"
-    : "0x337c5b96f03fB335b433291695A4171fd5dED8B0")) as `0x${string}`;
+    : "0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d")) as `0x${string}`;
 
 /** ZapPlotLinkV2 — one-click buy (ETH/USDC/HUNT -> PLOT -> storyline token via Uniswap V4 + MCV2)
  *  Testnet: disabled (V1 contract incompatible with V2 ABI) */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -26,7 +26,7 @@ export const DEPLOYMENT_BLOCK = BigInt(20_000_000);
  * Deployment block for PlotLink contracts on Base mainnet.
  * Used as the default fromBlock for mainnet event log queries.
  */
-export const DEPLOYMENT_BLOCK_MAINNET = BigInt(43_609_150);
+export const DEPLOYMENT_BLOCK_MAINNET = BigInt(43_824_790);
 
 /** Supported chain IDs for the PlotLink SDK. */
 export const SUPPORTED_CHAIN_IDS = new Set([BASE_SEPOLIA_CHAIN_ID, BASE_MAINNET_CHAIN_ID]);
@@ -41,7 +41,7 @@ export const STORY_FACTORY_ADDRESS =
 
 /** StoryFactory — storyline + plot management (Base mainnet). */
 export const STORY_FACTORY_MAINNET_ADDRESS =
-  "0x337c5b96f03fB335b433291695A4171fd5dED8B0" as const;
+  "0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d" as const;
 
 /** MCV2_Bond — bonding curve trading (Base Sepolia). */
 export const MCV2_BOND_ADDRESS =

--- a/src/app/api/cron/backfill/route.ts
+++ b/src/app/api/cron/backfill/route.ts
@@ -3,7 +3,7 @@ import { decodeEventLog, type Log } from "viem";
 import { publicClient } from "../../../../../lib/rpc";
 import { createServerClient } from "../../../../../lib/supabase";
 import { storyFactoryAbi } from "../../../../../lib/contracts/abi";
-import { STORY_FACTORY } from "../../../../../lib/contracts/constants";
+import { STORY_FACTORY, DEPLOYMENT_BLOCK } from "../../../../../lib/contracts/constants";
 import { hashContent } from "../../../../../lib/content";
 import { detectWriterType } from "../../../../../lib/contracts/erc8004";
 import { reconcileStorylinePlotCount } from "../../../../../lib/reconcile";
@@ -106,8 +106,8 @@ export async function GET(req: Request) {
     .single();
   const lastBlock = cursor?.last_block ? BigInt(cursor.last_block) : BigInt(0);
 
-  // Start from block after last processed; cap toBlock to limit scan per run
-  const fromBlock = lastBlock > BigInt(0) ? lastBlock + BigInt(1) : BigInt(0);
+  // Start from block after last processed; fall back to DEPLOYMENT_BLOCK for new contracts
+  const fromBlock = lastBlock > BigInt(0) ? lastBlock + BigInt(1) : DEPLOYMENT_BLOCK;
 
   if (fromBlock > currentBlock) {
     return NextResponse.json({ skipped: true, reason: "Already up to date" });

--- a/supabase/migrations/00023_reset_backfill_cursor_v4.sql
+++ b/supabase/migrations/00023_reset_backfill_cursor_v4.sql
@@ -1,0 +1,4 @@
+-- [#539] Reset backfill_cursor for StoryFactory v4 (J-curve + real PLOT)
+-- New contract deployed at block 43824790
+-- Old cursor may be past this block, so reset to pick up new factory events
+UPDATE backfill_cursor SET last_block = 43824789 WHERE id = 1;


### PR DESCRIPTION
## Summary
- Updated `STORY_FACTORY` mainnet address: `0x337c5b96...` → `0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d`
- Updated `DEPLOYMENT_BLOCK`: `43609150` → `43824790` (v4 deploy block)
- Updated in both `lib/contracts/constants.ts` and `packages/sdk/src/constants.ts`
- `.env.local` updated locally (gitignored, needs Vercel env var update too)
- Bumped version to `0.1.11`

## Test plan
- [ ] App loads storylines from new contract
- [ ] Backfill cron scans from new deployment block
- [ ] Footer shows new contract address link
- [ ] Vercel env `NEXT_PUBLIC_CONTRACT_ADDRESS` needs updating (operator action)

Fixes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)