### PR TITLE
[#630] Two-phase book page turn with visible page underneath

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -210,45 +210,63 @@ code, pre, .font-mono {
   }
 }
 
-/* Reading Mode page-flip transitions (3D book-style) */
+/* Reading Mode — two-phase book page turn */
 .page-flip-container {
-  perspective: 1200px;
+  perspective: 1500px;
 }
 
+.page-flip-stack {
+  position: relative;
+  min-height: 100%;
+}
+
+.page-flip-page {
+  position: relative;
+  will-change: transform, opacity;
+}
+
+/* Outgoing page stacks on top and flips away */
+.page-outgoing {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  backface-visibility: hidden;
+  overflow: hidden;
+}
+
+/* Incoming page: subtle fade-in from underneath */
+.page-incoming {
+  animation: page-reveal 500ms ease-out;
+}
+
+@keyframes page-reveal {
+  0%   { opacity: 0.4; }
+  60%  { opacity: 0.8; }
+  100% { opacity: 1; }
+}
+
+/* Next: outgoing page flips from right edge (like turning a book page forward) */
 @keyframes flip-out-forward {
-  0%   { transform: rotateY(0deg); opacity: 1; }
-  100% { transform: rotateY(-90deg); opacity: 0; }
-}
-@keyframes flip-out-backward {
-  0%   { transform: rotateY(0deg); opacity: 1; }
-  100% { transform: rotateY(90deg); opacity: 0; }
-}
-@keyframes flip-in-from-right {
-  0%   { transform: rotateY(90deg); opacity: 0; }
-  100% { transform: rotateY(0deg); opacity: 1; }
-}
-@keyframes flip-in-from-left {
-  0%   { transform: rotateY(-90deg); opacity: 0; }
-  100% { transform: rotateY(0deg); opacity: 1; }
+  0%   { transform: rotateY(0deg); box-shadow: -4px 0 16px rgba(0,0,0,0.1); }
+  40%  { box-shadow: -10px 0 30px rgba(0,0,0,0.2); }
+  100% { transform: rotateY(-120deg); box-shadow: none; }
 }
 
-/* Outgoing page: flips away */
+/* Prev: outgoing page flips from left edge (like turning a book page backward) */
+@keyframes flip-out-backward {
+  0%   { transform: rotateY(0deg); box-shadow: 4px 0 16px rgba(0,0,0,0.1); }
+  40%  { box-shadow: 10px 0 30px rgba(0,0,0,0.2); }
+  100% { transform: rotateY(120deg); box-shadow: none; }
+}
+
 .page-flip-out-left {
   transform-origin: left center;
-  animation: flip-out-forward 200ms ease-in forwards;
+  animation: flip-out-forward 500ms ease-in forwards;
 }
