### PR TITLE
Clean up token page and show USD balance

### DIFF
--- a/src/app/token/page.tsx
+++ b/src/app/token/page.tsx
@@ -75,6 +75,14 @@ export default function TokenPage() {
               })}{" "}
               <span className="text-background/80">PLOT</span>
             </div>
+            {tokenInfo?.price && parseFloat(formattedBalance) > 0 && (
+              <div className="text-background/60 mt-1 text-sm">
+                ${(parseFloat(formattedBalance) * tokenInfo.price).toLocaleString(undefined, {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })} USD
+              </div>
+            )}
           </div>
         )}
       </div>
@@ -106,31 +114,6 @@ export default function TokenPage() {
 
       {/* Swap Interface */}
       <SwapInterface />
-
-      {/* How to Get PLOT */}
-      <div className="border-border rounded border p-5">
-        <h3 className="text-foreground text-sm font-bold mb-3">How to Get PLOT</h3>
-        <div className="space-y-2">
-          <div className="flex items-start gap-3">
-            <span className="text-accent text-sm">&#8226;</span>
-            <p className="text-muted text-sm">
-              <span className="text-foreground font-semibold">Buy via Mint Club</span> — purchase PLOT on the bonding curve using HUNT tokens.
-            </p>
-          </div>
-          <div className="flex items-start gap-3">
-            <span className="text-accent text-sm">&#8226;</span>
-            <p className="text-muted text-sm">
-              <span className="text-foreground font-semibold">Sell story tokens</span> — selling any storyline token returns PLOT to your wallet.
-            </p>
-          </div>
-          <div className="flex items-start gap-3">
-            <span className="text-accent text-sm">&#8226;</span>
-            <p className="text-muted text-sm">
-              <span className="text-foreground font-semibold">Use the Zap</span> — buy story tokens with ETH or HUNT and the zap contract handles PLOT conversion automatically.
-            </p>
-          </div>
-        </div>
-      </div>
 
       {/* Token Information */}
       <div className="border-border rounded border p-5">


### PR DESCRIPTION
## Summary
Fixes #595

- **Remove "How to Get PLOT" section** — redundant with the swap interface and external links already on the page
- **Add USD equivalent** below the PLOT balance amount, calculated from `tokenInfo.price * balance`. Only shown when balance > 0 and price data is available. Styled as `text-background/60` to stay subtle within the accent card.

## Test plan
- [ ] Token page no longer shows "How to Get PLOT" section
- [ ] Connected wallet with PLOT balance shows USD value below the PLOT amount
- [ ] Zero balance does not show USD line
- [ ] Disconnected wallet shows "Connect your wallet" (unchanged)
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)