### PR TITLE
Fix nav bar alignment and border-radius consistency

### DIFF
--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -53,7 +53,7 @@ export function ConnectWallet({ onNavigate, compact }: ConnectWalletProps = {}) 
         <Link
           href={`/profile/${address}`}
           onClick={onNavigate}
-          className="border-border text-accent inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs font-medium hover:opacity-80 transition-opacity"
+          className="border-border text-accent inline-flex h-7 items-center gap-1.5 rounded border px-2 py-1 text-xs font-medium hover:opacity-80 transition-opacity"
         >
           {profile?.pfpUrl && (
             // eslint-disable-next-line @next/next/no-img-element
@@ -77,7 +77,7 @@ export function ConnectWallet({ onNavigate, compact }: ConnectWalletProps = {}) 
       <Link
         href={`/profile/${address}`}
         onClick={onNavigate}
-        className="border-border text-accent inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium hover:opacity-80 transition-opacity"
+        className="border-border text-accent inline-flex items-center gap-1.5 rounded border px-3 py-1 text-xs font-medium hover:opacity-80 transition-opacity"
       >
         {profile?.pfpUrl && (
           // eslint-disable-next-line @next/next/no-img-element
@@ -116,8 +116,8 @@ export function ConnectWallet({ onNavigate, compact }: ConnectWalletProps = {}) 
               type="button"
               className={
                 compact
-                  ? "border-border text-accent hover:bg-accent hover:text-background rounded border px-2 py-1 text-xs font-medium transition-colors"
-                  : "border-border text-accent hover:bg-accent hover:text-background rounded-full border px-3 py-1 text-xs font-medium transition-colors"
+                  ? "border-border text-accent hover:bg-accent hover:text-background flex h-7 items-center rounded border px-2 py-1 text-xs font-medium transition-colors"
+                  : "border-border text-accent hover:bg-accent hover:text-background rounded border px-3 py-1 text-xs font-medium transition-colors"
               }
             >
               {compact ? "Connect" : "connect wallet"}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -72,17 +72,17 @@ export function NavBar() {
 
         {/* Right side: wallet + mobile toggle */}
         <div className="flex items-center gap-1.5">
-          {/* Desktop: pill ConnectWallet */}
+          {/* Desktop: ConnectWallet */}
           <div className="hidden md:block">
             <ConnectWallet />
           </div>
           {/* Mobile: matched-height boxes — PFP box + hamburger box */}
-          <div className="md:hidden">
+          <div className="flex items-center md:hidden">
             <ConnectWallet compact />
           </div>
           <button
             onClick={() => setMobileOpen(!mobileOpen)}
-            className="border-border text-muted hover:text-foreground flex items-center justify-center rounded border px-2 py-1 transition-colors md:hidden"
+            className="border-border text-muted hover:text-foreground flex h-7 items-center justify-center rounded border px-2 py-1 transition-colors md:hidden"
             aria-label="Toggle menu"
             aria-expanded={mobileOpen}
           >


### PR DESCRIPTION
## Summary
- **Mobile alignment**: Added explicit `h-7` height to both compact wallet box and hamburger button, wrapped compact wallet in `flex items-center` to ensure perfect vertical alignment
- **Border-radius consistency**: Changed `rounded-full` (pill) to `rounded` (square) on desktop wallet button — both mobile and desktop now use `rounded` to match PlotLink's terminal aesthetic

## Files changed
- `src/components/NavBar.tsx` — mobile flex wrapper + hamburger height
- `src/components/ConnectWallet.tsx` — consistent `rounded` border-radius + compact `h-7`

## Self-verification
- [x] Mobile: both boxes perfectly vertically aligned (same height + position)
- [x] Desktop + mobile: same border-radius style (both square/rounded, not mixed)
- [x] `npm run build` passes
- [x] NavBar tests pass

Fixes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)