+
 .page-flip-out-right {
   transform-origin: right center;
-  animation: flip-out-backward 200ms ease-in forwards;
-}
-/* Incoming page: flips into view */
-.page-flip-in-left {
-  transform-origin: left center;
-  animation: flip-in-from-right 200ms ease-out;
-}
-.page-flip-in-right {
-  transform-origin: right center;
-  animation: flip-in-from-left 200ms ease-out;
+  animation: flip-out-backward 500ms ease-in forwards;
 }
 
 /* Custom select dropdown styling */

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -51,9 +51,10 @@ export function ReadingMode({
     setOutgoingIdx(currentIdx);
     setFlipDir(dir);
     setCurrentIdx(idx);
-    scrollToTop();
-    // Clear outgoing page after animation completes
+    // Delay scroll reset until after animation — the outgoing page is
+    // absolutely positioned over the scroll container during the flip
     setTimeout(() => {
+      scrollToTop();
       setOutgoingIdx(null);
       setFlipDir(null);
       flipping.current = false;

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -29,6 +29,7 @@ export function ReadingMode({
   const [showToc, setShowToc] = useState(false);
   const [flipDir, setFlipDir] = useState<"left" | "right" | null>(null);
   const [outgoingIdx, setOutgoingIdx] = useState<number | null>(null);
+  const [outgoingScroll, setOutgoingScroll] = useState(0);
   const contentRef = useRef<HTMLDivElement>(null);
   const stackRef = useRef<HTMLDivElement>(null);
   const touchStartX = useRef(0);
@@ -48,17 +49,20 @@ export function ReadingMode({
   const navigate = useCallback((idx: number, dir: "left" | "right" | null) => {
     if (flipping.current) return;
     flipping.current = true;
-    // Freeze container height so scroll geometry is stable during the flip
+    // Capture scroll offset so the outgoing page can render at its old position
+    const scrollOffset = contentRef.current?.scrollTop ?? 0;
+    setOutgoingScroll(scrollOffset);
+    // Freeze container height so layout is stable during the flip
     if (stackRef.current) {
       stackRef.current.style.minHeight = `${stackRef.current.offsetHeight}px`;
     }
-    // Capture outgoing page, set incoming as current
+    // Set outgoing, swap to incoming, and scroll to top immediately
     setOutgoingIdx(currentIdx);
     setFlipDir(dir);
     setCurrentIdx(idx);
-    // After animation: reset scroll, unfreeze height, clean up
+    scrollToTop();
+    // After animation: unfreeze height, clean up
     setTimeout(() => {
-      scrollToTop();
       if (stackRef.current) {
         stackRef.current.style.minHeight = "";
       }
@@ -157,13 +161,16 @@ export function ReadingMode({
             </div>
           </div>
 
-          {/* Outgoing page (on top, flipping away) */}
+          {/* Outgoing page (on top, flipping away at its old scroll offset) */}
           {outgoingChapter && flipDir && (
             <div
               className={`page-flip-page page-outgoing ${
                 flipDir === "left" ? "page-flip-out-left" : "page-flip-out-right"
               }`}
-              style={{ background: "var(--paper-bg, #F5F0E8)" }}
+              style={{
+                background: "var(--paper-bg, #F5F0E8)",
+                top: `-${outgoingScroll}px`,
+              }}
             >
               <div className="mx-auto max-w-[720px] px-6 py-8 sm:px-8 sm:py-12">
                 {outgoingChapter.content ? (

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -30,6 +30,7 @@ export function ReadingMode({
   const [flipDir, setFlipDir] = useState<"left" | "right" | null>(null);
   const [outgoingIdx, setOutgoingIdx] = useState<number | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const stackRef = useRef<HTMLDivElement>(null);
   const touchStartX = useRef(0);
   const touchStartY = useRef(0);
   const flipping = useRef(false);
@@ -47,14 +48,20 @@ export function ReadingMode({
   const navigate = useCallback((idx: number, dir: "left" | "right" | null) => {
     if (flipping.current) return;
     flipping.current = true;
+    // Freeze container height so scroll geometry is stable during the flip
+    if (stackRef.current) {
+      stackRef.current.style.minHeight = `${stackRef.current.offsetHeight}px`;
+    }
     // Capture outgoing page, set incoming as current
     setOutgoingIdx(currentIdx);
     setFlipDir(dir);
     setCurrentIdx(idx);
-    // Delay scroll reset until after animation — the outgoing page is
-    // absolutely positioned over the scroll container during the flip
+    // After animation: reset scroll, unfreeze height, clean up
     setTimeout(() => {
       scrollToTop();
+      if (stackRef.current) {
+        stackRef.current.style.minHeight = "";
+      }
       setOutgoingIdx(null);
       setFlipDir(null);
       flipping.current = false;
@@ -138,7 +145,7 @@ export function ReadingMode({
           }
         }}
       >
-        <div className="page-flip-stack">
+        <div ref={stackRef} className="page-flip-stack">
           {/* Incoming page (underneath) */}
           <div className={`page-flip-page ${outgoingIdx !== null ? "page-incoming" : ""}`}>
             <div className="mx-auto max-w-[720px] px-6 py-8 sm:px-8 sm:py-12">

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -28,7 +28,7 @@ export function ReadingMode({
   const [currentIdx, setCurrentIdx] = useState(initialChapterIndex);
   const [showToc, setShowToc] = useState(false);
   const [flipDir, setFlipDir] = useState<"left" | "right" | null>(null);
-  const [flipPhase, setFlipPhase] = useState<"out" | "in" | null>(null);
+  const [outgoingIdx, setOutgoingIdx] = useState<number | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const touchStartX = useRef(0);
   const touchStartY = useRef(0);
@@ -36,6 +36,7 @@ export function ReadingMode({
   const { isMiniApp } = usePlatformDetection();
 
   const chapter = chapters[currentIdx];
+  const outgoingChapter = outgoingIdx !== null ? chapters[outgoingIdx] : null;
   const hasPrev = currentIdx > 0;
   const hasNext = currentIdx < chapters.length - 1;
 
@@ -46,21 +47,18 @@ export function ReadingMode({
   const navigate = useCallback((idx: number, dir: "left" | "right" | null) => {
     if (flipping.current) return;
     flipping.current = true;
-    // Phase 1: flip out the current page
+    // Capture outgoing page, set incoming as current
+    setOutgoingIdx(currentIdx);
     setFlipDir(dir);
-    setFlipPhase("out");
+    setCurrentIdx(idx);
+    scrollToTop();
+    // Clear outgoing page after animation completes
     setTimeout(() => {
-      // Phase 2: swap content and flip in the new page
-      setCurrentIdx(idx);
-      scrollToTop();
-      setFlipPhase("in");
-      setTimeout(() => {
-        setFlipDir(null);
-        setFlipPhase(null);
-        flipping.current = false;
-      }, 200);
-    }, 200);
-  }, [scrollToTop]);
+      setOutgoingIdx(null);
+      setFlipDir(null);
+      flipping.current = false;
+    }, 500);
+  }, [currentIdx, scrollToTop]);
 
   const goPrev = useCallback(() => {
     if (hasPrev) navigate(currentIdx - 1, "right");
@@ -139,17 +137,34 @@ export function ReadingMode({
           }
         }}
       >
-        <div className={`mx-auto max-w-[720px] px-6 py-8 sm:px-8 sm:py-12 ${
-          flipPhase === "out" && flipDir === "left" ? "page-flip-out-left"
-          : flipPhase === "out" && flipDir === "right" ? "page-flip-out-right"
-          : flipPhase === "in" && flipDir === "left" ? "page-flip-in-left"
-          : flipPhase === "in" && flipDir === "right" ? "page-flip-in-right"
-          : ""
-        }`}>
-          {chapter?.content ? (
-            <StoryContent content={chapter.content} />
-          ) : (
-            <p className="text-muted text-sm italic">Content unavailable</p>
+        <div className="page-flip-stack">
+          {/* Incoming page (underneath) */}
+          <div className={`page-flip-page ${outgoingIdx !== null ? "page-incoming" : ""}`}>
+            <div className="mx-auto max-w-[720px] px-6 py-8 sm:px-8 sm:py-12">
+              {chapter?.content ? (
+                <StoryContent content={chapter.content} />
+              ) : (
+                <p className="text-muted text-sm italic">Content unavailable</p>
+              )}
+            </div>
+          </div>
+
+          {/* Outgoing page (on top, flipping away) */}
+          {outgoingChapter && flipDir && (
+            <div
+              className={`page-flip-page page-outgoing ${
+                flipDir === "left" ? "page-flip-out-left" : "page-flip-out-right"
+              }`}
+              style={{ background: "var(--paper-bg, #F5F0E8)" }}
+            >
+              <div className="mx-auto max-w-[720px] px-6 py-8 sm:px-8 sm:py-12">
+                {outgoingChapter.content ? (
+                  <StoryContent content={outgoingChapter.content} />
+                ) : (
+                  <p className="text-muted text-sm italic">Content unavailable</p>
+                )}
+              </div>
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- **ReadingMode.tsx**: Replaced sequential flip-out/in with simultaneous two-page stack. Both outgoing and incoming pages are in the DOM during the transition. Outgoing page (previous content) is absolutely positioned on top and flips away, revealing the incoming page underneath.
- **globals.css**: Updated animations — 500ms flip with fold shadow, 120deg rotation for realistic curl, `backface-visibility: hidden`, and incoming page fade-in.

Fixes realproject7/plotlink#630
Tracks realproject7/agent-os#318

## Test plan
- [ ] Click Next — outgoing page flips and incoming page visible underneath
- [ ] Click Prev — reverse flip direction
- [ ] Swipe left/right — same flip effect
- [ ] Arrow keys — same flip effect
- [ ] No reversed text visible during flip (backface hidden)
- [ ] Shadow along fold line during transition
- [ ] Smooth on mobile (GPU-accelerated transforms only)
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)