### PR TITLE
Add Agent Identity card to profile trust dashboard

### DIFF
--- a/lib/contracts/erc8004.ts
+++ b/lib/contracts/erc8004.ts
@@ -11,6 +11,8 @@ import { ERC8004_REGISTRY } from "./constants";
  * reverse lookup.
  */
 export interface AgentMetadata {
+  agentId?: string;
+  owner?: string;
   name: string;
   description: string;
   genre?: string;
@@ -209,16 +211,26 @@ export async function getAgentMetadata(
     });
     if (agentId <= BigInt(0)) return null;
 
-    const uri = await publicClient.readContract({
-      address: ERC8004_REGISTRY,
-      abi: erc8004Abi,
-      functionName: "agentURI",
-      args: [agentId],
-    });
+    const [uri, owner] = await Promise.all([
+      publicClient.readContract({
+        address: ERC8004_REGISTRY,
+        abi: erc8004Abi,
+        functionName: "agentURI",
+        args: [agentId],
+      }),
+      publicClient.readContract({
+        address: ERC8004_REGISTRY,
+        abi: erc8004Abi,
+        functionName: "ownerOf",
+        args: [agentId],
+      }).catch(() => undefined),
+    ]);
     if (!uri) return null;
 
     const parsed = JSON.parse(uri as string) as Record<string, unknown>;
     return {
+      agentId: agentId.toString(),
+      owner: owner as string | undefined,
       name: (parsed.name as string) || "Unknown Agent",
       description: (parsed.description as string) || "",
       genre: (parsed.genre as string) || undefined,

--- a/lib/contracts/erc8004.ts
+++ b/lib/contracts/erc8004.ts
@@ -196,6 +196,29 @@ export async function detectWriterType(
 }
 
 /**
+ * Resolve an agent URI string to a parsed JSON object.
+ * Handles raw JSON, data: URIs (base64 + URL-encoded), https://, and ipfs://.
+ */
+export async function resolveAgentURI(uri: string): Promise<Record<string, unknown>> {
+  if (uri.startsWith("{")) {
+    return JSON.parse(uri);
+  }
+  if (uri.startsWith("data:")) {
+    const comma = uri.indexOf(",");
+    const payload = comma >= 0 ? uri.slice(comma + 1) : uri;
+    return JSON.parse(
+      uri.includes("base64") ? atob(payload) : decodeURIComponent(payload),
+    );
+  }
+  // https:// or ipfs://
+  const fetchUrl = uri.startsWith("ipfs://")
+    ? uri.replace("ipfs://", "https://ipfs.io/ipfs/")
+    : uri;
+  const res = await fetch(fetchUrl);
+  return (await res.json()) as Record<string, unknown>;
+}
+
+/**
  * Resolve ERC-8004 agent metadata from an Ethereum address.
  * Returns null if the address is not a registered agent or on any error.
  */
@@ -227,7 +250,7 @@ export async function getAgentMetadata(
     ]);
     if (!uri) return null;
 
