### PR TITLE
[#755] Remove separator line above TVL in Writer storyline card

### DIFF
--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -920,7 +920,6 @@ function StoryRow({
           {/* TVL + Donations (inline in info area) */}
           {storyline.token_address && (
             <>
-              <div className="border-t border-border w-12 my-1.5" />
               <div className="space-y-0.5">
                 <WriterTradingStats storyline={storyline} plotUsd={plotUsd} showPrice={false} />
                 <StoryDonationCount storylineId={storyline.storyline_id} tokenAddress={storyline.token_address} />


### PR DESCRIPTION
## Summary
- Removes the `<div className="border-t border-border w-12 my-1.5" />` separator between stat boxes and TVL/Donations in the Writer tab StoryRow
- Single line deletion for a cleaner card layout

Fixes #755

## Test plan
- [ ] No separator line between stat boxes and TVL in Writer storyline cards
- [ ] TVL and Donations still display correctly
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)