### PR TITLE
Fix miniapp bottom padding with platform detection

### DIFF
--- a/src/components/MobileActionBar.tsx
+++ b/src/components/MobileActionBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, type ReactNode } from "react";
+import { usePlatformDetection } from "../hooks/usePlatformDetection";
 
 type Panel = "trade" | "donate" | "rate" | null;
 
@@ -14,6 +15,7 @@ export function MobileActionBar({
   rateContent?: ReactNode;
 }) {
   const [open, setOpen] = useState<Panel>(null);
+  const { isMiniApp } = usePlatformDetection();
 
   const buttons: { key: Panel; label: string; content?: ReactNode }[] = [
     { key: "trade", label: "Trade", content: tradeContent },
@@ -33,7 +35,7 @@ export function MobileActionBar({
 
       {/* Bottom sheet */}
       {open && (
-        <div className="fixed inset-x-0 bottom-0 z-50 max-h-[80vh] overflow-y-auto rounded-t-lg border-t border-[var(--border)] bg-[var(--bg)] p-4 pb-[calc(1rem+env(safe-area-inset-bottom))]">
+        <div className={`fixed inset-x-0 bottom-0 z-50 max-h-[80vh] overflow-y-auto rounded-t-lg border-t border-[var(--border)] bg-[var(--bg)] p-4 ${isMiniApp ? "pb-10" : "pb-[calc(1rem+env(safe-area-inset-bottom))]"}`}>
           <div className="mb-3 flex items-center justify-between">
             <span className="text-foreground text-sm font-medium capitalize">
               {open}
@@ -52,7 +54,7 @@ export function MobileActionBar({
       )}
 
       {/* Fixed bottom bar */}
-      <div className="fixed inset-x-0 bottom-0 z-30 grid grid-cols-3 gap-2 border-t border-[var(--border)] bg-[var(--bg)]/95 px-3 pt-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] backdrop-blur-sm">
+      <div className={`fixed inset-x-0 bottom-0 z-30 grid grid-cols-3 gap-2 border-t border-[var(--border)] bg-[var(--bg)]/95 px-3 pt-3 ${isMiniApp ? "pb-8" : "pb-[calc(0.75rem+env(safe-area-inset-bottom))]"} backdrop-blur-sm`}>
         {buttons.map(({ key, label }) => (
           <button
             key={key}

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from "react";
 import { StoryContent } from "./StoryContent";
+import { usePlatformDetection } from "../hooks/usePlatformDetection";
 
 interface Chapter {
   plotIndex: number;
@@ -27,6 +28,7 @@ export function ReadingMode({
   const [currentIdx, setCurrentIdx] = useState(initialChapterIndex);
   const [showToc, setShowToc] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
+  const { isMiniApp } = usePlatformDetection();
 
   const chapter = chapters[currentIdx];
   const hasPrev = currentIdx > 0;
@@ -115,7 +117,7 @@ export function ReadingMode({
 
       {/* Bottom navigation */}
       <nav
-        className="flex items-center justify-between px-4 pt-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] sm:px-6"
+        className={`flex items-center justify-between px-4 pt-3 ${isMiniApp ? "pb-8" : "pb-[calc(0.75rem+env(safe-area-inset-bottom))]"} sm:px-6`}
         style={{ borderTop: "1px solid var(--border)" }}
       >
         {hasPrev ? (


### PR DESCRIPTION
## Summary
Fixes #608

- Use `usePlatformDetection()` hook to detect miniapp environments instead of relying on `env(safe-area-inset-bottom)` which returns 0 in Farcaster/Base webviews
- **MobileActionBar fixed bar**: `pb-8` when `isMiniApp`, else existing safe-area padding
- **MobileActionBar bottom sheet**: `pb-10` when `isMiniApp`, else existing safe-area padding
- **ReadingMode bottom nav**: `pb-8` when `isMiniApp`, else existing safe-area padding
- Regular mobile browser and desktop layouts unaffected (safe-area fallback preserved)

## Test plan
- [ ] Farcaster miniapp: MobileActionBar buttons fully visible with extra padding
- [ ] Farcaster miniapp: Reading Mode prev/contents/next fully visible
- [ ] Base App: same bottom UI fully visible
- [ ] Regular mobile browser: no extra padding (uses safe-area-inset)
- [ ] Desktop: no layout change
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)