### PR TITLE
[#578] Fix story header vertical alignment

### DIFF
--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -251,7 +251,7 @@ function StoryHeader({
       <h1 className="font-body text-2xl font-bold tracking-tight text-accent">
         {storyline.title}
       </h1>
-      <div className="text-muted mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs">
+      <div className="text-muted mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
         <span>
           by{" "}
           <Suspense fallback={<span className="text-foreground">{truncateAddress(storyline.writer_address)}</span>}>


### PR DESCRIPTION
## Summary
Add `items-center` to the StoryHeader metadata flex container so view count (eye icon) and genre/language tags vertically align with other metadata items.

One-line fix: `flex flex-wrap gap-x-4` → `flex flex-wrap items-center gap-x-4`

Fixes #578

## Test plan
- [ ] View any story page — metadata items (author, plots, views, genre, language) all vertically aligned
- [ ] Build passes (`npm run build`)