### PR TITLE
[#672] Add USD values across dashboards

### DIFF
--- a/src/app/dashboard/reader/page.tsx
+++ b/src/app/dashboard/reader/page.tsx
@@ -27,6 +27,7 @@ const PAGE_SIZE = 10;
 
 export default function ReaderDashboard() {
   const { address, isConnected } = useAccount();
+  const { data: plotUsd } = usePlotUsdPrice();
 
   const {
     data,
@@ -99,10 +100,10 @@ export default function ReaderDashboard() {
         <WriterIdentityClient address={address!} />
       </p>
 
-      <ReaderPortfolio />
+      <ReaderPortfolio plotUsd={plotUsd} />
 
       {/* --- Trading History --- */}
-      <TradingHistory address={address!} />
+      <TradingHistory address={address!} plotUsd={plotUsd} />
 
       {/* --- Donation History --- */}
       <section className="mt-8">
@@ -190,8 +191,7 @@ function DonationRow({ donation, decimals }: { donation: Donation; decimals: num
 
 const TRADE_PAGE_SIZE = 10;
 
-function TradingHistory({ address }: { address: string }) {
-  const { data: plotUsd } = usePlotUsdPrice();
+function TradingHistory({ address, plotUsd }: { address: string; plotUsd?: number | null }) {
   const {
     data,
     isLoading,
@@ -292,7 +292,7 @@ function TradingHistory({ address }: { address: string }) {
                     {formatPrice(t.reserve_amount)} {RESERVE_LABEL}
                     {plotUsd && (
                       <span className="text-muted ml-1 text-[10px] font-normal">
-                        ({formatUsdValue(t.reserve_amount * plotUsd)})
+                        (≈ {formatUsdValue(t.reserve_amount * plotUsd)})
                       </span>
                     )}
                   </span>

--- a/src/app/dashboard/reader/page.tsx
+++ b/src/app/dashboard/reader/page.tsx
@@ -11,6 +11,8 @@ import { formatUnits } from "viem";
 import { ConnectWallet } from "../../../components/ConnectWallet";
 import { RESERVE_LABEL, PLOT_TOKEN, STORY_FACTORY, EXPLORER_URL } from "../../../../lib/contracts/constants";
 import { browserClient as publicClient } from "../../../../lib/rpc";
+import { formatUsdValue } from "../../../../lib/usd-price";
+import { usePlotUsdPrice } from "../../../hooks/usePlotUsdPrice";
 import { type Address } from "viem";
 
 /** Truncate formatUnits output to at most `digits` decimal places */
@@ -189,6 +191,7 @@ function DonationRow({ donation, decimals }: { donation: Donation; decimals: num
 const TRADE_PAGE_SIZE = 10;
 
 function TradingHistory({ address }: { address: string }) {
+  const { data: plotUsd } = usePlotUsdPrice();
   const {
     data,
     isLoading,
@@ -287,6 +290,11 @@ function TradingHistory({ address }: { address: string }) {
                 <div className="flex shrink-0 items-center gap-2">
                   <span className="text-foreground font-medium">
                     {formatPrice(t.reserve_amount)} {RESERVE_LABEL}
+                    {plotUsd && (
+                      <span className="text-muted ml-1 text-[10px] font-normal">
+                        ({formatUsdValue(t.reserve_amount * plotUsd)})
+                      </span>
+                    )}
                   </span>
                   {t.tx_hash && (
                     <a

--- a/src/app/dashboard/writer/page.tsx
+++ b/src/app/dashboard/writer/page.tsx
@@ -18,6 +18,7 @@ import { truncateAddress } from "../../../../lib/utils";
 import { formatPrice } from "../../../../lib/format";
 import Link from "next/link";
 import { ConnectWallet } from "../../../components/ConnectWallet";
+import { usePlotUsdPrice } from "../../../hooks/usePlotUsdPrice";
 import { type Address } from "viem";
 
 function formatViewCountDashboard(n: number): string {
@@ -51,6 +52,7 @@ const languageOptions = LANGUAGES.map((l) => ({ value: l, label: l }));
 
 export default function WriterDashboard() {
   const { address, isConnected } = useAccount();
+  const { data: plotUsd } = usePlotUsdPrice();
 
   const { data: storylines = [], isLoading, error } = useQuery({
     queryKey: ["writer-storylines", address],
@@ -91,7 +93,7 @@ export default function WriterDashboard() {
 
       <div className="mt-8 space-y-4">
         {storylines.map((s) => (
-          <StorylineDetail key={s.id} storyline={s} writerAddress={address!} />
+          <StorylineDetail key={s.id} storyline={s} writerAddress={address!} plotUsd={plotUsd} />
         ))}
         {!isLoading && !error && storylines.length === 0 && (
           <p className="text-muted py-8 text-center text-sm">
@@ -103,7 +105,7 @@ export default function WriterDashboard() {
   );
 }
 
-function StorylineDetail({ storyline, writerAddress }: { storyline: Storyline; writerAddress: Address }) {
+function StorylineDetail({ storyline, writerAddress, plotUsd }: { storyline: Storyline; writerAddress: Address; plotUsd?: number | null }) {
   return (
     <div className="border-border rounded border px-4 py-4">
       <div className="flex items-start justify-between gap-3">
@@ -172,11 +174,12 @@ function StorylineDetail({ storyline, writerAddress }: { storyline: Storyline; w
 
       {storyline.token_address && (
         <div className="mt-3 space-y-2">
-          <WriterTradingStats storyline={storyline} />
+          <WriterTradingStats storyline={storyline} plotUsd={plotUsd} />
           <ClaimRoyalties
             tokenAddress={storyline.token_address as Address}
             plotCount={storyline.plot_count}
             beneficiary={writerAddress}
+            plotUsd={plotUsd}
           />
         </div>
       )}

--- a/src/components/ClaimRoyalties.tsx
+++ b/src/components/ClaimRoyalties.tsx
@@ -8,7 +8,6 @@ import { browserClient } from "../../lib/rpc";
 import { mcv2BondAbi, getTokenTVL } from "../../lib/price";
 import { MCV2_BOND, RESERVE_LABEL, EXPLORER_URL, PLOT_TOKEN } from "../../lib/contracts/constants";
 import { formatUsdValue } from "../../lib/usd-price";
-import { usePlotUsdPrice } from "../hooks/usePlotUsdPrice";
 
 function formatTruncated(value: bigint, decimals: number, digits = 10): string {
   const raw = formatUnits(value, decimals);
@@ -24,9 +23,10 @@ interface ClaimRoyaltiesProps {
   tokenAddress: Address;
   plotCount: number;
   beneficiary: Address;
+  plotUsd?: number | null;
 }
 
-export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary }: ClaimRoyaltiesProps) {
+export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary, plotUsd }: ClaimRoyaltiesProps) {
   const [txState, setTxState] = useState<TxState>("idle");
   const [error, setError] = useState<string | null>(null);
   const [claimedAmount, setClaimedAmount] = useState<bigint>(BigInt(0));
@@ -34,7 +34,6 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary }: ClaimRo
   const [showTooltip, setShowTooltip] = useState(false);
 
   const { writeContractAsync } = useWriteContract();
-  const { data: plotUsd } = usePlotUsdPrice();
 
   // Fetch unclaimed royalty balance + cumulative claimed
   const { data: royaltyInfo } = useQuery({
@@ -151,7 +150,7 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary }: ClaimRo
           </span>
           {unclaimed > BigInt(0) && plotUsd && (
             <span className="text-muted ml-1 text-[10px]">
-              ({formatUsdValue(parseFloat(formatUnits(unclaimed, decimals)) * plotUsd)})
+              (≈ {formatUsdValue(parseFloat(formatUnits(unclaimed, decimals)) * plotUsd)})
             </span>
           )}
           {totalClaimed > BigInt(0) && (

--- a/src/components/ClaimRoyalties.tsx
+++ b/src/components/ClaimRoyalties.tsx
@@ -7,6 +7,8 @@ import { formatUnits, type Address } from "viem";
 import { browserClient } from "../../lib/rpc";
 import { mcv2BondAbi, getTokenTVL } from "../../lib/price";
 import { MCV2_BOND, RESERVE_LABEL, EXPLORER_URL, PLOT_TOKEN } from "../../lib/contracts/constants";
+import { formatUsdValue } from "../../lib/usd-price";
+import { usePlotUsdPrice } from "../hooks/usePlotUsdPrice";
 
 function formatTruncated(value: bigint, decimals: number, digits = 10): string {
   const raw = formatUnits(value, decimals);
@@ -32,6 +34,7 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary }: ClaimRo
   const [showTooltip, setShowTooltip] = useState(false);
 
   const { writeContractAsync } = useWriteContract();
+  const { data: plotUsd } = usePlotUsdPrice();
 
   // Fetch unclaimed royalty balance + cumulative claimed
   const { data: royaltyInfo } = useQuery({
@@ -146,6 +149,11 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary }: ClaimRo
           <span className={`ml-1 font-medium ${unclaimed > BigInt(0) ? "text-accent" : "text-foreground"}`}>
             {formatTruncated(unclaimed, decimals)} {RESERVE_LABEL}
           </span>
+          {unclaimed > BigInt(0) && plotUsd && (
+            <span className="text-muted ml-1 text-[10px]">
+              ({formatUsdValue(parseFloat(formatUnits(unclaimed, decimals)) * plotUsd)})
+            </span>
+          )}
           {totalClaimed > BigInt(0) && (
             <span className="text-muted ml-1 text-[10px]">
               (claimed: {formatTruncated(totalClaimed, decimals)} {RESERVE_LABEL} so far)

--- a/src/components/ReaderPortfolio.tsx
+++ b/src/components/ReaderPortfolio.tsx
@@ -10,7 +10,6 @@ import { MCV2_BOND, RESERVE_LABEL, STORY_FACTORY } from "../../lib/contracts/con
 import { supabase, type Storyline } from "../../lib/supabase";
 import Link from "next/link";
 import { formatUsdValue } from "../../lib/usd-price";
-import { usePlotUsdPrice } from "../hooks/usePlotUsdPrice";
 
 interface Holding {
   storyline: Storyline;
@@ -21,9 +20,8 @@ interface Holding {
   reserveDecimals: number;
 }
 
-export function ReaderPortfolio() {
+export function ReaderPortfolio({ plotUsd }: { plotUsd?: number | null }) {
   const { address, isConnected } = useAccount();
-  const { data: plotUsd } = usePlotUsdPrice();
   const { data: holdings, isLoading } = useQuery({
     queryKey: ["reader-portfolio", address],
     queryFn: async (): Promise<Holding[]> => {
@@ -133,7 +131,7 @@ export function ReaderPortfolio() {
               </span>
               {plotUsd && (
                 <span className="text-muted ml-1 text-[10px]">
-                  ({formatUsdValue(parseFloat(formatUnits(totalValue, reserveDecimals)) * plotUsd)})
+                  (≈ {formatUsdValue(parseFloat(formatUnits(totalValue, reserveDecimals)) * plotUsd)})
                 </span>
               )}
             </div>
@@ -176,7 +174,7 @@ export function ReaderPortfolio() {
                     {formatPrice(formatUnits(h.value, h.reserveDecimals))} {RESERVE_LABEL}
                     {plotUsd && (
                       <span className="text-muted ml-1 text-[10px]">
-                        ({formatUsdValue(parseFloat(formatUnits(h.value, h.reserveDecimals)) * plotUsd)})
+                        (≈ {formatUsdValue(parseFloat(formatUnits(h.value, h.reserveDecimals)) * plotUsd)})
                       </span>
                     )}
                   </div>

--- a/src/components/ReaderPortfolio.tsx
+++ b/src/components/ReaderPortfolio.tsx
@@ -9,6 +9,8 @@ import { erc20Abi, mcv2BondAbi, get24hPriceChange, getTokenTVL } from "../../lib
 import { MCV2_BOND, RESERVE_LABEL, STORY_FACTORY } from "../../lib/contracts/constants";
 import { supabase, type Storyline } from "../../lib/supabase";
 import Link from "next/link";
+import { formatUsdValue } from "../../lib/usd-price";
+import { usePlotUsdPrice } from "../hooks/usePlotUsdPrice";
 
 interface Holding {
   storyline: Storyline;
@@ -21,6 +23,7 @@ interface Holding {
 
 export function ReaderPortfolio() {
   const { address, isConnected } = useAccount();
+  const { data: plotUsd } = usePlotUsdPrice();
   const { data: holdings, isLoading } = useQuery({
     queryKey: ["reader-portfolio", address],
     queryFn: async (): Promise<Holding[]> => {
@@ -128,6 +131,11 @@ export function ReaderPortfolio() {
               <span className="text-accent text-sm font-medium">
                 {formatPrice(formatUnits(totalValue, reserveDecimals))} {RESERVE_LABEL}
               </span>
+              {plotUsd && (
+                <span className="text-muted ml-1 text-[10px]">
+                  ({formatUsdValue(parseFloat(formatUnits(totalValue, reserveDecimals)) * plotUsd)})
+                </span>
+              )}
             </div>
             {bestPick && bestPick.priceChange !== null && (
               <div>
@@ -166,6 +174,11 @@ export function ReaderPortfolio() {
                 <div className="text-right">
                   <div className="text-foreground">
                     {formatPrice(formatUnits(h.value, h.reserveDecimals))} {RESERVE_LABEL}
+                    {plotUsd && (
+                      <span className="text-muted ml-1 text-[10px]">
+                        ({formatUsdValue(parseFloat(formatUnits(h.value, h.reserveDecimals)) * plotUsd)})
+                      </span>
+                    )}
                   </div>
                   {h.priceChange !== null && (
                     <div

--- a/src/components/WriterTradingStats.tsx
+++ b/src/components/WriterTradingStats.tsx
@@ -7,16 +7,15 @@ import { mcv2BondAbi, getTokenTVL } from "../../lib/price";
 import { MCV2_BOND, RESERVE_LABEL } from "../../lib/contracts/constants";
 import { formatPrice } from "../../lib/format";
 import { formatUsdValue } from "../../lib/usd-price";
-import { usePlotUsdPrice } from "../hooks/usePlotUsdPrice";
 import type { Storyline } from "../../lib/supabase";
 
 interface WriterTradingStatsProps {
   storyline: Storyline;
+  plotUsd?: number | null;
 }
 
-export function WriterTradingStats({ storyline }: WriterTradingStatsProps) {
+export function WriterTradingStats({ storyline, plotUsd }: WriterTradingStatsProps) {
   const tokenAddress = storyline.token_address as Address;
-  const { data: plotUsd } = usePlotUsdPrice();
 
   // Fetch price + TVL together so they succeed/fail atomically
   const { data } = useQuery({
@@ -54,7 +53,7 @@ export function WriterTradingStats({ storyline }: WriterTradingStatsProps) {
         </span>
         {data && plotUsd && (
           <span className="text-muted ml-1 text-[10px]">
-            ({formatUsdValue(parseFloat(data.price) * plotUsd)})
+            (≈ {formatUsdValue(parseFloat(data.price) * plotUsd)})
           </span>
         )}
       </div>
@@ -67,7 +66,7 @@ export function WriterTradingStats({ storyline }: WriterTradingStatsProps) {
         </span>
         {data && plotUsd && (
           <span className="text-muted ml-1 text-[10px]">
-            ({formatUsdValue(parseFloat(data.tvl) * plotUsd)})
+            (≈ {formatUsdValue(parseFloat(data.tvl) * plotUsd)})
           </span>
         )}
       </div>

--- a/src/components/WriterTradingStats.tsx
+++ b/src/components/WriterTradingStats.tsx
@@ -6,6 +6,8 @@ import { browserClient } from "../../lib/rpc";
 import { mcv2BondAbi, getTokenTVL } from "../../lib/price";
 import { MCV2_BOND, RESERVE_LABEL } from "../../lib/contracts/constants";
 import { formatPrice } from "../../lib/format";
+import { formatUsdValue } from "../../lib/usd-price";
+import { usePlotUsdPrice } from "../hooks/usePlotUsdPrice";
 import type { Storyline } from "../../lib/supabase";
 
 interface WriterTradingStatsProps {
@@ -14,6 +16,7 @@ interface WriterTradingStatsProps {
 
 export function WriterTradingStats({ storyline }: WriterTradingStatsProps) {
   const tokenAddress = storyline.token_address as Address;
+  const { data: plotUsd } = usePlotUsdPrice();
 
   // Fetch price + TVL together so they succeed/fail atomically
   const { data } = useQuery({
@@ -49,6 +52,11 @@ export function WriterTradingStats({ storyline }: WriterTradingStatsProps) {
         <span className="font-semibold text-accent">
           {data ? `${formatPrice(data.price)} ${RESERVE_LABEL}` : "—"}
         </span>
+        {data && plotUsd && (
+          <span className="text-muted ml-1 text-[10px]">
+            ({formatUsdValue(parseFloat(data.price) * plotUsd)})
+          </span>
+        )}
       </div>
       <div>
         <span className="block text-[10px] uppercase tracking-wider">
@@ -57,6 +65,11 @@ export function WriterTradingStats({ storyline }: WriterTradingStatsProps) {
         <span className="font-semibold text-accent">
           {data ? `${formatPrice(data.tvl)} ${RESERVE_LABEL}` : "—"}
         </span>
+        {data && plotUsd && (
+          <span className="text-muted ml-1 text-[10px]">
+            ({formatUsdValue(parseFloat(data.tvl) * plotUsd)})
+          </span>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Added muted `(≈ $X.XX)` USD equivalents next to PLOT values across all dashboards:

- **WriterTradingStats**: token price and TVL
- **ClaimRoyalties**: unclaimed royalties
- **ReaderPortfolio**: total value and per-holding value
- **TradingHistory**: trade amounts

Uses existing `usePlotUsdPrice()` hook (single fetch per component, cached 2min) and `formatUsdValue()` utility. No new API calls per row.

## Changed files
- `src/components/WriterTradingStats.tsx` — USD for price + TVL
- `src/components/ClaimRoyalties.tsx` — USD for unclaimed royalties
- `src/components/ReaderPortfolio.tsx` — USD for total + per-holding
- `src/app/dashboard/reader/page.tsx` — USD for trade amounts

## Test plan
- [ ] Writer Dashboard shows USD for token price, TVL, royalties
- [ ] Reader Portfolio shows USD for total and per-holding values
- [ ] Reader Trading History shows USD for trade amounts
- [ ] Mobile layout readable, no overflow
- [ ] `npm run build` passes

Fixes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)