### PR TITLE
Fix Farcaster web share embed rendering

### DIFF
--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -44,9 +44,8 @@ export function ShareButtons({ storylineId, title }: ShareButtonsProps) {
         // Fall through to intent URL
       }
     }
-    const fullText = `${shareText}\n${storyUrl}`;
     window.open(
-      `https://farcaster.xyz/~/compose?text=${encodeURIComponent(fullText)}`,
+      `https://farcaster.xyz/~/compose?text=${encodeURIComponent(shareText)}&embeds[]=${encodeURIComponent(storyUrl)}`,
       "_blank",
     );
   }, [platform, shareText, storyUrl]);


### PR DESCRIPTION
## Summary
Fixes #598

- Farcaster web compose fallback now uses `embeds[]` query parameter for the story URL instead of appending it to the text body
- Enables proper link preview/embed rendering when sharing via web
- Miniapp SDK `composeCast` path unchanged (already uses `embeds` array)
- X/Twitter share unchanged (URL in text body is the standard pattern)

## Test plan
- [ ] Share to Farcaster via web → story URL renders as embed preview, not inline text
- [ ] Share to Farcaster via miniapp → still works (SDK path unchanged)
- [ ] Share to X → URL still appears in tweet text
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)