### PR TITLE
[#623] Book-style page flip + swipe gesture navigation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -215,14 +215,6 @@ code, pre, .font-mono {
   perspective: 1200px;
 }
 
-@keyframes flip-forward {
-  0%   { transform: rotateY(0deg); opacity: 1; }
-  100% { transform: rotateY(-90deg); opacity: 0; }
-}
-@keyframes flip-backward {
-  0%   { transform: rotateY(0deg); opacity: 1; }
-  100% { transform: rotateY(90deg); opacity: 0; }
-}
 @keyframes flip-in-from-right {
   0%   { transform: rotateY(90deg); opacity: 0; }
   100% { transform: rotateY(0deg); opacity: 1; }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -215,6 +215,14 @@ code, pre, .font-mono {
   perspective: 1200px;
 }
 
+@keyframes flip-out-forward {
+  0%   { transform: rotateY(0deg); opacity: 1; }
+  100% { transform: rotateY(-90deg); opacity: 0; }
+}
+@keyframes flip-out-backward {
+  0%   { transform: rotateY(0deg); opacity: 1; }
+  100% { transform: rotateY(90deg); opacity: 0; }
+}
 @keyframes flip-in-from-right {
   0%   { transform: rotateY(90deg); opacity: 0; }
   100% { transform: rotateY(0deg); opacity: 1; }
@@ -224,13 +232,23 @@ code, pre, .font-mono {
   100% { transform: rotateY(0deg); opacity: 1; }
 }
 
-.page-flip-left {
+/* Outgoing page: flips away */
+.page-flip-out-left {
   transform-origin: left center;
-  animation: flip-in-from-right 400ms ease-in-out;
+  animation: flip-out-forward 200ms ease-in forwards;
 }
-.page-flip-right {
+.page-flip-out-right {
   transform-origin: right center;
-  animation: flip-in-from-left 400ms ease-in-out;
+  animation: flip-out-backward 200ms ease-in forwards;
+}
+/* Incoming page: flips into view */
+.page-flip-in-left {
+  transform-origin: left center;
+  animation: flip-in-from-right 200ms ease-out;
+}
+.page-flip-in-right {
+  transform-origin: right center;
+  animation: flip-in-from-left 200ms ease-out;
 }
 
 /* Custom select dropdown styling */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -210,20 +210,35 @@ code, pre, .font-mono {
   }
 }
 
-/* Reading Mode page-flip transitions */
-@keyframes flip-in-left {
-  from { opacity: 0; transform: translateX(40px); }
-  to   { opacity: 1; transform: translateX(0); }
+/* Reading Mode page-flip transitions (3D book-style) */
+.page-flip-container {
+  perspective: 1200px;
 }
-@keyframes flip-in-right {
-  from { opacity: 0; transform: translateX(-40px); }
-  to   { opacity: 1; transform: translateX(0); }
+
+@keyframes flip-forward {
+  0%   { transform: rotateY(0deg); opacity: 1; }
+  100% { transform: rotateY(-90deg); opacity: 0; }
 }
+@keyframes flip-backward {
+  0%   { transform: rotateY(0deg); opacity: 1; }
+  100% { transform: rotateY(90deg); opacity: 0; }
+}
+@keyframes flip-in-from-right {
+  0%   { transform: rotateY(90deg); opacity: 0; }
+  100% { transform: rotateY(0deg); opacity: 1; }
+}
+@keyframes flip-in-from-left {
+  0%   { transform: rotateY(-90deg); opacity: 0; }
+  100% { transform: rotateY(0deg); opacity: 1; }
+}
+
 .page-flip-left {
-  animation: flip-in-left 0.25s ease-out;
+  transform-origin: left center;
+  animation: flip-in-from-right 400ms ease-in-out;
 }
 .page-flip-right {
-  animation: flip-in-right 0.25s ease-out;
+  transform-origin: right center;
+  animation: flip-in-from-left 400ms ease-in-out;
 }
 
 /* Custom select dropdown styling */

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -28,9 +28,11 @@ export function ReadingMode({
   const [currentIdx, setCurrentIdx] = useState(initialChapterIndex);
   const [showToc, setShowToc] = useState(false);
   const [flipDir, setFlipDir] = useState<"left" | "right" | null>(null);
+  const [flipPhase, setFlipPhase] = useState<"out" | "in" | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const touchStartX = useRef(0);
   const touchStartY = useRef(0);
+  const flipping = useRef(false);
   const { isMiniApp } = usePlatformDetection();
 
   const chapter = chapters[currentIdx];
@@ -42,14 +44,22 @@ export function ReadingMode({
   }, []);
 
   const navigate = useCallback((idx: number, dir: "left" | "right" | null) => {
+    if (flipping.current) return;
+    flipping.current = true;
+    // Phase 1: flip out the current page
     setFlipDir(dir);
-    // Brief delay to trigger the CSS animation before content swap
-    requestAnimationFrame(() => {
+    setFlipPhase("out");
+    setTimeout(() => {
+      // Phase 2: swap content and flip in the new page
       setCurrentIdx(idx);
       scrollToTop();
-      // Clear the animation class after transition completes
-      setTimeout(() => setFlipDir(null), 400);
-    });
+      setFlipPhase("in");
+      setTimeout(() => {
+        setFlipDir(null);
+        setFlipPhase(null);
+        flipping.current = false;
+      }, 200);
+    }, 200);
   }, [scrollToTop]);
 
   const goPrev = useCallback(() => {
@@ -130,7 +140,11 @@ export function ReadingMode({
         }}
       >
         <div className={`mx-auto max-w-[720px] px-6 py-8 sm:px-8 sm:py-12 ${
-          flipDir === "left" ? "page-flip-left" : flipDir === "right" ? "page-flip-right" : ""
+          flipPhase === "out" && flipDir === "left" ? "page-flip-out-left"
+          : flipPhase === "out" && flipDir === "right" ? "page-flip-out-right"
+          : flipPhase === "in" && flipDir === "left" ? "page-flip-in-left"
+          : flipPhase === "in" && flipDir === "right" ? "page-flip-in-right"
+          : ""
         }`}>
           {chapter?.content ? (
             <StoryContent content={chapter.content} />

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -29,6 +29,8 @@ export function ReadingMode({
   const [showToc, setShowToc] = useState(false);
   const [flipDir, setFlipDir] = useState<"left" | "right" | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const touchStartX = useRef(0);
+  const touchStartY = useRef(0);
   const { isMiniApp } = usePlatformDetection();
 
   const chapter = chapters[currentIdx];
@@ -46,7 +48,7 @@ export function ReadingMode({
       setCurrentIdx(idx);
       scrollToTop();
       // Clear the animation class after transition completes
-      setTimeout(() => setFlipDir(null), 250);
+      setTimeout(() => setFlipDir(null), 400);
     });
   }, [scrollToTop]);
 
@@ -110,7 +112,23 @@ export function ReadingMode({
       </div>
 
       {/* Content area */}
-      <div ref={contentRef} className="flex-1 overflow-y-auto overflow-x-hidden">
+      <div
+        ref={contentRef}
+        className="page-flip-container flex-1 overflow-y-auto overflow-x-hidden"
+        onTouchStart={(e) => {
+          touchStartX.current = e.touches[0].clientX;
+          touchStartY.current = e.touches[0].clientY;
+        }}
+        onTouchEnd={(e) => {
+          const dx = e.changedTouches[0].clientX - touchStartX.current;
+          const dy = e.changedTouches[0].clientY - touchStartY.current;
+          // Only trigger if horizontal swipe exceeds threshold and is more horizontal than vertical
+          if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy) * 1.5) {
+            if (dx < 0) goNext();
+            else goPrev();
+          }
+        }}
+      >
         <div className={`mx-auto max-w-[720px] px-6 py-8 sm:px-8 sm:py-12 ${
           flipDir === "left" ? "page-flip-left" : flipDir === "right" ? "page-flip-right" : ""
         }`}>


### PR DESCRIPTION
## Summary
- Replaced slide+fade animation with 3D book-style page flip using CSS `rotateY()` + `perspective(1200px)` — next flips from right edge, prev flips from left edge (400ms ease-in-out)
- Added touch swipe navigation: swipe left → next chapter, swipe right → prev chapter
- Swipe threshold of 50px with horizontal dominance check (`dx > dy * 1.5`) to avoid interfering with vertical scrolling
- No external dependencies — pure CSS transforms (GPU-accelerated) + native touch events

## Test plan
- [ ] Desktop: arrow keys and buttons trigger 3D page flip animation
- [ ] Mobile: swipe left/right navigates chapters with page flip
- [ ] Vertical scrolling works normally without triggering swipe
- [ ] Short taps don't trigger accidental navigation
- [ ] Animation is smooth on mobile devices
- [ ] Build passes clean

Fixes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)