### PR TITLE
[#750] Writer Stats: rename to Donations Received + add Royalties Claimed

### DIFF
--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -183,6 +183,7 @@ export default function ProfilePage() {
           agentMeta={agentMeta ?? null}
           isOwnProfile={isOwnProfile}
           connectedAddress={connectedAddress ?? null}
+          claimedRoyalties={claimedRoyalties}
         />
       )}
       {tab === "portfolio" && <PortfolioTab address={address} isOwnProfile={isOwnProfile} />}
@@ -526,12 +527,14 @@ function StoriesTab({
   agentMeta,
   isOwnProfile,
   connectedAddress,
+  claimedRoyalties,
 }: {
   address: string;
   isAgent: boolean;
   agentMeta: AgentMetadata | null;
   isOwnProfile: boolean;
   connectedAddress: string | null;
+  claimedRoyalties?: bigint;
 }) {
   const { data: plotUsd } = usePlotUsdPrice();
   const { data: storylines = [], isLoading, error } = useQuery({
@@ -726,7 +729,7 @@ function StoriesTab({
           </div>
         </div>
         <div className="border-border rounded border px-3 py-1.5">
-          <span className="text-muted">Received:</span>{" "}
+          <span className="text-muted">Donations Received:</span>{" "}
           <span className="text-foreground font-medium">
             {totalDonations > BigInt(0) ? `${formatPrice(formatUnits(totalDonations, 18))} ${RESERVE_LABEL}` : "—"}
           </span>
@@ -734,6 +737,17 @@ function StoriesTab({
             <span className="text-muted"> ({formatUsdValue(Number(formatUnits(totalDonations, 18)) * plotUsd)})</span>
           )}
         </div>
+        {claimedRoyalties !== undefined && claimedRoyalties > BigInt(0) && (
+          <div className="border-border rounded border px-3 py-1.5">
+            <span className="text-muted">Royalties Claimed:</span>{" "}
+            <span className="text-foreground font-medium">
+              {formatPrice(formatUnits(claimedRoyalties, 18))} {RESERVE_LABEL}
+            </span>
+            {plotUsd != null && (
+              <span className="text-muted"> ({formatUsdValue(Number(formatUnits(claimedRoyalties, 18)) * plotUsd)})</span>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Agent extras */}


### PR DESCRIPTION
## Summary
- Rename "Received" → "Donations Received" in Writer Stats
- Add "Royalties Claimed" row using existing `claimedRoyalties` data from profile page (on-chain `getRoyaltyInfo`)
- Only shows Royalties Claimed row when amount > 0
- Passes `claimedRoyalties` from parent ProfilePage to StoriesTab

Fixes #750

## Test plan
- [ ] Writer Stats: label reads "Donations Received" (not just "Received")
- [ ] Writer Stats: "Royalties Claimed" row shows when royalties > 0
- [ ] Writer Stats: "Royalties Claimed" row hidden when no royalties
- [ ] Both rows show RESERVE_LABEL amount + USD value
- [ ] Verify at 375px mobile viewport
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)