### PR TITLE
[#734] Moleskine polish: Writer & Reader tabs

### DIFF
--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -804,12 +804,11 @@ function StoryRow({
     <>
     <div className="border-border rounded border divide-y divide-border text-xs">
       {/* Moleskine book (left) + Info (right) */}
-      <div className="flex flex-col sm:flex-row gap-4 px-4 py-3">
+      <div className="flex flex-row gap-4 px-4 py-3">
         {/* Moleskine book card */}
         <Link
           href={`/story/${storyline.storyline_id}`}
-          className="moleskine-notebook group relative block shrink-0 self-start"
-          style={{ width: "120px" }}
+          className="moleskine-notebook group relative block shrink-0 self-start w-[110px] sm:w-[150px]"
         >
           <div
             className="notebook-cover relative z-10 flex flex-col overflow-hidden border border-[var(--border)]"
@@ -844,12 +843,6 @@ function StoryRow({
 
         {/* Info (right) */}
         <div className="min-w-0 flex-1 space-y-1">
-          <Link
-            href={`/story/${storyline.storyline_id}`}
-            className="font-body text-base font-bold text-accent hover:opacity-80 transition-opacity"
-          >
-            {storyline.title}
-          </Link>
           <div className="space-y-0.5">
             <div>
               <span className="text-muted">Plots:</span> <span className="text-foreground font-medium">{storyline.plot_count}</span>
@@ -864,16 +857,18 @@ function StoryRow({
             <div><span className="text-muted">Views:</span> <span className="text-foreground font-medium">{formatViewCount(storyline.view_count)}</span></div>
             <div><span className="text-muted">Created:</span> <span className="text-foreground font-medium">{storyline.block_timestamp ? new Date(storyline.block_timestamp).toLocaleDateString("en-US", { month: "short", day: "numeric" }) : "—"}</span></div>
           </div>
+          {/* TVL + Donations (inline in info area) */}
+          {storyline.token_address && (
+            <>
+              <div className="border-t border-border w-12 my-1.5" />
+              <div className="space-y-0.5">
+                <WriterTradingStats storyline={storyline} plotUsd={plotUsd} showPrice={false} />
+                <StoryDonationCount storylineId={storyline.storyline_id} tokenAddress={storyline.token_address} />
+              </div>
+            </>
+          )}
         </div>
       </div>
-
-      {/* TVL + Donations (below book row, no Price) */}
-      {storyline.token_address && (
-        <div className="px-4 py-2 space-y-1">
-          <WriterTradingStats storyline={storyline} plotUsd={plotUsd} showPrice={false} />
-          <StoryDonationCount storylineId={storyline.storyline_id} tokenAddress={storyline.token_address} />
-        </div>
-      )}
 
       {/* Deadline */}
       {!storyline.sunset && storyline.last_plot_time && (
@@ -1387,15 +1382,14 @@ function PortfolioTab({ address, isOwnProfile }: { address: string; isOwnProfile
       {/* Token holdings */}
       {hasHoldings && (
         <>
-        <p className="text-muted text-[10px] uppercase tracking-wider">Token Holdings</p>
+        <p className="text-muted text-[10px] uppercase tracking-wider">Story Token Holdings</p>
         {holdings!.map((h) => (
         <div key={h.storyline.id} className="border-border rounded border text-xs">
           {/* Moleskine book (left) + Info (right) */}
-          <div className="flex flex-col sm:flex-row gap-4 px-4 py-3">
+          <div className="flex flex-row gap-4 px-4 py-3">
             <Link
               href={`/story/${h.storyline.storyline_id}`}
-              className="moleskine-notebook group relative block shrink-0 self-start"
-              style={{ width: "120px" }}
+              className="moleskine-notebook group relative block shrink-0 self-start w-[110px] sm:w-[150px]"
             >
               <div
                 className="notebook-cover relative z-10 flex flex-col overflow-hidden border border-[var(--border)]"

--- a/src/components/ClaimRoyalties.tsx
+++ b/src/components/ClaimRoyalties.tsx
@@ -111,8 +111,8 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary, plotUsd }
   return (
     <div className="text-xs space-y-1">
       <p className="text-muted text-[10px] uppercase tracking-wider">Royalties</p>
-      {/* Claimable row */}
-      <div>
+      {/* Claimable row + Claim button inline */}
+      <div className="flex items-center gap-2">
         <span className="text-muted">Claimable:</span>{" "}
         <span className={`font-medium ${unclaimed > BigInt(0) ? "text-accent" : "text-foreground"}`}>
           {formatTruncated(unclaimed, decimals)} {RESERVE_LABEL}
@@ -120,9 +120,6 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary, plotUsd }
         {plotUsd != null && unclaimed > BigInt(0) && (
           <span className="text-muted"> ({formatUsdValue(parseFloat(formatUnits(unclaimed, decimals)) * plotUsd)})</span>
         )}
-      </div>
-      {/* Claim button */}
-      <div className="flex items-center gap-2 justify-end">
         <button
           onClick={txState === "error" ? reset : executeClaim}
           disabled={


### PR DESCRIPTION
## Summary
- Increase Moleskine book size to 150px desktop / 110px mobile (both tabs)
- Remove duplicated title outside the book (Writer tab) — title only inside book
- Move TVL + Donations into right-side info area below Created with `border-t w-12` separator
- Mobile: always `flex-row` — info always next to book, never stacked below (both tabs)
- Claim button inline on same row as Claimable value
- Rename "TOKEN HOLDINGS" → "STORY TOKEN HOLDINGS" (Reader tab)

Fixes #734

## Test plan
- [ ] Writer tab: verify book is ~150px on desktop, ~110px on mobile (375px)
- [ ] Writer tab: title appears only inside the book, not duplicated outside
- [ ] Writer tab: TVL + Donations appear in the right info area below Created with short separator
- [ ] Writer tab: on 375px mobile, book and info are side-by-side (flex-row)
- [ ] Writer tab: Claim button is inline next to Claimable value
- [ ] Reader tab: "STORY TOKEN HOLDINGS" header text
- [ ] Reader tab: book + info always side-by-side
- [ ] Reader tab: book is same larger size (150px desktop / 110px mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)