### PR TITLE
Add page-flip animation to Reading Mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -210,6 +210,22 @@ code, pre, .font-mono {
   }
 }
 
+/* Reading Mode page-flip transitions */
+@keyframes flip-in-left {
+  from { opacity: 0; transform: translateX(40px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+@keyframes flip-in-right {
+  from { opacity: 0; transform: translateX(-40px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+.page-flip-left {
+  animation: flip-in-left 0.25s ease-out;
+}
+.page-flip-right {
+  animation: flip-in-right 0.25s ease-out;
+}
+
 /* Custom select dropdown styling */
 select {
   appearance: none;

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -27,6 +27,7 @@ export function ReadingMode({
 }: ReadingModeProps) {
   const [currentIdx, setCurrentIdx] = useState(initialChapterIndex);
   const [showToc, setShowToc] = useState(false);
+  const [flipDir, setFlipDir] = useState<"left" | "right" | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const { isMiniApp } = usePlatformDetection();
 
@@ -38,25 +39,29 @@ export function ReadingMode({
     contentRef.current?.scrollTo(0, 0);
   }, []);
 
-  const goPrev = useCallback(() => {
-    if (hasPrev) {
-      setCurrentIdx((i) => i - 1);
+  const navigate = useCallback((idx: number, dir: "left" | "right" | null) => {
+    setFlipDir(dir);
+    // Brief delay to trigger the CSS animation before content swap
+    requestAnimationFrame(() => {
+      setCurrentIdx(idx);
       scrollToTop();
-    }
-  }, [hasPrev, scrollToTop]);
+      // Clear the animation class after transition completes
+      setTimeout(() => setFlipDir(null), 250);
+    });
+  }, [scrollToTop]);
+
+  const goPrev = useCallback(() => {
+    if (hasPrev) navigate(currentIdx - 1, "right");
+  }, [hasPrev, currentIdx, navigate]);
 
   const goNext = useCallback(() => {
-    if (hasNext) {
-      setCurrentIdx((i) => i + 1);
-      scrollToTop();
-    }
-  }, [hasNext, scrollToTop]);
+    if (hasNext) navigate(currentIdx + 1, "left");
+  }, [hasNext, currentIdx, navigate]);
 
   const goToChapter = useCallback((idx: number) => {
-    setCurrentIdx(idx);
     setShowToc(false);
-    scrollToTop();
-  }, [scrollToTop]);
+    navigate(idx, idx > currentIdx ? "left" : "right");
+  }, [currentIdx, navigate]);
 
   // Esc to close, arrow keys for navigation
   useEffect(() => {
@@ -105,8 +110,10 @@ export function ReadingMode({
       </div>
 
       {/* Content area */}
-      <div ref={contentRef} className="flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-[720px] px-6 py-8 sm:px-8 sm:py-12">
+      <div ref={contentRef} className="flex-1 overflow-y-auto overflow-x-hidden">
+        <div className={`mx-auto max-w-[720px] px-6 py-8 sm:px-8 sm:py-12 ${
+          flipDir === "left" ? "page-flip-left" : flipDir === "right" ? "page-flip-right" : ""
+        }`}>
           {chapter?.content ? (
             <StoryContent content={chapter.content} />
           ) : (


### PR DESCRIPTION
## Summary
Fixes #616

- Track navigation direction (`left`/`right`) via `flipDir` state
- Apply CSS-only slide animation (`translateX(40px)` + opacity fade) on content area
- Works for Prev/Next buttons, keyboard arrows (Left/Right), and TOC chapter jumps
- Direction-aware: "Next" slides from right, "Prev" slides from left, TOC compares indexes
- 250ms `ease-out` duration — smooth on mobile
- `overflow-x-hidden` on scroll container prevents horizontal scroll during animation
- Animation classes in `globals.css` using `@keyframes`

## Test plan
- [ ] Click Next → content slides in from right
- [ ] Click Prev → content slides in from left
- [ ] Arrow keys → same directional animation
- [ ] TOC jump → correct direction based on chapter position
- [ ] Animation is smooth on mobile
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)