### PR TITLE
[#739] Fix plot_count +1 bug: reconcile after genesis plot

### DIFF
--- a/src/app/api/cron/backfill/route.ts
+++ b/src/app/api/cron/backfill/route.ts
@@ -307,6 +307,9 @@ async function processStorylineCreated(
     throw new Error(`Database error (genesis plot): ${plotError.message}`);
   }
 
+  // Reconcile plot_count from actual plots rows (prevents genesis double-count)
+  await reconcileStorylinePlotCount(supabase, Number(storylineId));
+
   return { genesisPlotFailed: false };
 }
 

--- a/src/app/api/cron/reconcile-plots/route.ts
+++ b/src/app/api/cron/reconcile-plots/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { createServerClient } from "../../../../../lib/supabase";
+import { reconcileStorylinePlotCount } from "../../../../../lib/reconcile";
+import { STORY_FACTORY } from "../../../../../lib/contracts/constants";
+
+/**
+ * One-time reconciliation endpoint: re-counts plot_count for ALL storylines
+ * from the plots table. Safe to run multiple times (idempotent).
+ *
+ * POST /api/cron/reconcile-plots
+ */
+export async function POST() {
+  const supabase = createServerClient();
+  if (!supabase) {
+    return NextResponse.json({ error: "Supabase not configured" }, { status: 500 });
+  }
+
+  // Fetch all storyline IDs
+  const { data: storylines, error: fetchError } = await supabase
+    .from("storylines")
+    .select("storyline_id")
+    .eq("contract_address", STORY_FACTORY.toLowerCase());
+
+  if (fetchError) {
+    return NextResponse.json({ error: fetchError.message }, { status: 500 });
+  }
+
+  if (!storylines || storylines.length === 0) {
+    return NextResponse.json({ reconciled: 0 });
+  }
+
+  let reconciled = 0;
+  const errors: string[] = [];
+
+  for (const s of storylines) {
+    try {
+      await reconcileStorylinePlotCount(supabase, s.storyline_id);
+      reconciled++;
+    } catch (err) {
+      errors.push(`storyline ${s.storyline_id}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return NextResponse.json({ reconciled, total: storylines.length, errors });
+}

--- a/src/app/api/cron/reconcile-plots/route.ts
+++ b/src/app/api/cron/reconcile-plots/route.ts
@@ -9,7 +9,20 @@ import { STORY_FACTORY } from "../../../../../lib/contracts/constants";
  *
  * POST /api/cron/reconcile-plots
  */
-export async function POST() {
+/** Cron authorization — fail closed in production when CRON_SECRET is unset */
+function verifyCron(req: Request): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    return process.env.NODE_ENV !== "production";
+  }
+  const authHeader = req.headers.get("authorization");
+  return authHeader === `Bearer ${secret}`;
+}
+
+export async function POST(req: Request) {
+  if (!verifyCron(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   const supabase = createServerClient();
   if (!supabase) {
     return NextResponse.json({ error: "Supabase not configured" }, { status: 500 });

--- a/src/app/api/index/storyline/route.ts
+++ b/src/app/api/index/storyline/route.ts
@@ -12,6 +12,7 @@ import { detectWriterType } from "../../../../../lib/contracts/erc8004";
 import { hashContent } from "../../../../../lib/content";
 import { GENRES, LANGUAGES } from "../../../../../lib/genres";
 import type { Database } from "../../../../../lib/supabase";
+import { reconcileStorylinePlotCount } from "../../../../../lib/reconcile";
 
 const IPFS_GATEWAY = "https://ipfs.filebase.io/ipfs/";
 const IPFS_TIMEOUT_MS = 10_000;
@@ -178,6 +179,9 @@ export async function POST(req: Request) {
   if (plotDbError) {
     return error(`Database error (genesis plot): ${plotDbError.message}`, 500);
   }
+
+  // Reconcile plot_count from actual plots rows (prevents genesis double-count)
+  await reconcileStorylinePlotCount(supabase, Number(storylineId));
 
   return NextResponse.json({ success: true });
 }


### PR DESCRIPTION
## Summary
- **Root cause**: `StorylineCreated` handler hardcodes `plot_count: 1` but never calls `reconcileStorylinePlotCount()`, unlike the `PlotChained` handler which does. This causes the cached `plot_count` to drift by +1.
- **Fix**: Add `reconcileStorylinePlotCount()` after genesis plot upsert in both:
  - `src/app/api/index/storyline/route.ts` (live indexer)
  - `src/app/api/cron/backfill/route.ts` (backfill cron)
- **Why Reading Mode was correct**: It counts actual chapter objects, not the cached `plot_count` field.
- All display surfaces (profile, story page, cards, OG images) use `storyline.plot_count` from DB — no UI changes needed.

Fixes #739

## Test plan
- [ ] Verify existing storylines show correct plot count after a backfill run
- [ ] Create a new storyline — plot_count should be 1 (not 2)
- [ ] Chain a second plot — plot_count should be 2
- [ ] Reading Mode count matches profile/story page count
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)