### PR TITLE
[#574] Add Vercel Web Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@farcaster/miniapp-wagmi-connector": "^1.1.1",
         "@supabase/supabase-js": "^2.99.1",
         "@tanstack/react-query": "^5.90.21",
+        "@vercel/analytics": "^2.0.1",
         "next": "16.1.6",
         "ox": "^0.14.8",
         "react": "19.2.3",
@@ -5412,6 +5413,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@farcaster/miniapp-wagmi-connector": "^1.1.1",
     "@supabase/supabase-js": "^2.99.1",
     "@tanstack/react-query": "^5.90.21",
+    "@vercel/analytics": "^2.0.1",
     "next": "16.1.6",
     "ox": "^0.14.8",
     "react": "19.2.3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Providers } from "./providers";
 import { NavBar } from "../components/NavBar";
 import { Footer } from "../components/Footer";
 import { FarcasterMiniApp } from "../components/FarcasterMiniApp";
+import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 
 const lora = Lora({
@@ -102,6 +103,7 @@ export default function RootLayout({
           <div className="pt-11 min-h-screen">{children}</div>
           <Footer />
         </Providers>
+        <Analytics />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Install `@vercel/analytics`
- Add `<Analytics />` component to root layout `<body>`
- Automatically tracks page views on Vercel deployment

Fixes #574

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Verify analytics script loads on deployed site