### PR TITLE
[#554] Fix language filter default to all

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,7 +31,7 @@ export default async function Home({
     : "all";
   const page = Math.max(1, parseInt(rawPage ?? "1", 10) || 1);
   const genre = rawGenre && (GENRES as readonly string[]).includes(rawGenre) ? rawGenre : "all";
-  const lang = rawLang === "all" ? "all" : rawLang && (LANGUAGES as readonly string[]).includes(rawLang) ? rawLang : "English";
+  const lang = rawLang && (LANGUAGES as readonly string[]).includes(rawLang) ? rawLang : "all";
 
   const supabase = createServerClient();
 


### PR DESCRIPTION
## Summary
Fixes #274

The home page language filter defaulted to `"English"`, hiding all non-English storylines (Korean, Japanese, Chinese, Spanish, French). Changed the fallback from `"English"` to `"all"` in `src/app/page.tsx:34`.

One-line change: simplified the ternary to fall through to `"all"` when no valid `lang` param is provided.

## Test plan
- [ ] Visit plotlink.xyz with no `?lang=` param — should show all languages
- [ ] Visit `?lang=Korean` — should filter to Korean only
- [ ] Visit `?lang=invalid` — should show all languages (fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)