### PR TITLE
[#660] Fix create command missing creationFee as msg.value

### DIFF
--- a/packages/cli/src/sdk/abi.ts
+++ b/packages/cli/src/sdk/abi.ts
@@ -160,6 +160,13 @@ export const erc8004Abi = [
 export const mcv2BondAbi = [
   {
     type: "function",
+    name: "creationFee",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
     name: "getRoyaltyInfo",
     stateMutability: "view",
     inputs: [

--- a/packages/cli/src/sdk/client.ts
+++ b/packages/cli/src/sdk/client.ts
@@ -230,12 +230,20 @@ export class PlotLink {
     const contentCid = await uploadWithRetry(metadata, key, this.filebase!);
     const contentHash = hashContent(content);
 
+    // MCV2_Bond requires a creation fee as msg.value when minting a new token
+    const creationFee = await this.publicClient.readContract({
+      address: this.mcv2Bond,
+      abi: mcv2BondAbi,
+      functionName: "creationFee",
+    }) as bigint;
+
     const { request } = await this.publicClient.simulateContract({
       account: this.walletClient.account!,
       address: this.storyFactory,
       abi: storyFactoryAbi,
       functionName: "createStoryline",
       args: [title, contentCid, contentHash, hasDeadline],
+      value: creationFee,
     });
 
     const txHash = await this.walletClient.writeContract(request);


### PR DESCRIPTION
## Summary
- `plotlink create` reverted with `MCV2_Bond__InvalidCreationFee` (selector `0x3403ce37`) on mainnet because the SDK didn't pass the required creation fee
- Added `creationFee()` view call to the Bond ABI (`sdk/abi.ts`)
- SDK `createStoryline()` now reads `creationFee()` from MCV2_Bond and passes it as `value` in the `simulateContract` call (`sdk/client.ts`)
- Matches the web app's approach in `src/app/create/page.tsx:93-99`

## Changed files
- `packages/cli/src/sdk/abi.ts` — added `creationFee` function to `mcv2BondAbi`
- `packages/cli/src/sdk/client.ts` — read and pass `creationFee` as `value` in `createStoryline()`

## Test plan
- [ ] `npm run build` passes
- [ ] `plotlink create` succeeds on Base mainnet (verified during E2E in #322)
- [ ] Created storyline appears on plotlink.xyz after indexing
- [ ] Fee is 0.0007 ETH on mainnet (read dynamically, not hardcoded)

Fixes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)