### PR TITLE
[#762] Fix Reader holdings card overflow on mobile

### DIFF
--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -1486,7 +1486,7 @@ function PortfolioTab({ address, isOwnProfile }: { address: string; isOwnProfile
         {holdings!.map((h) => (
         <div key={h.storyline.id} className="border-border rounded border text-xs">
           {/* Moleskine book (left) + Info (right) */}
-          <div className="flex flex-row items-center gap-4 px-4 py-3">
+          <div className="flex flex-col sm:flex-row items-center gap-4 px-4 py-3">
             <Link
               href={`/story/${h.storyline.storyline_id}`}
               className="moleskine-notebook group relative block shrink-0 w-[130px] sm:w-[180px]"


### PR DESCRIPTION
## Summary
- Switches Reader holdings card layout from `flex-row` to `flex-col sm:flex-row`
- On mobile (375px), Moleskine book stacks on top with stat grid below at full width
- On desktop (sm+), layout remains side-by-side as before
- Single class change, no structural modifications

Fixes #762

## Test plan
- [ ] At 375px: Moleskine stacks above stat boxes, no overflow
- [ ] PnL and First Traded text fully visible on mobile
- [ ] At sm+ breakpoint: layout remains side-by-side
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)