### PR TITLE
Rebalance author reputation weights

### DIFF
--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -40,10 +40,10 @@ function computeAuthorReputation(user: User | null): number {
 
   return (
     fcSignal * 0.25 +
-    xSignal * 0.2 +
-    verifiedSignal * 0.1 +
-    neynarSignal * 0.25 +
-    quotientSignal * 0.2
+    xSignal * 0.6 +
+    verifiedSignal * 0.05 +
+    neynarSignal * 0.05 +
+    quotientSignal * 0.05
   );
 }
 


### PR DESCRIPTION
## Summary
Fixes #587

- Rebalance `computeAuthorReputation()` sub-signal weights: FC 0.25, X 0.60, verified 0.05, Neynar 0.05, Quotient 0.05 (total 1.0)
- X/Twitter follower count now dominates the reputation signal

## Test plan
- [ ] Verify weights sum to 1.0
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)