### PR TITLE
[#272] Post-E2E cleanup: update StoryFactory address & remove orphan data

### DIFF
--- a/lib/contracts/constants.ts
+++ b/lib/contracts/constants.ts
@@ -24,14 +24,14 @@ export const EXPLORER_URL = IS_TESTNET
 // PlotLink contracts
 // ---------------------------------------------------------------------------
 
-/** Deployment block for the v4 StoryFactory (J-curve + real PLOT) on Base mainnet */
-export const DEPLOYMENT_BLOCK = BigInt(43_824_790);
+/** Deployment block for the v4b StoryFactory (symbol-collision fix) on Base mainnet */
+export const DEPLOYMENT_BLOCK = BigInt(43_840_298);
 
 /** StoryFactory — storyline + plot management */
 export const STORY_FACTORY = (process.env.NEXT_PUBLIC_CONTRACT_ADDRESS ??
   (IS_TESTNET
     ? "0xfa5489b6710Ba2f8406b37fA8f8c3018e51FA229"
-    : "0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d")) as `0x${string}`;
+    : "0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf")) as `0x${string}`;
 
 /** ZapPlotLinkV2 — one-click buy (ETH/USDC/HUNT -> PLOT -> storyline token via Uniswap V4 + MCV2)
  *  Testnet: disabled (V1 contract incompatible with V2 ABI) */

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -26,7 +26,7 @@ export const DEPLOYMENT_BLOCK = BigInt(20_000_000);
  * Deployment block for PlotLink contracts on Base mainnet.
  * Used as the default fromBlock for mainnet event log queries.
  */
-export const DEPLOYMENT_BLOCK_MAINNET = BigInt(43_824_790);
+export const DEPLOYMENT_BLOCK_MAINNET = BigInt(43_840_298);
 
 /** Supported chain IDs for the PlotLink SDK. */
 export const SUPPORTED_CHAIN_IDS = new Set([BASE_SEPOLIA_CHAIN_ID, BASE_MAINNET_CHAIN_ID]);
@@ -41,7 +41,7 @@ export const STORY_FACTORY_ADDRESS =
 
 /** StoryFactory — storyline + plot management (Base mainnet). */
 export const STORY_FACTORY_MAINNET_ADDRESS =
-  "0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d" as const;
+  "0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf" as const;
 
 /** MCV2_Bond — bonding curve trading (Base Sepolia). */
 export const MCV2_BOND_ADDRESS =

