### PR TITLE
[#634] Await agent DB writes and handle cache failures gracefully

### DIFF
--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -93,7 +93,9 @@ export default function AgentsPage() {
   useEffect(() => {
     if (!dbDetected && hasExistingAgent && address && detectedAgentId && !cachedRef.current) {
       cachedRef.current = true;
-      cacheAgentById(address, detectedAgentId.toString()).catch(() => {});
+      cacheAgentById(address, detectedAgentId.toString()).catch(() =>
+        cacheAgentById(address, detectedAgentId.toString()).catch(() => {}),
+      );
     }
   }, [dbDetected, hasExistingAgent, address, detectedAgentId]);
 

--- a/src/app/api/user/agent-register/route.ts
+++ b/src/app/api/user/agent-register/route.ts
@@ -63,10 +63,26 @@ export async function POST(request: NextRequest) {
     if (existingUser) {
       await supabase.from("users").update(agentFields).eq("id", existingUser.id);
     } else {
-      await supabase.from("users").insert({
+      const { error: insertError } = await supabase.from("users").insert({
         primary_address: normalized,
         ...agentFields,
       });
+
+      // 23505: row was created concurrently — update it instead
+      if (insertError?.code === "23505") {
+        const { data: raceUser } = await supabase
+          .from("users")
+          .select("id")
+          .or(`primary_address.eq.${normalized},agent_wallet.eq.${normalized},agent_owner.eq.${normalized}`)
+          .limit(1)
+          .single();
+
+        if (raceUser) {
+          await supabase.from("users").update(agentFields).eq("id", raceUser.id);
+        }
+      } else if (insertError) {
+        throw insertError;
+      }
     }
 
     return NextResponse.json({ ok: true });

--- a/src/app/api/user/agent-register/route.ts
+++ b/src/app/api/user/agent-register/route.ts
@@ -85,6 +85,8 @@ export async function POST(request: NextRequest) {
           if (updateError) {
             return NextResponse.json({ error: updateError.message }, { status: 500 });
           }
+        } else {
+          return NextResponse.json({ error: "Conflict but user not found on retry" }, { status: 500 });
         }
       } else if (insertError) {
         return NextResponse.json({ error: insertError.message }, { status: 500 });

--- a/src/app/api/user/agent-register/route.ts
+++ b/src/app/api/user/agent-register/route.ts
@@ -61,7 +61,10 @@ export async function POST(request: NextRequest) {
     };
 
     if (existingUser) {
-      await supabase.from("users").update(agentFields).eq("id", existingUser.id);
+      const { error: updateError } = await supabase.from("users").update(agentFields).eq("id", existingUser.id);
+      if (updateError) {
+        return NextResponse.json({ error: updateError.message }, { status: 500 });
+      }
     } else {
       const { error: insertError } = await supabase.from("users").insert({
         primary_address: normalized,
@@ -78,10 +81,13 @@ export async function POST(request: NextRequest) {
           .single();
 
         if (raceUser) {
-          await supabase.from("users").update(agentFields).eq("id", raceUser.id);
+          const { error: updateError } = await supabase.from("users").update(agentFields).eq("id", raceUser.id);
+          if (updateError) {
+            return NextResponse.json({ error: updateError.message }, { status: 500 });
+          }
         }
       } else if (insertError) {
-        throw insertError;
+        return NextResponse.json({ error: insertError.message }, { status: 500 });
       }
     }
 

--- a/src/app/api/user/agent-update/route.ts
+++ b/src/app/api/user/agent-update/route.ts
@@ -77,7 +77,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
 
-    await supabase.from("users").update(sanitized).eq("id", existingUser.id);
+    const { error: updateError } = await supabase.from("users").update(sanitized).eq("id", existingUser.id);
+
+    if (updateError) {
+      return NextResponse.json({ error: updateError.message }, { status: 500 });
+    }
 
     return NextResponse.json({ ok: true });
   } catch (err) {

--- a/src/components/AgentDashboard.tsx
+++ b/src/components/AgentDashboard.tsx
@@ -103,7 +103,9 @@ export function AgentDashboard() {
   useEffect(() => {
     if (!dbDetected && isAgent && address && agentId && !cachedRef.current) {
       cachedRef.current = true;
-      cacheAgentById(address, agentId.toString()).catch(() => {});
+      cacheAgentById(address, agentId.toString()).catch(() =>
+        cacheAgentById(address, agentId.toString()).catch(() => {}),
+      );
     }
   }, [dbDetected, isAgent, address, agentId]);
 

--- a/src/components/AgentManage.tsx
+++ b/src/components/AgentManage.tsx
@@ -164,21 +164,27 @@ export function AgentManage({ agentId, role }: AgentManageProps) {
       await publicClient.waitForTransactionReceipt({ hash });
       const parsed = JSON.parse(editUri);
       setMetadata({ ...metadata!, ...parsed });
-      setSuccessMessage("Agent profile updated");
       // Persist URI update to DB
-      fetch("/api/user/agent-update", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          walletAddress: address,
-          fields: {
-            agent_name: parsed.name,
-            agent_description: parsed.description,
-            agent_genre: parsed.genre || null,
-            agent_llm_model: parsed.llmModel || null,
-          },
-        }),
-      }).catch(() => {});
+      try {
+        const cacheRes = await fetch("/api/user/agent-update", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            walletAddress: address,
+            fields: {
+              agent_name: parsed.name,
+              agent_description: parsed.description,
+              agent_genre: parsed.genre || null,
+              agent_llm_model: parsed.llmModel || null,
+            },
+          }),
+        });
+        setSuccessMessage(cacheRes.ok
+          ? "Agent profile updated"
+          : "On-chain OK, but cache failed — will sync on next visit");
+      } catch {
+        setSuccessMessage("On-chain OK, but cache failed — will sync on next visit");
+      }
       setEditing(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to update URI");
@@ -200,16 +206,22 @@ export function AgentManage({ agentId, role }: AgentManageProps) {
       });
       setTxHash(hash);
       await publicClient.waitForTransactionReceipt({ hash });
-      setSuccessMessage("Agent wallet removed");
       // Persist unset to DB
-      fetch("/api/user/agent-update", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          walletAddress: address,
-          fields: { agent_wallet: null },
-        }),
-      }).catch(() => {});
+      try {
+        const cacheRes = await fetch("/api/user/agent-update", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            walletAddress: address,
+            fields: { agent_wallet: null },
+          }),
+        });
+        setSuccessMessage(cacheRes.ok
+          ? "Agent wallet removed"
+          : "On-chain OK, but cache failed — will sync on next visit");
+      } catch {
+        setSuccessMessage("On-chain OK, but cache failed — will sync on next visit");
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to unset wallet");
     } finally {
@@ -260,15 +272,21 @@ export function AgentManage({ agentId, role }: AgentManageProps) {
       setTxHash(hash);
       await publicClient.waitForTransactionReceipt({ hash });
       // Persist new wallet binding to DB
-      fetch("/api/user/agent-update", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          walletAddress: address,
-          fields: { agent_wallet: newWalletAddr.toLowerCase() },
-        }),
-      }).catch(() => {});
-      setSuccessMessage("Agent wallet bound successfully");
+      try {
+        const cacheRes = await fetch("/api/user/agent-update", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            walletAddress: address,
+            fields: { agent_wallet: newWalletAddr.toLowerCase() },
+          }),
+        });
+        setSuccessMessage(cacheRes.ok
+          ? "Agent wallet bound successfully"
+          : "On-chain OK, but cache failed — will sync on next visit");
+      } catch {
+        setSuccessMessage("On-chain OK, but cache failed — will sync on next visit");
+      }
       setWalletStep(null);
       setChangingWallet(false);
       setNewWalletAddr("");

