### PR TITLE
[#675] Improve nav wallet UX

### DIFF
--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -17,6 +17,7 @@ import type { FarcasterProfile } from "../../../../lib/farcaster";
 import type { AgentMetadata } from "../../../../lib/contracts/erc8004";
 import { usePlotUsdPrice } from "../../../hooks/usePlotUsdPrice";
 import { formatUsdValue } from "../../../../lib/usd-price";
+import { DisconnectButton } from "../../../components/ConnectWallet";
 
 type Tab = "stories" | "portfolio" | "activity";
 
@@ -241,6 +242,7 @@ function ProfileHeader({
                 </span>
               )
             )}
+            {isOwnProfile && <DisconnectButton />}
           </div>
 
           {/* Bio */}

--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -8,7 +8,13 @@ import { isFarcasterMiniApp } from "../../lib/farcaster-detect";
 import { truncateAddress } from "../../lib/utils";
 import { useConnectedIdentity } from "../hooks/useConnectedIdentity";
 
-export function ConnectWallet({ onNavigate }: { onNavigate?: () => void } = {}) {
+interface ConnectWalletProps {
+  onNavigate?: () => void;
+  /** Compact mode for mobile top nav — shows only PFP + short ID */
+  compact?: boolean;
+}
+
+export function ConnectWallet({ onNavigate, compact }: ConnectWalletProps = {}) {
   const { address, isConnected } = useAccount();
   const { connect, connectors } = useConnect();
   const { disconnect } = useDisconnect();
@@ -37,8 +43,34 @@ export function ConnectWallet({ onNavigate }: { onNavigate?: () => void } = {}) 
     });
   }, [inMiniApp, connectors, connect, isConnected]);
 
-  // Connected state: show Farcaster PFP + username + address + disconnect
+  // Connected state
   if (isConnected && address) {
+    const shortAddr = address.slice(0, 6);
+
+    // Compact mode: PFP + short identifier for mobile top nav
+    if (compact) {
+      return (
+        <Link
+          href={`/profile/${address}`}
+          onClick={onNavigate}
+          className="text-accent inline-flex items-center gap-1 text-xs font-medium hover:opacity-80 transition-opacity"
+        >
+          {profile?.pfpUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={profile.pfpUrl}
+              alt=""
+              width={16}
+              height={16}
+              className="rounded-full"
+            />
+          )}
+          {profile ? `@${profile.username}` : shortAddr}
+        </Link>
+      );
+    }
+
+    // Full mode: PFP + username + shortened address (no disconnect)
     return (
       <div className="border-border flex items-center gap-3 rounded border px-3 py-2 text-sm">
         <Link
@@ -56,24 +88,16 @@ export function ConnectWallet({ onNavigate }: { onNavigate?: () => void } = {}) 
               className="rounded-full"
             />
           )}
-          {profile ? `@${profile.username}` : truncateAddress(address)}
+          {profile ? `@${profile.username}` : shortAddr}
         </Link>
-        {profile && (
-          <span className="text-muted text-[10px] font-mono">
-            {truncateAddress(address)}
-          </span>
-        )}
-        <button
-          onClick={() => disconnect()}
-          className="text-muted hover:text-error transition-colors"
-        >
-          disconnect
-        </button>
+        <span className="text-muted text-[10px] font-mono">
+          {shortAddr}
+        </span>
       </div>
     );
   }
 
-  // Disconnected state: RainbowKit modal (outside Farcaster) or auto-connect (inside)
+  // Disconnected state: RainbowKit modal
   return (
     <ConnectButton.Custom>
       {({ openConnectModal, mounted }) => {
@@ -93,13 +117,34 @@ export function ConnectWallet({ onNavigate }: { onNavigate?: () => void } = {}) 
             <button
               onClick={openConnectModal}
               type="button"
-              className="border-accent text-accent hover:bg-accent hover:text-background rounded border px-4 py-2 text-sm transition-colors"
+              className={
+                compact
+                  ? "border-accent text-accent hover:bg-accent hover:text-background rounded border px-2.5 py-1 text-xs transition-colors"
+                  : "border-accent text-accent hover:bg-accent hover:text-background rounded border px-4 py-2 text-sm transition-colors"
+              }
             >
-              connect wallet
+              {compact ? "Connect" : "connect wallet"}
             </button>
           </div>
         );
       }}
     </ConnectButton.Custom>
+  );
+}
+
+/**
+ * Disconnect button for use on the profile page.
+ * Only renders when the viewer is viewing their own profile.
+ */
+export function DisconnectButton() {
+  const { disconnect } = useDisconnect();
+
+  return (
+    <button
+      onClick={() => disconnect()}
+      className="text-muted hover:text-error border-border rounded border px-2 py-0.5 text-[10px] transition-colors"
+    >
+      disconnect
+    </button>
   );
 }

--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -65,7 +65,9 @@ export function ConnectWallet({ onNavigate, compact }: ConnectWalletProps = {}) 
               className="rounded-full"
             />
           )}
-          {profile ? `@${profile.username}` : shortAddr}
+          {profile
+            ? `@${profile.username.length > 10 ? profile.username.slice(0, 10) + "…" : profile.username}`
+            : shortAddr}
         </Link>
       );
     }
@@ -90,9 +92,11 @@ export function ConnectWallet({ onNavigate, compact }: ConnectWalletProps = {}) 
           )}
           {profile ? `@${profile.username}` : shortAddr}
         </Link>
-        <span className="text-muted text-[10px] font-mono">
-          {shortAddr}
-        </span>
+        {profile && (
+          <span className="text-muted text-[10px] font-mono">
+            {shortAddr}
+          </span>
+        )}
       </div>
     );
   }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -60,8 +60,13 @@ export function NavBar() {
 
         {/* Right side: wallet + mobile toggle */}
         <div className="flex items-center gap-2">
+          {/* Desktop: full ConnectWallet */}
           <div className="hidden md:block">
             <ConnectWallet />
+          </div>
+          {/* Mobile: compact Connect button / PFP in top nav */}
+          <div className="md:hidden">
+            <ConnectWallet compact />
           </div>
           <button
             onClick={() => setMobileOpen(!mobileOpen)}


### PR DESCRIPTION
## Summary
- **Shortened address**: Nav shows first 6 chars only (e.g. `0x4d68`) instead of full truncated format
- **Disconnect moved**: Removed from nav bar, added to profile page next to Human/AI Agent badge (own profile only)
- **Mobile top nav**: Compact Connect button / PFP+identifier visible in top bar next to hamburger icon — no longer hidden inside menu
- **ConnectWallet `compact` prop**: New variant for mobile top nav with smaller button and tighter layout

## Changed files
- `src/components/ConnectWallet.tsx` — added `compact` prop, exported `DisconnectButton` component, removed disconnect from nav connected state
- `src/components/NavBar.tsx` — added compact `ConnectWallet` in mobile top bar
- `src/app/profile/[address]/page.tsx` — added `DisconnectButton` next to Human/AI Agent badge on own profile

## Test plan
- [ ] Desktop nav shows `@username 0x1234` style with no disconnect
- [ ] Profile page shows disconnect next to badge on own profile only
- [ ] Disconnect from profile works
- [ ] Mobile top nav shows compact Connect / PFP without opening hamburger
- [ ] Hamburger still shows full nav + wallet info
- [ ] `npm run build` passes

Fixes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)