### PR TITLE
[#661] Fix hardcoded Sepolia addresses in claim and status

### DIFF
--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { type Address, erc20Abi, formatUnits, isAddress } from "viem";
-import { MCV2_BOND_ADDRESS, mcv2BondAbi } from "../sdk/index.js";
+import { mcv2BondAbi } from "../sdk/index.js";
 import { buildClient } from "../sdk.js";
 
 export function registerClaim(program: Command): void {
@@ -20,7 +20,7 @@ export function registerClaim(program: Command): void {
         // Fetch bond data (creator = beneficiary, reserve token for display)
         console.log("Checking royalties...");
         const bond = await client.publicClient.readContract({
-          address: MCV2_BOND_ADDRESS,
+          address: client.mcv2Bond,
           abi: mcv2BondAbi,
           functionName: "tokenBond",
           args: [tokenAddress],

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import { createClient } from "@supabase/supabase-js";
 import { type Address, erc20Abi, formatUnits } from "viem";
-import { MCV2_BOND_ADDRESS, mcv2BondAbi, STORY_FACTORY_ADDRESS } from "../sdk/index.js";
+import { mcv2BondAbi } from "../sdk/index.js";
 import { buildClient } from "../sdk.js";
 import { loadConfig } from "../config.js";
 
@@ -45,7 +45,7 @@ export function registerStatus(program: Command): void {
             .from("storylines")
             .select("plot_count, last_plot_time, has_deadline, sunset, writer_type, block_timestamp")
             .eq("storyline_id", Number(storylineId))
-            .eq("contract_address", STORY_FACTORY_ADDRESS.toLowerCase())
+            .eq("contract_address", client.storyFactory.toLowerCase())
             .single();
           dbRow = data;
         }
@@ -59,7 +59,7 @@ export function registerStatus(program: Command): void {
         let bondReserveToken: Address | null = null;
         try {
           const bond = await client.publicClient.readContract({
-            address: MCV2_BOND_ADDRESS,
+            address: client.mcv2Bond,
             abi: mcv2BondAbi,
             functionName: "tokenBond",
             args: [info.tokenAddress],

--- a/packages/cli/src/sdk/client.ts
+++ b/packages/cli/src/sdk/client.ts
@@ -149,8 +149,8 @@ export class PlotLink {
   readonly walletClient: WalletClient;
   readonly address: Address;
 
-  private readonly storyFactory: Address;
-  private readonly mcv2Bond: Address;
+  readonly storyFactory: Address;
+  readonly mcv2Bond: Address;
   private readonly erc8004Registry: Address;
   private readonly filebase: FilebaseConfig | undefined;
   private readonly chain: Chain;


### PR DESCRIPTION
## Summary
- `claim` and `status` commands imported `MCV2_BOND_ADDRESS` and `STORY_FACTORY_ADDRESS` directly from constants, which always resolved to Sepolia addresses — causing reverts on mainnet
- Made `storyFactory` and `mcv2Bond` public readonly on the `PlotLink` client class (already resolves based on chainId)
- Updated both commands to use `client.mcv2Bond` / `client.storyFactory` instead of hardcoded imports

## Changed files
- `packages/cli/src/sdk/client.ts` — `storyFactory` and `mcv2Bond` changed from `private` to public `readonly`
- `packages/cli/src/commands/claim.ts` — use `client.mcv2Bond` instead of `MCV2_BOND_ADDRESS`
- `packages/cli/src/commands/status.ts` — use `client.mcv2Bond` and `client.storyFactory` instead of hardcoded constants

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes
- [ ] `plotlink claim` resolves correct Bond address on mainnet (verified during E2E in #322)
- [ ] `plotlink status` uses correct StoryFactory and Bond addresses per chain

Fixes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)