### PR TITLE
Overhaul ERC-8004 agent integration

### DIFF
--- a/lib/contracts/erc8004.ts
+++ b/lib/contracts/erc8004.ts
@@ -20,7 +20,7 @@ export interface AgentMetadata {
 }
 
 export const erc8004Abi = [
-  // View
+  // View — reverse lookup wallet → agentId
   {
     type: "function",
     name: "agentIdByWallet",
@@ -28,12 +28,59 @@ export const erc8004Abi = [
     inputs: [{ name: "wallet", type: "address" }],
     outputs: [{ name: "agentId", type: "uint256" }],
   },
+  // View — fetch metadata URI for an agent
   {
     type: "function",
     name: "agentURI",
     stateMutability: "view",
     inputs: [{ name: "agentId", type: "uint256" }],
     outputs: [{ name: "", type: "string" }],
+  },
+  // View — get the bound agent wallet for an agentId
+  {
+    type: "function",
+    name: "getAgentWallet",
+    stateMutability: "view",
+    inputs: [{ name: "agentId", type: "uint256" }],
+    outputs: [{ name: "", type: "address" }],
+  },
+  // View — get arbitrary metadata by key
+  {
+    type: "function",
+    name: "getMetadata",
+    stateMutability: "view",
+    inputs: [
+      { name: "agentId", type: "uint256" },
+      { name: "metadataKey", type: "string" },
+    ],
+    outputs: [{ name: "", type: "bytes" }],
+  },
+  // View — ERC-721: owner of a token (agentId)
+  {
+    type: "function",
+    name: "ownerOf",
+    stateMutability: "view",
+    inputs: [{ name: "tokenId", type: "uint256" }],
+    outputs: [{ name: "owner", type: "address" }],
+  },
+  // View — ERC-721: number of tokens owned by an address
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "owner", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  // View — ERC-721 Enumerable: token at index for owner
+  {
+    type: "function",
+    name: "tokenOfOwnerByIndex",
+    stateMutability: "view",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "index", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
   },
   // Write — register a new agent
   {
@@ -56,6 +103,37 @@ export const erc8004Abi = [
     ],
     outputs: [],
   },
+  // Write — remove agent wallet binding
+  {
+    type: "function",
+    name: "unsetAgentWallet",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "agentId", type: "uint256" }],
+    outputs: [],
+  },
+  // Write — update agent URI (owner/approved only)
+  {
+    type: "function",
+    name: "setAgentURI",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "agentId", type: "uint256" },
+      { name: "newURI", type: "string" },
+    ],
+    outputs: [],
+  },
+  // Write — set arbitrary metadata key/value
+  {
+    type: "function",
+    name: "setMetadata",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "agentId", type: "uint256" },
+      { name: "metadataKey", type: "string" },
+      { name: "metadataValue", type: "bytes" },
+    ],
+    outputs: [],
+  },
   // Event — emitted on successful registration
   {
     type: "event",
@@ -64,6 +142,27 @@ export const erc8004Abi = [
       { name: "agentId", type: "uint256", indexed: true },
       { name: "agentURI", type: "string", indexed: false },
       { name: "owner", type: "address", indexed: true },
+    ],
+  },
+  // Event — emitted when URI is updated
+  {
+    type: "event",
+    name: "URIUpdated",
+    inputs: [
+      { name: "agentId", type: "uint256", indexed: true },
+      { name: "newURI", type: "string", indexed: false },
+      { name: "updatedBy", type: "address", indexed: true },
+    ],
+  },
+  // Event — emitted when metadata is set
+  {
+    type: "event",
+    name: "MetadataSet",
+    inputs: [
+      { name: "agentId", type: "uint256", indexed: true },
+      { name: "indexedMetadataKey", type: "string", indexed: true },
+      { name: "metadataKey", type: "string", indexed: false },
+      { name: "metadataValue", type: "bytes", indexed: false },
     ],
   },
 ] as const;

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -1,17 +1,69 @@
 "use client";
 
 import { useState } from "react";
-import { useAccount } from "wagmi";
+import { useAccount, useReadContract } from "wagmi";
+import { zeroAddress } from "viem";
 import { ConnectWallet } from "../../components/ConnectWallet";
 import { AgentRegister } from "../../components/AgentRegister";
+import { AgentManage } from "../../components/AgentManage";
 import { AgentBuild } from "../../components/AgentBuild";
 import { AgentDashboard } from "../../components/AgentDashboard";
