### PR TITLE
[#631] Replace direct Neynar calls with DB-first lookup

### DIFF
--- a/src/app/story/[storylineId]/og/route.tsx
+++ b/src/app/story/[storylineId]/og/route.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from "next/og";
 import { type Address } from "viem";
 import { createServerClient, type Storyline } from "../../../../../lib/supabase";
 import { getTokenTVL } from "../../../../../lib/price";
-import { lookupByAddress } from "../../../../../lib/farcaster";
+import { getFarcasterProfile } from "../../../../../lib/actions";
 import { RESERVE_LABEL, STORY_FACTORY } from "../../../../../lib/contracts/constants";
 import { formatPrice } from "../../../../../lib/format";
 import { truncateAddress } from "../../../../../lib/utils";
@@ -60,7 +60,7 @@ export async function GET(
   const [tvlInfo, plotUsd, farcasterProfile, fontData] = await Promise.all([
     sl.token_address ? getTokenTVL(sl.token_address as Address) : null,
     getPlotUsdPrice(),
-    lookupByAddress(sl.writer_address).catch(() => null),
+    getFarcasterProfile(sl.writer_address).catch(() => null),
     loadFont(),
   ]);
 

--- a/src/components/WriterIdentity.tsx
+++ b/src/components/WriterIdentity.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { lookupByAddress } from "../../lib/farcaster";
+import { getFarcasterProfile } from "../../lib/actions";
 import { truncateAddress } from "../../lib/utils";
 
 /**
@@ -8,7 +8,7 @@ import { truncateAddress } from "../../lib/utils";
  * Links to the internal profile page at /profile/[address].
  */
 export async function WriterIdentity({ address }: { address: string }) {
-  const profile = await lookupByAddress(address);
+  const profile = await getFarcasterProfile(address);
 
   if (!profile) {
     return (


### PR DESCRIPTION
## Summary
- **WriterIdentity.tsx**: Replaced `lookupByAddress()` with `getFarcasterProfile()` which checks DB cache before hitting external APIs.
- **OG image route**: Same replacement — avoids unnecessary paid Neynar API calls when profile data is already in DB.

Fixes realproject7/plotlink#631
Tracks realproject7/agent-os#310

## Test plan
- [ ] Writer identity still resolves correctly on story pages
- [ ] OG image route (`/story/<id>/og`) still renders author name
- [ ] No direct `lookupByAddress` imports remain in components (only in lib/ and API routes)
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)