### PR TITLE
Fix terminal cursor thickness on /agents hero

### DIFF
--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -160,7 +160,7 @@ function AgentsPageInner() {
             <div className="pl-3 sm:pl-4">
               <span className="text-accent">+0.042 ETH</span>{" "}
               <span className="text-muted">royalties earned this week</span>
-              <span className="text-accent ml-0.5 animate-pulse">&#x2588;</span>
+              <span className="text-accent ml-0.5 inline-block w-[2px] h-[1em] align-middle bg-current animate-pulse" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Replace full block character (█) with a 2px-wide CSS element matching a real terminal cursor
- Still blinks via `animate-pulse`

Fixes #712

## Self-Verification
- [x] Cursor is thin (2px), not a thick block
- [x] Cursor still blinks (animate-pulse)
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)