--- a/src/components/AgentRegister.tsx
+++ b/src/components/AgentRegister.tsx
@@ -102,19 +102,26 @@ export function AgentRegister() {
       setOwnerAddress(address);
       // Persist agent data to DB
       const meta = JSON.parse(agentURI);
-      fetch("/api/user/agent-register", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          walletAddress: address,
-          agentId: newAgentId?.toString(),
-          name: meta.name,
-          description: meta.description,
-          genre: meta.genre,
-          llmModel: meta.llmModel,
-          agentOwner: address,
-        }),
-      }).catch(() => {});
+      try {
+        const cacheRes = await fetch("/api/user/agent-register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            walletAddress: address,
+            agentId: newAgentId?.toString(),
+            name: meta.name,
+            description: meta.description,
+            genre: meta.genre,
+            llmModel: meta.llmModel,
+            agentOwner: address,
+          }),
+        });
+        if (!cacheRes.ok) {
+          setError("On-chain OK, but cache failed — will sync on next visit");
+        }
+      } catch {
+        setError("On-chain OK, but cache failed — will sync on next visit");
+      }
       setStep("3a");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Registration failed");


### PR DESCRIPTION
## Summary
- **AgentRegister.tsx**: Awaits DB write after on-chain registration, shows warning if cache fails instead of silent swallowing.
- **AgentManage.tsx**: Awaits all three DB writes (URI update, wallet bind, wallet unbind) with user-friendly warning on failure.
- **agent-register/route.ts**: Added 23505 unique violation handling — re-queries and updates the conflicting row instead of throwing.
- **agents/page.tsx + AgentDashboard.tsx**: `cacheAgentById` retries once on failure before giving up.

On-chain success is never blocked by DB failure.

Fixes realproject7/plotlink#634
Tracks realproject7/agent-os#314

## Test plan
- [ ] Agent register awaits DB write and shows warning if it fails
- [ ] Agent manage actions (URI update, wallet bind/unbind) await DB writes
- [ ] Rapid re-registration doesn't 500 (23505 handled)
- [ ] cacheAgentById retries once on failure
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)