### PR TITLE
[#567] Support non-Farcaster wallet users

### DIFF
--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -15,9 +15,9 @@ import type { Address } from "viem";
 export async function getFarcasterProfile(
   address: string,
 ): Promise<FarcasterProfile | null> {
-  // Try DB first
+  // Try DB first (only if user has a FID — wallet-only users have no Farcaster profile)
   const dbUser = await getUserFromDB(address);
-  if (dbUser) {
+  if (dbUser && dbUser.fid != null) {
     return {
       fid: dbUser.fid,
       username: dbUser.username ?? "",
@@ -41,6 +41,7 @@ export async function fetchAgentMetadata(
 
 /**
  * Look up a user from the DB by wallet address.
+ * Searches verified_addresses first, then primary_address for wallet-only users.
  */
 export async function getUserFromDB(
   address: string,
@@ -50,11 +51,19 @@ export async function getUserFromDB(
 
   const normalized = address.toLowerCase();
 
-  const { data } = await supabase
+  const { data: byVerified } = await supabase
     .from("users")
     .select("*")
     .contains("verified_addresses", [normalized])
     .single();
 
-  return data ?? null;
+  if (byVerified) return byVerified;
+
+  const { data: byPrimary } = await supabase
+    .from("users")
+    .select("*")
+    .eq("primary_address", normalized)
+    .single();
+
+  return byPrimary ?? null;
 }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -394,7 +394,7 @@ export interface Database {
       users: {
       Row: {
         id: string;
-        fid: number;
+        fid: number | null;
         username: string | null;
         display_name: string | null;
         pfp_url: string | null;
@@ -429,7 +429,7 @@ export interface Database {
       };
       Insert: {
         id?: never;
-        fid: number;
+        fid?: number | null;
         username?: string | null;
         display_name?: string | null;
         pfp_url?: string | null;
@@ -464,7 +464,7 @@ export interface Database {
       };
       Update: {
         id?: never;
-        fid?: number;
+        fid?: number | null;
         username?: string | null;
         display_name?: string | null;
         pfp_url?: string | null;

--- a/lib/user-data.ts
+++ b/lib/user-data.ts
@@ -69,12 +69,21 @@ export async function buildUserData(opts: {
     } as UserInsert;
   }
 
+  if (neynarProfile) {
+    return {
+      ...base,
+      fid: neynarProfile.fid,
+      username: neynarProfile.username,
+      display_name: neynarProfile.displayName,
+      pfp_url: neynarProfile.pfpUrl,
+      bio: neynarProfile.bio,
+    } as UserInsert;
+  }
+
+  // Wallet-only user (no Farcaster account)
   return {
     ...base,
-    fid: neynarProfile!.fid,
-    username: neynarProfile!.username,
-    display_name: neynarProfile!.displayName,
-    pfp_url: neynarProfile!.pfpUrl,
-    bio: neynarProfile!.bio,
+    fid: null,
+    primary_address: verifiedAddresses[0] || null,
   } as UserInsert;
 }

--- a/src/app/api/user/onboard/route.ts
+++ b/src/app/api/user/onboard/route.ts
@@ -32,12 +32,23 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Check existing user and cooldown
-    const { data: existingUser } = await supabase
+    // Check existing user (by verified_addresses or primary_address)
+    let existingUser = null;
+    const { data: byVerified } = await supabase
       .from("users")
       .select("*")
       .contains("verified_addresses", [normalizedAddress])
       .single();
+    if (byVerified) {
+      existingUser = byVerified;
+    } else {
+      const { data: byPrimary } = await supabase
+        .from("users")
+        .select("*")
+        .eq("primary_address", normalizedAddress)
+        .single();
+      existingUser = byPrimary;
+    }
 
     // Enforce 5-min cooldown on ALL refreshes
     if (existingUser?.steemhunt_fetched_at) {
@@ -64,14 +75,7 @@ export async function POST(request: NextRequest) {
       neynarProfile = await lookupByAddress(normalizedAddress);
     }
 
-    if (!steemhuntUser && !neynarProfile) {
-      return NextResponse.json(
-        { error: "No Farcaster account found for this wallet." },
-        { status: 404 },
-      );
-    }
-
-    const fid = steemhuntUser?.fid ?? neynarProfile?.fid;
+    const fid = steemhuntUser?.fid ?? neynarProfile?.fid ?? null;
 
     // Build verified addresses
     let verifiedAddresses: string[];
@@ -106,14 +110,14 @@ export async function POST(request: NextRequest) {
       quotientData,
     });
 
-    // Upsert
+    // Upsert — use fid or primary_address as key
     if (existingUser) {
-      const { data, error } = await supabase
-        .from("users")
-        .update(userData)
-        .eq("fid", userData.fid)
-        .select()
-        .single();
+      const updateQuery = supabase.from("users").update(userData);
+      const conditioned =
+        userData.fid != null
+          ? updateQuery.eq("fid", userData.fid)
+          : updateQuery.eq("primary_address", normalizedAddress);
+      const { data, error } = await conditioned.select().single();
 
       if (error) {
         console.error("[onboard] Update error:", error);

--- a/src/app/api/user/onboard/route.ts
+++ b/src/app/api/user/onboard/route.ts
@@ -110,14 +110,14 @@ export async function POST(request: NextRequest) {
       quotientData,
     });
 
-    // Upsert — use fid or primary_address as key
+    // Upsert — update by existing row identity
     if (existingUser) {
-      const updateQuery = supabase.from("users").update(userData);
-      const conditioned =
-        userData.fid != null
-          ? updateQuery.eq("fid", userData.fid)
-          : updateQuery.eq("primary_address", normalizedAddress);
-      const { data, error } = await conditioned.select().single();
+      const { data, error } = await supabase
+        .from("users")
+        .update(userData)
+        .eq("id", existingUser.id)
+        .select()
+        .single();
 
       if (error) {
         console.error("[onboard] Update error:", error);

--- a/src/app/api/user/onboard/route.ts
+++ b/src/app/api/user/onboard/route.ts
@@ -128,20 +128,41 @@ export async function POST(request: NextRequest) {
       }
       return NextResponse.json({ success: true, user: data });
     } else {
-      const { data, error } = await supabase
+      const { data: insertData, error: insertError } = await supabase
         .from("users")
         .insert(userData)
         .select()
         .single();
 
-      if (error) {
-        console.error("[onboard] Insert error:", error);
+      if (insertError) {
+        if (insertError.code === "23505") {
+          // Unique violation — update by conflicting identity
+          const updateQuery = supabase.from("users").update(userData);
+          const conditioned =
+            userData.fid != null
+              ? updateQuery.eq("fid", userData.fid)
+              : updateQuery.eq("primary_address", normalizedAddress);
+
+          const { data: updateData, error: updateError } = await conditioned
+            .select()
+            .single();
+
+          if (updateError) {
+            console.error("[onboard] Update error:", updateError);
+            return NextResponse.json(
+              { error: "Failed to save user data" },
+              { status: 500 },
+            );
+          }
+          return NextResponse.json({ success: true, user: updateData });
+        }
+        console.error("[onboard] Insert error:", insertError);
         return NextResponse.json(
           { error: "Failed to save user data" },
           { status: 500 },
         );
       }
-      return NextResponse.json({ success: true, user: data });
+      return NextResponse.json({ success: true, user: insertData });
     }
   } catch (error) {
     console.error("[onboard] Error:", error);

--- a/src/app/api/user/register-by-wallet/route.ts
+++ b/src/app/api/user/register-by-wallet/route.ts
@@ -111,12 +111,11 @@ export async function POST(request: NextRequest) {
 
     if (insertError) {
       if (insertError.code === "23505") {
-        // Unique violation — update existing by fid or primary_address
+        // Unique violation — update by existing row identity
         const updateQuery = supabase.from("users").update(userData);
-        const conditioned =
-          userData.fid != null
-            ? updateQuery.eq("fid", userData.fid)
-            : updateQuery.eq("primary_address", normalizedAddress);
+        const conditioned = existingUser
+          ? updateQuery.eq("id", existingUser.id)
+          : updateQuery.eq("primary_address", normalizedAddress);
 
         const { data: updateData, error: updateError } = await conditioned
           .select()

--- a/src/app/api/user/register-by-wallet/route.ts
+++ b/src/app/api/user/register-by-wallet/route.ts
@@ -7,8 +7,8 @@ import { buildUserData } from "../../../../../lib/user-data";
 
 /**
  * POST /api/user/register-by-wallet
- * Called on wallet connect — upserts all Farcaster profile fields.
- * SteemHunt primary (free), Neynar fallback (paid).
+ * Called on wallet connect — upserts user profile fields.
+ * Works for both Farcaster and non-Farcaster wallet users.
  */
 export async function POST(request: NextRequest) {
   try {
@@ -31,13 +31,26 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Check if user exists and data is fresh (< 5 min)
-    const { data: existingUser } = await supabase
+    // Check if user exists (by verified_addresses or primary_address)
+    let existingUser = null;
+    const { data: byVerified } = await supabase
       .from("users")
       .select("*")
       .contains("verified_addresses", [normalizedAddress])
       .single();
 
+    if (byVerified) {
+      existingUser = byVerified;
+    } else {
+      const { data: byPrimary } = await supabase
+        .from("users")
+        .select("*")
+        .eq("primary_address", normalizedAddress)
+        .single();
+      existingUser = byPrimary;
+    }
+
+    // If user exists and data is fresh (< 5 min), return cached
     if (existingUser?.steemhunt_fetched_at) {
       const age =
         Date.now() - new Date(existingUser.steemhunt_fetched_at).getTime();
@@ -49,20 +62,10 @@ export async function POST(request: NextRequest) {
     // SteemHunt lookup (primary, free)
     const steemhuntUser = await getUserByWallet(normalizedAddress);
 
-    // Neynar fallback
+    // Neynar fallback (only if SteemHunt found nothing)
     let neynarProfile = null;
     if (!steemhuntUser) {
       neynarProfile = await lookupByAddress(normalizedAddress);
-    }
-
-    if (!steemhuntUser && !neynarProfile) {
-      return NextResponse.json(
-        {
-          error:
-            "No Farcaster account found for this wallet. Please use a wallet linked to your Farcaster account.",
-        },
-        { status: 404 },
-      );
     }
 
     // Build verified addresses
@@ -78,9 +81,9 @@ export async function POST(request: NextRequest) {
       verifiedAddresses.push(normalizedAddress);
     }
 
-    const fid = steemhuntUser?.fid ?? neynarProfile?.fid;
+    const fid = steemhuntUser?.fid ?? neynarProfile?.fid ?? null;
 
-    // Fetch Quotient Score (non-blocking, don't fail if unavailable)
+    // Fetch Quotient Score (non-blocking, only when FID available)
     let quotientData = null;
     if (fid) {
       try {
@@ -108,11 +111,14 @@ export async function POST(request: NextRequest) {
 
     if (insertError) {
       if (insertError.code === "23505") {
-        // Unique violation — update existing
-        const { data: updateData, error: updateError } = await supabase
-          .from("users")
-          .update(userData)
-          .eq("fid", userData.fid)
+        // Unique violation — update existing by fid or primary_address
+        const updateQuery = supabase.from("users").update(userData);
+        const conditioned =
+          userData.fid != null
+            ? updateQuery.eq("fid", userData.fid)
+            : updateQuery.eq("primary_address", normalizedAddress);
+
+        const { data: updateData, error: updateError } = await conditioned
           .select()
           .single();
 

--- a/src/app/api/user/register-by-wallet/route.ts
+++ b/src/app/api/user/register-by-wallet/route.ts
@@ -111,11 +111,13 @@ export async function POST(request: NextRequest) {
 
     if (insertError) {
       if (insertError.code === "23505") {
-        // Unique violation — update by existing row identity
+        // Unique violation — update by the conflicting identity
         const updateQuery = supabase.from("users").update(userData);
         const conditioned = existingUser
           ? updateQuery.eq("id", existingUser.id)
-          : updateQuery.eq("primary_address", normalizedAddress);
+          : userData.fid != null
+            ? updateQuery.eq("fid", userData.fid)
+            : updateQuery.eq("primary_address", normalizedAddress);
 
         const { data: updateData, error: updateError } = await conditioned
           .select()

--- a/supabase/migrations/00028_users_fid_nullable.sql
+++ b/supabase/migrations/00028_users_fid_nullable.sql
@@ -1,0 +1,8 @@
+-- [#567] Make fid nullable for non-Farcaster wallet users
+-- PlotLink must work for ALL wallet users, not just Farcaster.
+
+ALTER TABLE users ALTER COLUMN fid DROP NOT NULL;
+
+-- Unique index on primary_address for wallet-only user upserts
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_primary_address_unique
+  ON users (primary_address) WHERE primary_address IS NOT NULL;


### PR DESCRIPTION
## Summary
- **Migration 00028**: make `fid` nullable, add unique index on `primary_address` for wallet-only user upserts
- **register-by-wallet**: no longer returns 404 for non-Farcaster wallets — creates user record with `fid=NULL`, wallet address stored as `primary_address`
- **buildUserData**: third path for wallet-only users (no SteemHunt, no Neynar)
- **Upsert logic**: uses `primary_address` as key when `fid` is null (both register-by-wallet and onboard routes)
- **User lookup**: `getUserFromDB` and all route lookups now search by `primary_address` as fallback
- **getFarcasterProfile**: skips DB shortcut for wallet-only users so they don't get a broken profile object
- **Supabase types**: `fid` is now `number | null` across Row/Insert/Update
- All existing FID user flows are completely unaffected

Fixes #567

## Test plan
- [ ] Connect a non-Farcaster wallet → verify user record created (fid=NULL)
- [ ] Profile page renders correctly for wallet-only user (truncated address, no FC data)
- [ ] Connect a Farcaster wallet → verify existing behavior unchanged
- [ ] Run migration 00028 against Supabase
- [ ] Verify build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)