+import { erc8004Abi } from "../../../lib/contracts/erc8004";
+import { ERC8004_REGISTRY } from "../../../lib/contracts/constants";
 
 type Tab = "register" | "build" | "dashboard";
 
 export default function AgentsPage() {
-  const { isConnected } = useAccount();
+  const { isConnected, address } = useAccount();
   const [tab, setTab] = useState<Tab>("register");
+
+  // Check if wallet is bound as an agent wallet
+  const { data: agentIdByWallet, isLoading: walletLoading } = useReadContract({
+    address: ERC8004_REGISTRY,
+    abi: erc8004Abi,
+    functionName: "agentIdByWallet",
+    args: address ? [address] : undefined,
+    query: { enabled: !!address },
+  });
+
+  // Check if wallet owns any agent NFTs (ERC-721 balanceOf)
+  const { data: nftBalance, isLoading: balanceLoading } = useReadContract({
+    address: ERC8004_REGISTRY,
+    abi: erc8004Abi,
+    functionName: "balanceOf",
+    args: address ? [address] : undefined,
+    query: { enabled: !!address },
+  });
+
+  // If owner, get the first owned token ID
+  const hasNft = nftBalance !== undefined && nftBalance > BigInt(0);
+  const { data: ownedTokenId, isLoading: tokenLoading } = useReadContract({
+    address: ERC8004_REGISTRY,
+    abi: erc8004Abi,
+    functionName: "tokenOfOwnerByIndex",
+    args: address ? [address, BigInt(0)] : undefined,
+    query: { enabled: !!address && hasNft },
+  });
+
+  const isAgentWallet = agentIdByWallet !== undefined && agentIdByWallet > BigInt(0);
+  const isOwner = hasNft && ownedTokenId !== undefined;
+  const detectLoading = walletLoading || balanceLoading || (hasNft && tokenLoading);
+
+  // Determine which agentId and role to use
+  let detectedAgentId: bigint | undefined;
+  let detectedRole: "owner" | "agentWallet" | undefined;
+  if (isOwner) {
+    detectedAgentId = ownedTokenId;
+    detectedRole = "owner";
+  } else if (isAgentWallet) {
+    detectedAgentId = agentIdByWallet;
+    detectedRole = "agentWallet";
+  }
+
+  const hasExistingAgent = detectedAgentId !== undefined && detectedRole !== undefined;
+
+  // Determine the label for the first tab
+  const firstTabLabel = hasExistingAgent ? "Manage" : "Register";
 
   return (
     <div className="mx-auto max-w-2xl px-6 py-12">
@@ -34,7 +86,7 @@ export default function AgentsPage() {
                 : "text-muted hover:text-foreground"
             }`}
           >
-            {t === "register" ? "Register" : t === "build" ? "Build" : "Dashboard"}
+            {t === "register" ? firstTabLabel : t === "build" ? "Build" : "Dashboard"}
           </button>
         ))}
       </div>
@@ -43,9 +95,15 @@ export default function AgentsPage() {
       {tab === "register" && (
         !isConnected ? (
           <div className="flex flex-col items-center justify-center gap-4 py-16">
-            <p className="text-muted text-sm">Connect your wallet to register an agent.</p>
+            <p className="text-muted text-sm">Connect your wallet to register or manage an agent.</p>
             <ConnectWallet />
           </div>
+        ) : detectLoading ? (
+          <div className="mt-6 py-8 text-center">
+            <p className="text-muted text-sm">Detecting agent status...</p>
+          </div>
+        ) : hasExistingAgent ? (
+          <AgentManage agentId={detectedAgentId!} role={detectedRole!} />
         ) : (
           <AgentRegister />
         )

--- a/src/components/AgentDashboard.tsx
+++ b/src/components/AgentDashboard.tsx
@@ -51,8 +51,13 @@ export function AgentDashboard() {
   const isAgent = agentId !== undefined;
 
   // Determine the writer address for storyline lookup
-  // If connected as owner, use the bound agent wallet; if connected as agent wallet, use current address
-  const writerAddress = isOwner && boundAgentWallet ? (boundAgentWallet as string) : address;
+  // If connected as owner, prefer the bound agent wallet but fall back to owner address
+  // when the agent wallet is unset (zero address) or missing
+  const hasValidAgentWallet =
+    boundAgentWallet && boundAgentWallet !== "0x0000000000000000000000000000000000000000";
+  const writerAddress = isOwner
+    ? hasValidAgentWallet ? (boundAgentWallet as string) : address
+    : address;
 
   // Fetch agent's storylines from Supabase
   const { data: storylines, isLoading: storylinesLoading } = useQuery({

--- a/src/components/AgentDashboard.tsx
+++ b/src/components/AgentDashboard.tsx
@@ -9,8 +9,8 @@ import { ERC8004_REGISTRY } from "../../lib/contracts/constants";
 export function AgentDashboard() {
   const { address } = useAccount();
 
-  // Check if wallet is registered as an agent
-  const { data: agentId, isLoading: agentIdLoading } = useReadContract({
+  // Check if wallet is registered as an agent wallet
+  const { data: agentIdByWallet, isLoading: walletLoading } = useReadContract({
     address: ERC8004_REGISTRY,
     abi: erc8004Abi,
     functionName: "agentIdByWallet",
@@ -18,21 +18,55 @@ export function AgentDashboard() {
     query: { enabled: !!address },
   });
 
-  const isAgent = agentId !== undefined && agentId > BigInt(0);
+  // Check if wallet owns agent NFTs (owner role)
+  const { data: nftBalance, isLoading: balanceLoading } = useReadContract({
+    address: ERC8004_REGISTRY,
+    abi: erc8004Abi,
+    functionName: "balanceOf",
+    args: address ? [address] : undefined,
+    query: { enabled: !!address },
+  });
+
+  const hasNft = nftBalance !== undefined && nftBalance > BigInt(0);
+  const { data: ownedTokenId, isLoading: tokenLoading } = useReadContract({
+    address: ERC8004_REGISTRY,
+    abi: erc8004Abi,
+    functionName: "tokenOfOwnerByIndex",
+    args: address ? [address, BigInt(0)] : undefined,
+    query: { enabled: !!address && hasNft },
+  });
+
+  // Get the agent wallet for the owned token (to query storylines by that address)
+  const isOwner = hasNft && ownedTokenId !== undefined;
+  const { data: boundAgentWallet } = useReadContract({
+    address: ERC8004_REGISTRY,
+    abi: erc8004Abi,
+    functionName: "getAgentWallet",
+    args: ownedTokenId !== undefined ? [ownedTokenId] : undefined,
+    query: { enabled: isOwner },
+  });
+
+  const isAgentWallet = agentIdByWallet !== undefined && agentIdByWallet > BigInt(0);
+  const agentId = isOwner ? ownedTokenId : isAgentWallet ? agentIdByWallet : undefined;
+  const isAgent = agentId !== undefined;
+
+  // Determine the writer address for storyline lookup
+  // If connected as owner, use the bound agent wallet; if connected as agent wallet, use current address
+  const writerAddress = isOwner && boundAgentWallet ? (boundAgentWallet as string) : address;
 
   // Fetch agent's storylines from Supabase
   const { data: storylines, isLoading: storylinesLoading } = useQuery({
-    queryKey: ["agent-storylines", address],
+    queryKey: ["agent-storylines", writerAddress],
     queryFn: async () => {
-      if (!address) return [];
-      const res = await fetch(`/api/storyline/by-writer?writer=${address}&type=agent`);
+      if (!writerAddress) return [];
+      const res = await fetch(`/api/storyline/by-writer?writer=${writerAddress}&type=agent`);
       if (!res.ok) return [];
       return res.json() as Promise<Array<{ storyline_id: number; title: string; token_address: string; plot_count: number }>>;
     },
-    enabled: !!address && isAgent,
+    enabled: !!writerAddress && isAgent,
   });
 
-  if (agentIdLoading) {
+  if (walletLoading || balanceLoading || (hasNft && tokenLoading)) {
     return (
       <div className="mt-6 py-8 text-center">
         <p className="text-muted text-sm">Loading agent status...</p>
@@ -54,8 +88,15 @@ export function AgentDashboard() {
   return (
     <div className="mt-6">
       <div className="border-accent/30 bg-accent/5 rounded border px-4 py-3 mb-6">
-        <p className="text-accent text-sm font-medium">Agent #{agentId.toString()}</p>
-        <p className="text-muted mt-1 text-xs font-mono">
+        <p className="text-accent text-sm font-medium">Agent #{agentId!.toString()}</p>
+        <p className="text-muted mt-1 text-xs">
+          {isOwner && isAgentWallet
+            ? "Connected as owner + agent wallet"
+            : isOwner
+              ? "Connected as owner"
+              : "Connected as agent wallet"}
+        </p>
+        <p className="text-muted text-xs font-mono">
           {address?.slice(0, 6)}...{address?.slice(-4)}
         </p>
       </div>

--- a/src/components/AgentManage.tsx
+++ b/src/components/AgentManage.tsx
@@ -98,7 +98,26 @@ export function AgentManage({ agentId, role }: AgentManageProps) {
         });
         if (cancelled) return;
         if (!uri) { setMetadata(null); return; }
-        const parsed = JSON.parse(uri as string) as Record<string, unknown>;
+        const uriStr = uri as string;
+        let parsed: Record<string, unknown>;
+        if (uriStr.startsWith("{")) {
+          // Raw JSON stored directly in the URI field
+          parsed = JSON.parse(uriStr);
+        } else if (uriStr.startsWith("data:")) {
+          // data: URI — extract the base64/json payload
+          const comma = uriStr.indexOf(",");
+          const payload = comma >= 0 ? uriStr.slice(comma + 1) : uriStr;
+          parsed = JSON.parse(
+            uriStr.includes("base64") ? atob(payload) : decodeURIComponent(payload),
+          );
+        } else {
+          // https:// or ipfs:// — fetch the metadata JSON
+          const fetchUrl = uriStr.startsWith("ipfs://")
+            ? uriStr.replace("ipfs://", "https://ipfs.io/ipfs/")
+            : uriStr;
+          const res = await fetch(fetchUrl);
+          parsed = (await res.json()) as Record<string, unknown>;
+        }
         setMetadata({
           name: (parsed.name as string) || "Unknown Agent",
           description: (parsed.description as string) || "",

--- a/src/components/AgentManage.tsx
+++ b/src/components/AgentManage.tsx
@@ -1,0 +1,505 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { useAccount, useWriteContract, useReadContract, useSignTypedData } from "wagmi";
+import { type Hex, type Address, zeroAddress } from "viem";
+import { browserClient as publicClient } from "../../lib/rpc";
+import { erc8004Abi, type AgentMetadata } from "../../lib/contracts/erc8004";
+import { ERC8004_REGISTRY, BASE_CHAIN_ID, EXPLORER_URL } from "../../lib/contracts/constants";
+import { Select } from "./Select";
+
+const GENRES = [
+  "Fantasy", "Sci-Fi", "Mystery", "Romance", "Horror",
+  "Thriller", "Literary Fiction", "Comedy", "Historical", "Adventure",
+] as const;
+
+const LLM_MODELS = [
+  "Claude Opus 4", "Claude Sonnet 4", "GPT-5", "GPT-4o",
+  "Gemini 2.5 Pro", "Llama 4 Maverick", "Custom / Other",
+] as const;
+
+const EIP712_DOMAIN = {
+  name: "ERC8004IdentityRegistry",
+  version: "1",
+  chainId: BigInt(BASE_CHAIN_ID),
+  verifyingContract: ERC8004_REGISTRY,
+} as const;
+
+const SET_WALLET_TYPES = {
+  AgentWalletSet: [
+    { name: "agentId", type: "uint256" },
+    { name: "newWallet", type: "address" },
+    { name: "owner", type: "address" },
+    { name: "deadline", type: "uint256" },
+  ],
+} as const;
+
+interface AgentManageProps {
+  agentId: bigint;
+  role: "owner" | "agentWallet";
+}
+
+export function AgentManage({ agentId, role }: AgentManageProps) {
+  const { address } = useAccount();
+  const { writeContractAsync } = useWriteContract();
+  const { signTypedDataAsync } = useSignTypedData();
+
+  const [metadata, setMetadata] = useState<AgentMetadata | null>(null);
+  const [loadingMeta, setLoadingMeta] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [txHash, setTxHash] = useState<Hex | undefined>();
+
+  // Edit state for URI update
+  const [editing, setEditing] = useState(false);
+  const [editName, setEditName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editGenre, setEditGenre] = useState("");
+  const [editLlmModel, setEditLlmModel] = useState("");
+  const [savingUri, setSavingUri] = useState(false);
+
+  // Wallet change state
+  const [changingWallet, setChangingWallet] = useState(false);
+  const [newWalletAddr, setNewWalletAddr] = useState("");
+  const [walletSignature, setWalletSignature] = useState<Hex | undefined>();
+  const [walletDeadline, setWalletDeadline] = useState<bigint | undefined>();
+  const [walletStep, setWalletStep] = useState<"enter" | "sign" | "submit" | null>(null);
+  const [signingWallet, setSigningWallet] = useState(false);
+  const [submittingWallet, setSubmittingWallet] = useState(false);
+
+  // Unset wallet state
+  const [unsettingWallet, setUnsettingWallet] = useState(false);
+
+  // Fetch current agent wallet
+  const { data: currentAgentWallet } = useReadContract({
+    address: ERC8004_REGISTRY,
+    abi: erc8004Abi,
+    functionName: "getAgentWallet",
+    args: [agentId],
+  });
+
+  // Fetch owner of the agent NFT
+  const { data: ownerAddr } = useReadContract({
+    address: ERC8004_REGISTRY,
+    abi: erc8004Abi,
+    functionName: "ownerOf",
+    args: [agentId],
+  });
+
+  // Fetch metadata from URI
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchMeta() {
+      try {
+        const uri = await publicClient.readContract({
+          address: ERC8004_REGISTRY,
+          abi: erc8004Abi,
+          functionName: "agentURI",
+          args: [agentId],
+        });
+        if (cancelled) return;
+        if (!uri) { setMetadata(null); return; }
+        const parsed = JSON.parse(uri as string) as Record<string, unknown>;
+        setMetadata({
+          name: (parsed.name as string) || "Unknown Agent",
+          description: (parsed.description as string) || "",
+          genre: (parsed.genre as string) || undefined,
+          llmModel: (parsed.llmModel as string) || (parsed.model as string) || undefined,
+          registeredBy: (parsed.registeredBy as string) || undefined,
+          registeredAt: (parsed.registeredAt as string) || undefined,
+        });
+      } catch {
+        if (!cancelled) setMetadata(null);
+      } finally {
+        if (!cancelled) setLoadingMeta(false);
+      }
+    }
+    fetchMeta();
+    return () => { cancelled = true; };
+  }, [agentId]);
+
+  // Populate edit fields when metadata loads
+  useEffect(() => {
+    if (metadata) {
+      setEditName(metadata.name);
+      setEditDescription(metadata.description);
+      setEditGenre(metadata.genre ?? "");
+      setEditLlmModel(metadata.llmModel ?? "");
+    }
+  }, [metadata]);
+
+  const isOwner = role === "owner";
+  const editUri = useMemo(() => {
+    if (!editName.trim()) return "";
+    return JSON.stringify({
+      name: editName.trim(),
+      description: editDescription.trim(),
+      genre: editGenre || undefined,
+      llmModel: editLlmModel || undefined,
+      registeredBy: metadata?.registeredBy ?? address,
+      registeredAt: metadata?.registeredAt ?? new Date().toISOString(),
+    });
+  }, [editName, editDescription, editGenre, editLlmModel, metadata, address]);
+
+  async function handleUpdateUri() {
+    if (!editUri) return;
+    try {
+      setError(null);
+      setSavingUri(true);
+      const hash = await writeContractAsync({
+        address: ERC8004_REGISTRY,
+        abi: erc8004Abi,
+        functionName: "setAgentURI",
+        args: [agentId, editUri],
+      });
+      setTxHash(hash);
+      await publicClient.waitForTransactionReceipt({ hash });
+      const parsed = JSON.parse(editUri);
+      setMetadata({ ...metadata!, ...parsed });
+      setEditing(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update URI");
+    } finally {
+      setSavingUri(false);
+    }
+  }
+
+  async function handleUnsetWallet() {
+    try {
+      setError(null);
+      setUnsettingWallet(true);
+      const hash = await writeContractAsync({
+        address: ERC8004_REGISTRY,
+        abi: erc8004Abi,
+        functionName: "unsetAgentWallet",
+        args: [agentId],
+      });
+      setTxHash(hash);
+      await publicClient.waitForTransactionReceipt({ hash });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to unset wallet");
+    } finally {
+      setUnsettingWallet(false);
+    }
+  }
+
+  async function handleSignNewWallet() {
+    if (!newWalletAddr || !address) return;
+    try {
+      setError(null);
+      setSigningWallet(true);
+      const deadline = BigInt(Math.floor(Date.now() / 1000) + 300);
+      const signature = await signTypedDataAsync({
+        domain: EIP712_DOMAIN,
+        types: SET_WALLET_TYPES,
+        primaryType: "AgentWalletSet",
+        message: {
+          agentId,
+          newWallet: newWalletAddr as Address,
+          owner: (ownerAddr ?? address) as Address,
+          deadline,
+        },
+      });
+      setWalletSignature(signature);
+      setWalletDeadline(deadline);
+      setWalletStep("submit");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Signing failed");
+    } finally {
+      setSigningWallet(false);
+    }
+  }
+
+  async function handleSubmitNewWallet() {
+    if (!walletSignature || !walletDeadline || !newWalletAddr) return;
+    try {
+      setError(null);
+      setSubmittingWallet(true);
+      const hash = await writeContractAsync({
+        address: ERC8004_REGISTRY,
+        abi: erc8004Abi,
+        functionName: "setAgentWallet",
+        args: [agentId, newWalletAddr as Address, walletDeadline, walletSignature],
+      });
+      setTxHash(hash);
+      await publicClient.waitForTransactionReceipt({ hash });
+      setWalletStep(null);
+      setChangingWallet(false);
+      setNewWalletAddr("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Wallet binding failed");
+    } finally {
+      setSubmittingWallet(false);
+    }
+  }
+
+  const isNewWalletConnected =
+    address?.toLowerCase() === newWalletAddr.toLowerCase() && newWalletAddr.match(/^0x[a-fA-F0-9]{40}$/);
+  const isOwnerConnected =
+    ownerAddr && address?.toLowerCase() === (ownerAddr as string).toLowerCase();
+
+  if (loadingMeta) {
+    return (
+      <div className="mt-6 py-8 text-center">
+        <p className="text-muted text-sm">Loading agent info...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-6 space-y-6">
+      {/* Agent Info Header */}
+      <div className="border-accent/30 bg-accent/5 rounded border px-4 py-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-accent text-sm font-medium">
+              {metadata?.name ?? "Agent"} #{agentId.toString()}
+            </p>
+            <p className="text-muted mt-0.5 text-xs">
+              {role === "owner" ? "You own this agent" : "Your wallet is bound to this agent"}
+            </p>
+          </div>
+          {isOwner && !editing && (
+            <button
+              onClick={() => setEditing(true)}
+              className="border-border text-muted hover:text-foreground rounded border px-3 py-1 text-xs transition-colors"
+            >
+              Edit
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="border-error/30 text-error rounded border px-3 py-2 text-xs">{error}</div>
+      )}
+
+      {txHash && (
+        <div className="border-border text-muted rounded border px-3 py-2 text-xs">
+          Tx:{" "}
+          <a
+            href={`${EXPLORER_URL}/tx/${txHash}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            {txHash.slice(0, 10)}...{txHash.slice(-8)}
+          </a>
+        </div>
+      )}
+
+      {/* View / Edit Metadata */}
+      {editing ? (
+        <div className="space-y-4">
+          <div>
+            <label className="text-foreground mb-2 block text-sm">Agent Name</label>
+            <input
+              type="text"
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              className="border-border bg-surface text-foreground w-full rounded border px-3 py-2 text-sm focus:border-accent focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="text-foreground mb-2 block text-sm">Description</label>
+            <textarea
+              value={editDescription}
+              onChange={(e) => setEditDescription(e.target.value)}
+              rows={3}
+              className="border-border bg-surface text-foreground w-full resize-y rounded border px-3 py-2 text-sm leading-relaxed focus:border-accent focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="text-foreground mb-2 block text-sm">Primary Genre</label>
+            <Select value={editGenre} onChange={setEditGenre} placeholder="Select genre..." options={GENRES.map((g) => ({ value: g, label: g }))} />
+          </div>
+          <div>
+            <label className="text-foreground mb-2 block text-sm">LLM Model</label>
+            <Select value={editLlmModel} onChange={setEditLlmModel} placeholder="Select model..." options={LLM_MODELS.map((m) => ({ value: m, label: m }))} />
+          </div>
+          <div className="flex gap-3">
+            <button
+              onClick={() => setEditing(false)}
+              disabled={savingUri}
+              className="border-border text-muted hover:text-foreground rounded border px-4 py-2 text-sm transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleUpdateUri}
+              disabled={savingUri || !editName.trim()}
+              className="border-accent text-accent hover:bg-accent hover:text-background flex-1 rounded border py-2 text-sm font-medium transition-colors disabled:opacity-50"
+            >
+              {savingUri ? "Saving..." : "Update Agent URI"}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {metadata?.description && (
+            <p className="text-foreground text-sm leading-relaxed">{metadata.description}</p>
+          )}
+          <div className="flex flex-wrap gap-3 text-xs">
+            {metadata?.genre && (
+              <span className="border-border text-muted rounded border px-2 py-1">{metadata.genre}</span>
+            )}
+            {metadata?.llmModel && (
+              <span className="border-border text-muted rounded border px-2 py-1">{metadata.llmModel}</span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Wallet Info */}
+      <div className="border-border rounded border divide-y divide-[var(--border)]">
+        <div className="px-4 py-3">
+          <p className="text-muted text-xs mb-1">Owner Wallet</p>
+          <p className="text-foreground text-xs font-mono break-all">
+            {ownerAddr ? (ownerAddr as string) : "—"}
+          </p>
+        </div>
+        <div className="px-4 py-3">
+          <p className="text-muted text-xs mb-1">Agent Wallet</p>
+          <p className="text-foreground text-xs font-mono break-all">
+            {currentAgentWallet && currentAgentWallet !== zeroAddress
+              ? (currentAgentWallet as string)
+              : "Not set"}
+          </p>
+        </div>
+      </div>
+
+      {/* Owner-only management actions */}
+      {isOwner && !editing && (
+        <div className="space-y-3">
+          {/* Change Agent Wallet */}
+          {!changingWallet ? (
+            <div className="flex gap-3">
+              <button
+                onClick={() => { setChangingWallet(true); setWalletStep("enter"); setError(null); }}
+                className="border-border text-muted hover:text-foreground flex-1 rounded border py-2 text-xs transition-colors"
+              >
+                {currentAgentWallet && currentAgentWallet !== zeroAddress ? "Change" : "Set"} Agent Wallet
+              </button>
+              {currentAgentWallet && currentAgentWallet !== zeroAddress && (
+                <button
+                  onClick={handleUnsetWallet}
+                  disabled={unsettingWallet}
+                  className="border-border text-muted hover:text-error rounded border px-4 py-2 text-xs transition-colors disabled:opacity-50"
+                >
+                  {unsettingWallet ? "Unsetting..." : "Unset Wallet"}
+                </button>
+              )}
+            </div>
+          ) : (
+            <div className="border-border rounded border p-4 space-y-4">
+              {walletStep === "enter" && (
+                <>
+                  <div>
+                    <label className="text-foreground mb-2 block text-sm">New Agent Wallet Address</label>
+                    <input
+                      type="text"
+                      value={newWalletAddr}
+                      onChange={(e) => setNewWalletAddr(e.target.value)}
+                      placeholder="0x..."
+                      className="border-border bg-surface text-foreground placeholder:text-muted w-full rounded border px-3 py-2 text-sm font-mono focus:border-accent focus:outline-none"
+                    />
+                  </div>
+                  <p className="text-muted text-xs leading-relaxed">
+                    The new agent wallet must sign an EIP-712 message. Switch to that wallet and sign within 5 minutes.
+                  </p>
+                  <div className="flex gap-3">
+                    <button
+                      onClick={() => { setChangingWallet(false); setWalletStep(null); setNewWalletAddr(""); }}
+                      className="border-border text-muted hover:text-foreground rounded border px-4 py-2 text-xs transition-colors"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={() => setWalletStep("sign")}
+                      disabled={!newWalletAddr.match(/^0x[a-fA-F0-9]{40}$/)}
+                      className="border-accent text-accent hover:bg-accent hover:text-background flex-1 rounded border py-2 text-xs font-medium transition-colors disabled:opacity-50"
+                    >
+                      Continue
+                    </button>
+                  </div>
+                </>
+              )}
+
+              {walletStep === "sign" && (
+                <>
+                  <div className="border-border bg-surface rounded border px-4 py-3 space-y-2">
+                    <p className="text-foreground text-sm font-medium">Switch to the new agent wallet</p>
+                    <p className="text-accent text-xs font-mono break-all">{newWalletAddr}</p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className={`h-2 w-2 rounded-full ${isNewWalletConnected ? "bg-accent" : "bg-border"}`} />
+                    <span className="text-muted text-xs">
+                      {isNewWalletConnected ? (
+                        <span className="text-accent">New wallet connected. Ready to sign.</span>
+                      ) : (
+                        <>Currently: <code className="text-foreground font-mono">{address?.slice(0, 6)}...{address?.slice(-4)}</code></>
+                      )}
+                    </span>
+                  </div>
+                  <div className="flex gap-3">
+                    <button
+                      onClick={() => setWalletStep("enter")}
+                      disabled={signingWallet}
+                      className="border-border text-muted hover:text-foreground rounded border px-4 py-2 text-xs transition-colors disabled:opacity-50"
+                    >
+                      Back
+                    </button>
+                    <button
+                      onClick={handleSignNewWallet}
+                      disabled={signingWallet || !isNewWalletConnected}
+                      className="border-accent text-accent hover:bg-accent hover:text-background flex-1 rounded border py-2 text-xs font-medium transition-colors disabled:opacity-50"
+                    >
+                      {signingWallet ? "Signing..." : "Sign with New Wallet"}
+                    </button>
+                  </div>
+                </>
+              )}
+
+              {walletStep === "submit" && (
+                <>
+                  <div className="border-accent/30 bg-accent/5 rounded border px-4 py-3">
+                    <p className="text-accent text-sm font-medium">Signature obtained</p>
+                  </div>
+                  <div className="border-border bg-surface rounded border px-4 py-3 space-y-2">
+                    <p className="text-foreground text-sm font-medium">Switch back to the owner wallet</p>
+                    <p className="text-accent text-xs font-mono break-all">{ownerAddr as string}</p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className={`h-2 w-2 rounded-full ${isOwnerConnected ? "bg-accent" : "bg-border"}`} />
+                    <span className="text-muted text-xs">
+                      {isOwnerConnected ? (
+                        <span className="text-accent">Owner wallet connected. Ready to submit.</span>
+                      ) : (
+                        <>Currently: <code className="text-foreground font-mono">{address?.slice(0, 6)}...{address?.slice(-4)}</code></>
+                      )}
+                    </span>
+                  </div>
+                  <div className="flex gap-3">
+                    <button
+                      onClick={() => { setChangingWallet(false); setWalletStep(null); }}
+                      disabled={submittingWallet}
+                      className="border-border text-muted hover:text-foreground rounded border px-4 py-2 text-xs transition-colors disabled:opacity-50"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={handleSubmitNewWallet}
+                      disabled={submittingWallet || !isOwnerConnected}
+                      className="border-accent text-accent hover:bg-accent hover:text-background flex-1 rounded border py-2 text-xs font-medium transition-colors disabled:opacity-50"
+                    >
+                      {submittingWallet ? "Binding..." : "Submit Binding Transaction"}
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/AgentRegister.tsx
+++ b/src/components/AgentRegister.tsx
@@ -109,7 +109,7 @@ export function AgentRegister() {
     try {
       setError(null);
       setSigning(true);
-      const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600);
+      const deadline = BigInt(Math.floor(Date.now() / 1000) + 300);
       const signature = await signTypedDataAsync({
         domain: EIP712_DOMAIN,
         types: SET_WALLET_TYPES,


### PR DESCRIPTION
## Summary
Fixes #583

- **CRITICAL fix**: Wallet binding deadline reduced from 3600s (1 hour) to 300s (5 minutes) to match contract's max deadline enforcement
- **ABI additions**: `getAgentWallet`, `unsetAgentWallet`, `setAgentURI`, `setMetadata`, `getMetadata`, `ownerOf`, `balanceOf`, `tokenOfOwnerByIndex`, plus `URIUpdated` and `MetadataSet` events
- **Existing agent detection**: On `/agents` page load, checks both `agentIdByWallet()` (bound agent wallet) and `balanceOf()` + `tokenOfOwnerByIndex()` (NFT owner) to detect registered agents
- **Owner vs agent wallet distinction**: Owner wallets that hold the AGENT NFT but have a separate bound wallet now correctly see their agent in Dashboard and Management UI
- **New `AgentManage` component**: View agent info, update URI metadata, change/unset agent wallet — all with correct 5-minute EIP-712 deadlines
- **Registration guard**: Existing agents see management UI instead of registration form; tab label changes from "Register" to "Manage"

## Test plan
- [ ] Verify wallet binding uses 300s deadline (was 3600s)
- [ ] Connect an owner wallet that holds an AGENT NFT → should see "Manage" tab with agent info
- [ ] Connect a bound agent wallet → should see management UI with "agentWallet" role
- [ ] Connect an unregistered wallet → should see registration form
- [ ] Test Update URI flow (owner only)
- [ ] Test Change Agent Wallet flow (EIP-712 sign + submit)
- [ ] Test Unset Agent Wallet button
- [ ] Dashboard shows storylines for both owner and agent wallet connections
- [ ] Build passes (`tsc --noEmit` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)