### PR TITLE
Fix Reading Mode duplicate genesis

### DIFF
--- a/src/app/story/[storylineId]/[plotIndex]/page.tsx
+++ b/src/app/story/[storylineId]/[plotIndex]/page.tsx
@@ -11,6 +11,22 @@ import { StoryContent } from "../../../../components/StoryContent";
 import { ReadingModeWrapper } from "../../../../components/ReadingModeWrapper";
 import Link from "next/link";
 
+/** Deduplicate plots by plot_index, keeping the first occurrence. */
+function deduplicateByPlotIndex(plots: { plot_index: number; title: string; content: string | null }[]) {
+  const seen = new Set<number>();
+  return plots
+    .filter((p) => {
+      if (seen.has(p.plot_index)) return false;
+      seen.add(p.plot_index);
+      return true;
+    })
+    .map((p) => ({
+      plotIndex: p.plot_index,
+      title: p.title || (p.plot_index === 0 ? "Genesis" : `Chapter ${p.plot_index}`),
+      content: p.content,
+    }));
+}
+
 type Params = Promise<{ storylineId: string; plotIndex: string }>;
 
 const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
@@ -112,11 +128,7 @@ export default async function PlotDetailPage({ params }: { params: Params }) {
           <ReadingModeWrapper
             storylineId={sid}
             storylineTitle={sl.title}
-            chapters={allPlots.map((ap) => ({
-              plotIndex: ap.plot_index,
-              title: ap.title || (ap.plot_index === 0 ? "Genesis" : `Chapter ${ap.plot_index}`),
-              content: ap.content,
-            }))}
+            chapters={deduplicateByPlotIndex(allPlots)}
             initialPlotIndex={pidx}
           />
         </div>

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -24,6 +24,22 @@ import { CommentSection } from "../../../components/CommentSection";
 import { MobileActionBar } from "../../../components/MobileActionBar";
 import { UsdPriceTag } from "../../../components/UsdPriceTag";
 
+/** Deduplicate plots by plot_index, keeping the first occurrence. */
+function deduplicateByPlotIndex(plots: Plot[]) {
+  const seen = new Set<number>();
+  return plots
+    .filter((p) => {
+      if (seen.has(p.plot_index)) return false;
+      seen.add(p.plot_index);
+      return true;
+    })
+    .map((p) => ({
+      plotIndex: p.plot_index,
+      title: p.title || (p.plot_index === 0 ? "Genesis" : `Chapter ${p.plot_index}`),
+      content: p.content,
+    }));
+}
+
 type Params = Promise<{ storylineId: string }>;
 
 const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
@@ -157,11 +173,7 @@ export default async function StoryPage({ params }: { params: Params }) {
                   <ReadingModeWrapper
                     storylineId={id}
                     storylineTitle={sl.title}
-                    chapters={plots.map((p) => ({
-                      plotIndex: p.plot_index,
-                      title: p.title || (p.plot_index === 0 ? "Genesis" : `Chapter ${p.plot_index}`),
-                      content: p.content,
-                    }))}
+                    chapters={deduplicateByPlotIndex(plots)}
                     initialPlotIndex={0}
                   />
                 }


### PR DESCRIPTION
## Summary
Fixes #609

- Add `deduplicateByPlotIndex()` helper that filters duplicate `plot_index` entries, keeping the first occurrence
- Applied on both story page and chapter detail page before passing chapters to `ReadingModeWrapper`
- Genesis now appears exactly once in Reading Mode content, Table of Contents, and Prev/Next navigation
- Root cause: `plots` query can return duplicate rows for the same `plot_index` (e.g., multiple contract addresses or re-indexed entries)

## Test plan
- [ ] Reading Mode: genesis appears exactly once
- [ ] Table of Contents: each chapter listed once
- [ ] Prev/Next navigation works correctly (no repeated chapters)
- [ ] Works from both story page and chapter detail page
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)