### PR TITLE
[#555] Persist language filter in localStorage

### DIFF
--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -55,7 +55,8 @@ export function FilterBar({ writer, genre, lang, tab }: FilterBarProps) {
 
   // Restore saved language preference on first visit (no lang param in URL)
   useEffect(() => {
-    if (lang !== "all") return;
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has("lang")) return; // explicit param — don't override
     try {
       const saved = localStorage.getItem("plotlink_lang");
       if (saved && saved !== "all" && (LANGUAGES as readonly string[]).includes(saved)) {

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -53,12 +53,24 @@ export function FilterBar({ writer, genre, lang, tab }: FilterBarProps) {
     return () => document.removeEventListener("mousedown", handleClick);
   }, []);
 
+  // Restore saved language preference on first visit (no lang param in URL)
+  useEffect(() => {
+    if (lang !== "all") return;
+    try {
+      const saved = localStorage.getItem("plotlink_lang");
+      if (saved && saved !== "all" && (LANGUAGES as readonly string[]).includes(saved)) {
+        router.replace(buildHref({ tab, writer, genre, lang: saved }));
+      }
+    } catch {}
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   function toggle(key: FilterKey) {
     setOpen(open === key ? null : key);
   }
 
   function navigate(params: { tab: string; writer: string; genre: string; lang: string }) {
     setOpen(null);
+    try { localStorage.setItem("plotlink_lang", params.lang); } catch {}
     router.push(buildHref(params));
   }
 


### PR DESCRIPTION
## Summary
Fixes #275

Saves the user's language filter selection to localStorage and restores it on revisit.

- On language filter change, saves to `localStorage.plotlink_lang`
- On page load with no `lang` URL param (default "all"), reads saved preference and applies it via `router.replace`
- Validates saved value against `LANGUAGES` list before applying
- Falls back to "all" when no saved preference or invalid value

## Test plan
- [ ] Select "Korean" language filter, navigate away, return to home — should show Korean
- [ ] Select "All" language filter — should clear preference (shows all on return)
- [ ] Clear localStorage manually, visit home — should show all languages
- [ ] Direct link with `?lang=French` should override saved preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)