--- a/supabase/migrations/00025_cleanup_orphan_storylines.sql
+++ b/supabase/migrations/00025_cleanup_orphan_storylines.sql
@@ -1,0 +1,35 @@
+-- [#549] Clean up orphan storylines 25-33 from first E2E attempt
+--
+-- These were created on the old v4 factory (0x92c3bd44...) with wrong
+-- content hashes during initial E2E testing. The new v4b factory
+-- (0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf) has the correct data.
+
+-- 1. Delete plots for orphan storylines
+DELETE FROM plots WHERE storyline_id BETWEEN 25 AND 33;
+
+-- 2. Delete donations for orphan storylines
+DELETE FROM donations WHERE storyline_id BETWEEN 25 AND 33;
+
+-- 3. Delete ratings for orphan storylines
+DELETE FROM ratings WHERE storyline_id BETWEEN 25 AND 33;
+
+-- 4. Delete comments for orphan storylines
+DELETE FROM comments WHERE storyline_id BETWEEN 25 AND 33;
+
+-- 5. Delete page views for orphan storylines
+DELETE FROM page_views WHERE storyline_id BETWEEN 25 AND 33;
+
+-- 6. Delete trade history for orphan storylines
+DELETE FROM trade_history WHERE storyline_id BETWEEN 25 AND 33;
+
+-- 7. Delete the orphan storylines themselves
+DELETE FROM storylines WHERE storyline_id BETWEEN 25 AND 33;
+
+-- 8. Clean up backfill_failures for orphan storylines
+DELETE FROM backfill_failures WHERE storyline_id BETWEEN 25 AND 33;
+
+-- 9. Clean up notification_queue for orphan storylines (skip if table doesn't exist)
+DO $$ BEGIN
+  DELETE FROM notification_queue WHERE storyline_id BETWEEN 25 AND 33;
+EXCEPTION WHEN undefined_table THEN NULL;
+END $$;

--- a/supabase/migrations/00025_cleanup_orphan_storylines.sql
+++ b/supabase/migrations/00025_cleanup_orphan_storylines.sql
@@ -1,29 +1,45 @@
 -- [#549] Clean up orphan storylines 25-33 from first E2E attempt
+-- and reset backfill cursor for the v4b factory redeployment.
 --
--- These were created on the old v4 factory (0x92c3bd44...) with wrong
--- content hashes during initial E2E testing. The new v4b factory
--- (0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf) has the correct data.
+-- Storylines 25-33 were created on the old v4 factory (0x92c3bd44...)
+-- with wrong content hashes during initial E2E testing. The new v4b
+-- factory (0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf) has correct data.
 
--- 1. Delete plots for orphan storylines
-DELETE FROM plots WHERE storyline_id BETWEEN 25 AND 33;
+-- Scope all deletes to the old v4 factory to avoid touching data from
+-- any other contract.
 
--- 2. Delete donations for orphan storylines
-DELETE FROM donations WHERE storyline_id BETWEEN 25 AND 33;
+-- 1. Delete plots for orphan storylines on old factory
+DELETE FROM plots
+  WHERE storyline_id BETWEEN 25 AND 33
+    AND lower(contract_address) = lower('0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d');
 
--- 3. Delete ratings for orphan storylines
-DELETE FROM ratings WHERE storyline_id BETWEEN 25 AND 33;
+-- 2. Delete donations for orphan storylines on old factory
+DELETE FROM donations
+  WHERE storyline_id BETWEEN 25 AND 33
+    AND lower(contract_address) = lower('0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d');
 
--- 4. Delete comments for orphan storylines
-DELETE FROM comments WHERE storyline_id BETWEEN 25 AND 33;
+-- 3. Delete ratings for orphan storylines on old factory
+DELETE FROM ratings
+  WHERE storyline_id BETWEEN 25 AND 33
+    AND lower(contract_address) = lower('0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d');
 
--- 5. Delete page views for orphan storylines
-DELETE FROM page_views WHERE storyline_id BETWEEN 25 AND 33;
+-- 4. Delete comments for orphan storylines on old factory
+DELETE FROM comments
+  WHERE storyline_id BETWEEN 25 AND 33
+    AND lower(contract_address) = lower('0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d');
+
+-- 5. Delete page views for orphan storylines on old factory
+DELETE FROM page_views
+  WHERE storyline_id BETWEEN 25 AND 33
+    AND lower(contract_address) = lower('0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d');
 
 -- 6. Delete trade history for orphan storylines
 DELETE FROM trade_history WHERE storyline_id BETWEEN 25 AND 33;
 
--- 7. Delete the orphan storylines themselves
-DELETE FROM storylines WHERE storyline_id BETWEEN 25 AND 33;
+-- 7. Delete the orphan storylines on old factory (last, after FK-dependent deletes)
+DELETE FROM storylines
+  WHERE storyline_id BETWEEN 25 AND 33
+    AND lower(contract_address) = lower('0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d');
 
 -- 8. Clean up backfill_failures for orphan storylines
 DELETE FROM backfill_failures WHERE storyline_id BETWEEN 25 AND 33;
@@ -33,3 +49,8 @@ DO $$ BEGIN
   DELETE FROM notification_queue WHERE storyline_id BETWEEN 25 AND 33;
 EXCEPTION WHEN undefined_table THEN NULL;
 END $$;
+
+-- 10. Reset backfill cursor to just before the v4b factory deployment block
+-- so the backfill picks up events from the new factory (deployed at 43840298)
+UPDATE backfill_cursor SET last_block = 43840297 WHERE id = 1;
+UPDATE backfill_cursor SET last_block = 43840297 WHERE id = 2;

--- a/supabase/migrations/00025_cleanup_orphan_storylines.sql
+++ b/supabase/migrations/00025_cleanup_orphan_storylines.sql
@@ -1,45 +1,46 @@
 -- [#549] Clean up orphan storylines 25-33 from first E2E attempt
 -- and reset backfill cursor for the v4b factory redeployment.
 --
--- Storylines 25-33 were created on the old v4 factory (0x92c3bd44...)
--- with wrong content hashes during initial E2E testing. The new v4b
--- factory (0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf) has correct data.
+-- Storylines 25-33 were created on the v4b factory
+-- (0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf) during the first E2E
+-- attempt with wrong content hashes. They need to be removed so the
+-- backfill can re-index clean data from the same factory.
 
--- Scope all deletes to the old v4 factory to avoid touching data from
+-- Scope all deletes to the v4b factory to avoid touching data from
 -- any other contract.
 
--- 1. Delete plots for orphan storylines on old factory
+-- 1. Delete plots for orphan storylines on v4b factory
 DELETE FROM plots
   WHERE storyline_id BETWEEN 25 AND 33
-    AND lower(contract_address) = lower('0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d');
+    AND lower(contract_address) = lower('0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf');
 
--- 2. Delete donations for orphan storylines on old factory
+-- 2. Delete donations for orphan storylines on v4b factory
 DELETE FROM donations
   WHERE storyline_id BETWEEN 25 AND 33
-    AND lower(contract_address) = lower('0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d');
+    AND lower(contract_address) = lower('0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf');
 
--- 3. Delete ratings for orphan storylines on old factory
+-- 3. Delete ratings for orphan storylines on v4b factory
 DELETE FROM ratings
   WHERE storyline_id BETWEEN 25 AND 33
-    AND lower(contract_address) = lower('0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d');
+    AND lower(contract_address) = lower('0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf');
 
--- 4. Delete comments for orphan storylines on old factory
+-- 4. Delete comments for orphan storylines on v4b factory
 DELETE FROM comments
   WHERE storyline_id BETWEEN 25 AND 33
-    AND lower(contract_address) = lower('0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d');
+    AND lower(contract_address) = lower('0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf');
 
--- 5. Delete page views for orphan storylines on old factory
+-- 5. Delete page views for orphan storylines on v4b factory
 DELETE FROM page_views
   WHERE storyline_id BETWEEN 25 AND 33
-    AND lower(contract_address) = lower('0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d');
+    AND lower(contract_address) = lower('0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf');
 
 -- 6. Delete trade history for orphan storylines
 DELETE FROM trade_history WHERE storyline_id BETWEEN 25 AND 33;
 
--- 7. Delete the orphan storylines on old factory (last, after FK-dependent deletes)
+-- 7. Delete the orphan storylines on v4b factory (last, after FK-dependent deletes)
 DELETE FROM storylines
   WHERE storyline_id BETWEEN 25 AND 33
-    AND lower(contract_address) = lower('0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d');
+    AND lower(contract_address) = lower('0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf');
 
 -- 8. Clean up backfill_failures for orphan storylines
 DELETE FROM backfill_failures WHERE storyline_id BETWEEN 25 AND 33;


### PR DESCRIPTION
## Summary
Fixes #272

- Updated StoryFactory mainnet fallback from v4 (`0x92c3bd44...`) to v4b (`0x9D2AE1E9...8744Cf`) in `lib/contracts/constants.ts` and `packages/sdk/src/constants.ts`
- Updated `DEPLOYMENT_BLOCK` / `DEPLOYMENT_BLOCK_MAINNET` to `43840298` (the v4b deployment block)
- Added migration `00025_cleanup_orphan_storylines.sql` to delete storyline IDs 25-33 (orphans from first E2E attempt with wrong content hashes)

Companion PR in plotlink-contracts updates the README with the new address.

## Test plan
- [ ] Verify `npx tsc --noEmit` passes
- [ ] Verify backfill picks up events from new factory address
- [ ] Run migration on staging DB and confirm storylines 25-33 are removed
- [ ] Confirm E2E scripts in plotlink-contracts already reference new address

🤖 Generated with [Claude Code](https://claude.com/claude-code)