### PR TITLE
[#625] Fix EIP-712 chainId signing failure in Farcaster miniapp

### DIFF
--- a/src/components/AgentManage.tsx
+++ b/src/components/AgentManage.tsx
@@ -21,7 +21,7 @@ const LLM_MODELS = [
 const EIP712_DOMAIN = {
   name: "ERC8004IdentityRegistry",
   version: "1",
-  chainId: BigInt(BASE_CHAIN_ID),
+  chainId: Number(BASE_CHAIN_ID),
   verifyingContract: ERC8004_REGISTRY,
 } as const;
 

--- a/src/components/AgentRegister.tsx
+++ b/src/components/AgentRegister.tsx
@@ -23,7 +23,7 @@ type WizardStep = 1 | 2 | "3a" | "3b" | "3c" | "done";
 const EIP712_DOMAIN = {
   name: "ERC8004IdentityRegistry",
   version: "1",
-  chainId: BigInt(BASE_CHAIN_ID),
+  chainId: Number(BASE_CHAIN_ID),
   verifyingContract: ERC8004_REGISTRY,
 } as const;
 


### PR DESCRIPTION
## Summary
- Change `BigInt(BASE_CHAIN_ID)` → `Number(BASE_CHAIN_ID)` in EIP-712 domain config in both `AgentManage.tsx` and `AgentRegister.tsx`
- `BASE_CHAIN_ID` is already a `Number` in `constants.ts` — the `BigInt` wrapping caused viem's `stringify` to serialize it as string `"8453"`, which the Farcaster wallet rejects with "Unable to parse chainId"

## Test plan
- [ ] Open the miniapp in Farcaster and attempt `setAgentWallet` EIP-712 signing — should no longer error with "Unable to parse chainId"
- [ ] Verify the typed data signature completes and the transaction succeeds on Base Sepolia

Fixes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)