### PR TITLE
Close mobile nav when navigating to profile

### DIFF
--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -7,7 +7,7 @@ import { isFarcasterMiniApp } from "../../lib/farcaster-detect";
 import { truncateAddress } from "../../lib/utils";
 import { useConnectedIdentity } from "../hooks/useConnectedIdentity";
 
-export function ConnectWallet() {
+export function ConnectWallet({ onNavigate }: { onNavigate?: () => void } = {}) {
   const { address, isConnected } = useAccount();
   const { connect, connectors, isPending } = useConnect();
   const { disconnect } = useDisconnect();
@@ -41,6 +41,7 @@ export function ConnectWallet() {
       <div className="border-border flex items-center gap-3 rounded border px-3 py-2 text-sm">
         <Link
           href={`/profile/${address}`}
+          onClick={onNavigate}
           className="text-accent inline-flex items-center gap-1.5 font-medium hover:opacity-80 transition-opacity"
         >
           {profile?.pfpUrl && (

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -110,7 +110,7 @@ export function NavBar() {
             })}
           </div>
           <div className="mt-2 border-t border-[var(--border)] pt-2">
-            <ConnectWallet />
+            <ConnectWallet onNavigate={() => setMobileOpen(false)} />
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
Fixes #615

- Add optional `onNavigate` callback prop to `ConnectWallet`
- Call it on profile link click to close the mobile nav dropdown
- NavBar passes `() => setMobileOpen(false)` from the mobile dropdown
- Desktop `ConnectWallet` renders without the prop (unchanged behavior)

## Test plan
- [ ] Mobile: tap profile link in nav dropdown → nav closes, navigates to profile
- [ ] Desktop: clicking profile link works normally (no callback)
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)