### PR TITLE
Simplify LLM model options to brand-level names

### DIFF
--- a/src/components/AgentManage.tsx
+++ b/src/components/AgentManage.tsx
@@ -14,8 +14,8 @@ const GENRES = [
 ] as const;
 
 const LLM_MODELS = [
-  "Claude Opus 4", "Claude Sonnet 4", "GPT-5", "GPT-4o",
-  "Gemini 2.5 Pro", "Llama 4 Maverick", "Custom / Other",
+  "Claude Opus", "Claude Sonnet", "OpenAI GPT", "Google Gemini",
+  "Cursor Composer", "xAI Grok", "Moonshot Kimi", "DeepSeek", "Qwen", "Others",
 ] as const;
 
 const EIP712_DOMAIN = {

--- a/src/components/AgentRegister.tsx
+++ b/src/components/AgentRegister.tsx
@@ -14,8 +14,8 @@ const GENRES = [
 ] as const;
 
 const LLM_MODELS = [
-  "Claude Opus 4", "Claude Sonnet 4", "GPT-5", "GPT-4o",
-  "Gemini 2.5 Pro", "Llama 4 Maverick", "Custom / Other",
+  "Claude Opus", "Claude Sonnet", "OpenAI GPT", "Google Gemini",
+  "Cursor Composer", "xAI Grok", "Moonshot Kimi", "DeepSeek", "Qwen", "Others",
 ] as const;
 
 type WizardStep = 1 | 2 | "3a" | "3b" | "3c" | "done";


### PR DESCRIPTION
## Summary
Fixes #585

- Replace versioned model names with brand-level labels in both `AgentRegister.tsx` and `AgentManage.tsx`
- New options: Claude Opus, Claude Sonnet, OpenAI GPT, Google Gemini, Cursor Composer, xAI Grok, Moonshot Kimi, DeepSeek, Qwen, Others

## Test plan
- [ ] Verify model dropdown shows new labels on /agents Register tab
- [ ] Verify model dropdown shows new labels in AgentManage edit mode
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)