-    const parsed = JSON.parse(uri as string) as Record<string, unknown>;
+    const parsed = await resolveAgentURI(uri as string);
     return {
       agentId: agentId.toString(),
       owner: owner as string | undefined,

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -372,6 +372,59 @@ function ProfileHeader({
           </div>
         )}
 
+        {/* Agent Identity card — shown for registered agents */}
+        {isAgent && agentMeta && (
+          <div className="border-border rounded border p-3">
+            <span className="text-muted text-[10px] font-medium uppercase tracking-wider">Agent Identity</span>
+            <div className="mt-1.5 space-y-1.5">
+              {agentMeta.agentId && (
+                <div className="text-xs">
+                  <span className="text-muted">Agent ID: </span>
+                  <span className="text-foreground font-mono font-medium">{agentMeta.agentId}</span>
+                </div>
+              )}
+              <div className="text-xs">
+                <span className="text-muted">Name: </span>
+                <span className="text-foreground font-medium">{agentMeta.name}</span>
+              </div>
+              {agentMeta.description && (
+                <div className="text-xs">
+                  <span className="text-muted">Description: </span>
+                  <span className="text-foreground">{agentMeta.description}</span>
+                </div>
+              )}
+              {agentMeta.llmModel && (
+                <div className="text-xs">
+                  <span className="text-muted">Model: </span>
+                  <span className="text-foreground font-medium">{agentMeta.llmModel}</span>
+                </div>
+              )}
+              {agentMeta.genre && (
+                <div className="text-xs">
+                  <span className="text-muted">Genre: </span>
+                  <span className="text-foreground">{agentMeta.genre}</span>
+                </div>
+              )}
+              {agentMeta.registeredAt && (
+                <div className="text-xs">
+                  <span className="text-muted">Registered: </span>
+                  <span className="text-foreground">
+                    {new Date(agentMeta.registeredAt).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
+                  </span>
+                </div>
+              )}
+              {agentMeta.owner && agentMeta.owner.toLowerCase() !== address.toLowerCase() && (
+                <div className="text-xs">
+                  <span className="text-muted">Owner: </span>
+                  <Link href={`/profile/${agentMeta.owner}`} className="text-accent hover:underline font-mono text-[11px]">
+                    {agentMeta.owner.slice(0, 6)}...{agentMeta.owner.slice(-4)}
+                  </Link>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
         {/* Wallet identity card — always shown */}
         <div className="border-border rounded border p-3">
           <span className="text-muted text-[10px] font-medium uppercase tracking-wider">Wallet</span>

--- a/src/components/AgentManage.tsx
+++ b/src/components/AgentManage.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo } from "react";
 import { useAccount, useWriteContract, useReadContract, useSignTypedData } from "wagmi";
 import { type Hex, type Address, zeroAddress } from "viem";
 import { browserClient as publicClient } from "../../lib/rpc";
-import { erc8004Abi, type AgentMetadata } from "../../lib/contracts/erc8004";
+import { erc8004Abi, resolveAgentURI, type AgentMetadata } from "../../lib/contracts/erc8004";
 import { ERC8004_REGISTRY, BASE_CHAIN_ID, EXPLORER_URL } from "../../lib/contracts/constants";
 import { Select } from "./Select";
 
@@ -98,26 +98,7 @@ export function AgentManage({ agentId, role }: AgentManageProps) {
         });
         if (cancelled) return;
         if (!uri) { setMetadata(null); return; }
-        const uriStr = uri as string;
-        let parsed: Record<string, unknown>;
-        if (uriStr.startsWith("{")) {
-          // Raw JSON stored directly in the URI field
-          parsed = JSON.parse(uriStr);
-        } else if (uriStr.startsWith("data:")) {
-          // data: URI — extract the base64/json payload
-          const comma = uriStr.indexOf(",");
-          const payload = comma >= 0 ? uriStr.slice(comma + 1) : uriStr;
-          parsed = JSON.parse(
-            uriStr.includes("base64") ? atob(payload) : decodeURIComponent(payload),
-          );
-        } else {
-          // https:// or ipfs:// — fetch the metadata JSON
-          const fetchUrl = uriStr.startsWith("ipfs://")
-            ? uriStr.replace("ipfs://", "https://ipfs.io/ipfs/")
-            : uriStr;
-          const res = await fetch(fetchUrl);
-          parsed = (await res.json()) as Record<string, unknown>;
-        }
+        const parsed = await resolveAgentURI(uri as string);
         setMetadata({
           name: (parsed.name as string) || "Unknown Agent",
           description: (parsed.description as string) || "",


### PR DESCRIPTION
## Summary
Fixes #586

- New **Agent Identity** card in the profile trust dashboard grid for registered agents (writer_type=1)
- Displays: Agent ID, name, description, LLM model, genre, registration date
- Shows owner wallet link when different from the bound agent wallet (cross-wallet visibility)
- Extends `AgentMetadata` interface with `agentId` and `owner` fields, fetched in parallel via `ownerOf()`
- Non-agent profiles completely unaffected — card only renders when `isAgent && agentMeta` is truthy
- Matches existing trust dashboard card styling (border-border, text sizing, label/value pattern)

## Test plan
- [ ] Visit an agent profile → Agent Identity card appears with all available fields
- [ ] Visit a human profile → no Agent Identity card
- [ ] Agent with owner different from bound wallet → "Owner" row shows with link
- [ ] Agent where viewer IS the owner → "Owner" row omitted
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)