### PR TITLE
[#639] Harden resolveAgentURI with timeout and validation

### DIFF
--- a/lib/contracts/erc8004.ts
+++ b/lib/contracts/erc8004.ts
@@ -212,27 +212,48 @@ export async function detectWriterType(
   }
 }
 
+const MAX_URI_BYTES = 50 * 1024; // 50 KB size limit
+const FETCH_TIMEOUT_MS = 5000; // 5-second timeout
+
 /**
  * Resolve an agent URI string to a parsed JSON object.
  * Handles raw JSON, data: URIs (base64 + URL-encoded), https://, and ipfs://.
+ * Includes timeout, size limits, and response validation for safety.
  */
 export async function resolveAgentURI(uri: string): Promise<Record<string, unknown>> {
-  if (uri.startsWith("{")) {
-    return JSON.parse(uri);
+  try {
+    if (uri.startsWith("{")) {
+      if (uri.length > MAX_URI_BYTES) return {};
+      return JSON.parse(uri);
+    }
+    if (uri.startsWith("data:")) {
+      const comma = uri.indexOf(",");
+      const payload = comma >= 0 ? uri.slice(comma + 1) : uri;
+      if (payload.length > MAX_URI_BYTES) return {};
+      return JSON.parse(
+        uri.includes("base64") ? atob(payload) : decodeURIComponent(payload),
+      );
+    }
+    // https:// or ipfs://
+    const fetchUrl = uri.startsWith("ipfs://")
+      ? uri.replace("ipfs://", "https://ipfs.io/ipfs/")
+      : uri;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const res = await fetch(fetchUrl, { signal: controller.signal });
+      if (!res.ok) return {};
+
+      const text = await res.text();
+      if (text.length > MAX_URI_BYTES) return {};
+      return JSON.parse(text);
+    } finally {
+      clearTimeout(timeout);
+    }
+  } catch {
+    return {};
   }
-  if (uri.startsWith("data:")) {
-    const comma = uri.indexOf(",");
-    const payload = comma >= 0 ? uri.slice(comma + 1) : uri;
-    return JSON.parse(
-      uri.includes("base64") ? atob(payload) : decodeURIComponent(payload),
-    );
-  }
-  // https:// or ipfs://
-  const fetchUrl = uri.startsWith("ipfs://")
-    ? uri.replace("ipfs://", "https://ipfs.io/ipfs/")
-    : uri;
-  const res = await fetch(fetchUrl);
-  return (await res.json()) as Record<string, unknown>;
 }
 
 /**

--- a/lib/contracts/erc8004.ts
+++ b/lib/contracts/erc8004.ts
@@ -264,9 +264,18 @@ export async function resolveAgentURI(uri: string): Promise<Record<string, unkno
         }
         chunks.push(value);
       }
-      const text = new TextDecoder().decode(
-        chunks.length === 1 ? chunks[0] : Buffer.concat(chunks),
-      );
+      let bytes: Uint8Array;
+      if (chunks.length === 1) {
+        bytes = chunks[0];
+      } else {
+        bytes = new Uint8Array(totalBytes);
+        let offset = 0;
+        for (const chunk of chunks) {
+          bytes.set(chunk, offset);
+          offset += chunk.byteLength;
+        }
+      }
+      const text = new TextDecoder().decode(bytes);
       return JSON.parse(text);
     } finally {
       clearTimeout(timeout);

--- a/lib/contracts/erc8004.ts
+++ b/lib/contracts/erc8004.ts
@@ -245,8 +245,28 @@ export async function resolveAgentURI(uri: string): Promise<Record<string, unkno
       const res = await fetch(fetchUrl, { signal: controller.signal });
       if (!res.ok) return {};
 
-      const text = await res.text();
-      if (text.length > MAX_URI_BYTES) return {};
+      // Reject early if Content-Length exceeds limit
+      const contentLength = res.headers.get("content-length");
+      if (contentLength && parseInt(contentLength, 10) > MAX_URI_BYTES) return {};
+
+      // Stream body with size cap to avoid buffering oversized responses
+      const reader = res.body?.getReader();
+      if (!reader) return {};
+      const chunks: Uint8Array[] = [];
+      let totalBytes = 0;
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        totalBytes += value.byteLength;
+        if (totalBytes > MAX_URI_BYTES) {
+          reader.cancel();
+          return {};
+        }
+        chunks.push(value);
+      }
+      const text = new TextDecoder().decode(
+        chunks.length === 1 ? chunks[0] : Buffer.concat(chunks),
+      );
       return JSON.parse(text);
     } finally {
       clearTimeout(timeout);


### PR DESCRIPTION
## Summary
- **5s timeout**: `AbortController` on remote fetches (https/ipfs) prevents hangs from slow servers
- **Response validation**: Checks `res.ok` before parsing body
- **50KB size limit**: Enforced on all payload types (remote, `data:` URI, raw JSON)
- **Graceful error handling**: Entire function wrapped in try/catch, returns `{}` on any failure instead of throwing

Fixes realproject7/plotlink#639
Tracks realproject7/agent-os#312

## Test plan
- [ ] Remote fetch with slow server times out after 5s (returns `{}`)
- [ ] Non-200 responses return `{}` (not crash)
- [ ] Invalid JSON returns `{}` gracefully
- [ ] Oversized `data:` URI payloads return `{}`
- [ ] Normal agent URIs still resolve correctly
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)