### PR TITLE
Fix CJK content overflowing story page layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -89,6 +89,9 @@ code, pre, .font-mono {
   background-position-y: calc(var(--line-height) * 2);
   box-shadow: 0 0 0.75rem rgba(0, 0, 0, 0.06);
   border-radius: 4px;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  overflow-x: hidden;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- Adds `overflow-wrap: break-word`, `word-break: break-word`, and `overflow-x: hidden` to `.ruled-paper` in `globals.css`
- Fixes Chinese/Japanese text overflowing the container and pushing sidebar off-screen

Fixes #686

## Test plan
- [ ] https://plotlink.xyz/story/40 (Chinese) — text wraps within container, sidebar visible
- [ ] https://plotlink.xyz/story/39 (Japanese) — text wraps within container, sidebar visible
- [ ] English stories unaffected — normal wrapping preserved
- [ ] Korean stories unaffected
- [ ] Reading Mode CJK content wraps correctly
- [ ] Mobile view CJK content wraps correctly
- [ ] `npm run build` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)