### PR TITLE
Nav connected state: show wallet address instead of username

### DIFF
--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -65,9 +65,7 @@ export function ConnectWallet({ onNavigate, compact }: ConnectWalletProps = {}) 
               className="rounded-full"
             />
           )}
-          {profile
-            ? `@${profile.username.length > 10 ? profile.username.slice(0, 10) + "…" : profile.username}`
-            : displayAddr}
+          {displayAddr}
         </Link>
       );
     }
@@ -89,7 +87,7 @@ export function ConnectWallet({ onNavigate, compact }: ConnectWalletProps = {}) 
             className="rounded-full"
           />
         )}
-        {profile ? `@${profile.username}` : displayAddr}
+        {displayAddr}
       </Link>
     );
   }


### PR DESCRIPTION
## Summary
- Always display truncated wallet address (`0x4d68...b6c8`) in nav connected state instead of `@username`
- Both desktop (full) and mobile (compact) modes now show `[PFP] 0x4d68...b6c8`
- PFP still displays from Farcaster profile when available
- Clicking still navigates to profile page

Fixes #698

## Self-Verification
- [x] Desktop: shows `[PFP] 0x4d68...b6c8` (not `@username`)
- [x] Mobile: shows `[PFP] 0x4d68...b6c8` (not `@username`)
- [x] PFP still shows if Farcaster profile has one
- [x] Wallet-only users (no Farcaster): shows `0x4d68...b6c8` (same as before)
- [x] Clicking navigates to profile page
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)