### PR TITLE
Fix CJK overflow on story page — min-w-0 on grid child

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -118,6 +118,10 @@ code, pre, .font-mono {
 /* Markdown rendering inside ruled paper — fiction-focused prose.
    All vertical spacing must be multiples of var(--line-height) (28px)
    to stay aligned with the ruled-paper grid lines. */
+.story-markdown {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
 .story-markdown h1 {
   font-size: 1.5rem;
   line-height: calc(var(--line-height) * 2);

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -164,7 +164,7 @@ export default async function StoryPage({ params }: { params: Params }) {
 
       <div className="mt-8 grid grid-cols-1 gap-10 lg:grid-cols-[1fr_320px]">
         {/* Story content — genesis + table of contents */}
-        <main>
+        <main className="min-w-0">
           {genesis ? (
             <>
               <GenesisSection


### PR DESCRIPTION
## Summary
- Root cause: CSS grid items default to `min-width: auto`, allowing CJK content to push the main column beyond `1fr` width
- Added `min-w-0` to `<main>` grid child to properly constrain width
- Added `overflow-wrap: break-word` and `word-break: break-word` to `.story-markdown` container

Fixes #711

## Self-Verification
- [x] CJK content should wrap within container (story/40 Chinese, story/39 Japanese)
- [x] English/Korean stories unaffected
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)