### PR TITLE
[#637] Align trade price calculation between real-time and cron indexers

### DIFF
--- a/src/app/api/index/trade/route.ts
+++ b/src/app/api/index/trade/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { type Hex, decodeEventLog, formatUnits } from "viem";
 import { publicClient, getReceiptWithRetry } from "../../../../../lib/rpc";
 import { createServerClient } from "../../../../../lib/supabase";
-import { mcv2BondEventAbi, priceForNextMintFunction } from "../../../../../lib/contracts/abi";
+import { mcv2BondEventAbi } from "../../../../../lib/contracts/abi";
 import { MCV2_BOND, ZAP_PLOTLINK } from "../../../../../lib/contracts/constants";
 import { erc20Abi } from "../../../../../lib/price";
 import { validateRecentTx } from "../../../../../lib/index-auth";
@@ -87,24 +87,11 @@ export async function POST(req: Request) {
       const reserveAmount = isMint ? args.reserveAmount! : args.refundAmount!;
       const tokenAmount = isMint ? args.amountMinted! : args.amountBurned!;
 
-      // Marginal price from bonding curve (not batch average)
-      let pricePerToken = 0;
-      try {
-        const price = await publicClient.readContract({
-          address: MCV2_BOND as `0x${string}`,
-          abi: [priceForNextMintFunction],
-          functionName: "priceForNextMint",
-          args: [args.token],
-          blockNumber: receipt.blockNumber,
-        });
-        pricePerToken = Number(formatUnits(price, 18));
-      } catch {
-        // Fallback to batch average if RPC call fails
-        pricePerToken = tokenAmount > BigInt(0)
-          ? Number(formatUnits(reserveAmount, 18)) /
-            Number(formatUnits(tokenAmount, 18))
-          : 0;
-      }
+      // Batch average price (reserveAmount / tokenAmount) — consistent with cron indexer
+      const pricePerToken = tokenAmount > BigInt(0)
+        ? Number(formatUnits(reserveAmount, 18)) /
+          Number(formatUnits(tokenAmount, 18))
+        : 0;
 
       let totalSupply = BigInt(0);
       try {


### PR DESCRIPTION
## Summary
- **Real-time indexer** (`/api/index/trade`): Replaced `priceForNextMint` (marginal bonding curve price) with batch average (`reserveAmount / tokenAmount`) to match the cron indexer.
- Removed unused `priceForNextMintFunction` import and extra RPC call.
- Both indexers now produce identical `price_per_token` values for the same trade.

Fixes realproject7/plotlink#637
Tracks realproject7/agent-os#317

## Test plan
- [ ] Both indexers use same price calculation (batch average)
- [ ] Trade history `price_per_token` is consistent regardless of which indexer runs
- [ ] No extra `priceForNextMint` RPC call in real-time path
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)