### PR TITLE
[#763] Fix plot count +1: deduplicate and add unique constraint

### DIFF
--- a/lib/reconcile.ts
+++ b/lib/reconcile.ts
@@ -6,6 +6,8 @@ type SupabaseDB = SupabaseClient<Database>;
 /**
  * Reconcile a storyline's plot_count and last_plot_time from the plots table.
  * Uses COUNT(*) and MAX(block_timestamp) — idempotent and safe for replays.
+ * Relies on the unique constraint on (storyline_id, plot_index) to prevent
+ * duplicate rows that would inflate the count.
  *
  * Throws on any Supabase error so callers can handle failures.
  */

--- a/src/app/api/cron/backfill/route.ts
+++ b/src/app/api/cron/backfill/route.ts
@@ -302,7 +302,7 @@ async function processStorylineCreated(
   };
   const { error: plotError } = await supabase
     .from("plots")
-    .upsert(plotRow, { onConflict: "tx_hash,log_index" });
+    .upsert(plotRow, { onConflict: "storyline_id,plot_index", ignoreDuplicates: true });
   if (plotError) {
     throw new Error(`Database error (genesis plot): ${plotError.message}`);
   }
@@ -360,7 +360,7 @@ async function processPlotChained(
 
   const { error: plotError } = await supabase
     .from("plots")
-    .upsert(row, { onConflict: "tx_hash,log_index" });
+    .upsert(row, { onConflict: "storyline_id,plot_index", ignoreDuplicates: true });
   if (plotError) {
     throw new Error(`Database error (plot): ${plotError.message}`);
   }

--- a/src/app/api/cron/backfill/route.ts
+++ b/src/app/api/cron/backfill/route.ts
@@ -360,7 +360,7 @@ async function processPlotChained(
 
   const { error: plotError } = await supabase
     .from("plots")
-    .upsert(row, { onConflict: "storyline_id,plot_index", ignoreDuplicates: true });
+    .upsert(row, { onConflict: "storyline_id,plot_index" });
   if (plotError) {
     throw new Error(`Database error (plot): ${plotError.message}`);
   }

--- a/src/app/api/index/plot/route.ts
+++ b/src/app/api/index/plot/route.ts
@@ -129,7 +129,7 @@ export async function POST(req: Request) {
 
   const { error: dbError } = await supabase.from("plots").upsert(
     row,
-    { onConflict: "storyline_id,plot_index", ignoreDuplicates: true }
+    { onConflict: "storyline_id,plot_index" }
   );
 
   if (dbError) {

--- a/src/app/api/index/plot/route.ts
+++ b/src/app/api/index/plot/route.ts
@@ -129,7 +129,7 @@ export async function POST(req: Request) {
 
   const { error: dbError } = await supabase.from("plots").upsert(
     row,
-    { onConflict: "tx_hash,log_index" }
+    { onConflict: "storyline_id,plot_index", ignoreDuplicates: true }
   );
 
   if (dbError) {

--- a/src/app/api/index/storyline/route.ts
+++ b/src/app/api/index/storyline/route.ts
@@ -173,7 +173,7 @@ export async function POST(req: Request) {
 
   const { error: plotDbError } = await supabase.from("plots").upsert(
     plotRow,
-    { onConflict: "tx_hash,log_index" }
+    { onConflict: "storyline_id,plot_index", ignoreDuplicates: true }
   );
 
   if (plotDbError) {

--- a/supabase/migrations/00030_dedupe_plots_unique_constraint.sql
+++ b/supabase/migrations/00030_dedupe_plots_unique_constraint.sql
@@ -1,13 +1,17 @@
--- Deduplicate plots rows with the same (storyline_id, plot_index), keeping the
--- earliest entry (lowest id). Then add a unique constraint to prevent recurrence.
+-- Deduplicate plots rows with the same (storyline_id, plot_index), preferring
+-- the row with the richest data (non-null title first, then latest id as tiebreaker).
+-- Then add a unique constraint to prevent recurrence.
 -- Finally re-reconcile plot_count from the deduplicated data.
 
--- Step 1: Delete duplicate rows, keeping the one with the smallest id per pair
+-- Step 1: For each (storyline_id, plot_index) group, keep the best row:
+-- prefer rows with a non-empty title, then the latest id as tiebreaker.
 DELETE FROM plots
 WHERE id NOT IN (
-  SELECT MIN(id)
+  SELECT DISTINCT ON (storyline_id, plot_index) id
   FROM plots
-  GROUP BY storyline_id, plot_index
+  ORDER BY storyline_id, plot_index,
+    (COALESCE(title, '') != '') DESC,
+    id DESC
 );
 
 -- Step 2: Add unique constraint to prevent future duplicates

--- a/supabase/migrations/00030_dedupe_plots_unique_constraint.sql
+++ b/supabase/migrations/00030_dedupe_plots_unique_constraint.sql
@@ -1,0 +1,29 @@
+-- Deduplicate plots rows with the same (storyline_id, plot_index), keeping the
+-- earliest entry (lowest id). Then add a unique constraint to prevent recurrence.
+-- Finally re-reconcile plot_count from the deduplicated data.
+
+-- Step 1: Delete duplicate rows, keeping the one with the smallest id per pair
+DELETE FROM plots
+WHERE id NOT IN (
+  SELECT MIN(id)
+  FROM plots
+  GROUP BY storyline_id, plot_index
+);
+
+-- Step 2: Add unique constraint to prevent future duplicates
+ALTER TABLE plots
+  ADD CONSTRAINT plots_storyline_plot_unique UNIQUE (storyline_id, plot_index);
+
+-- Step 3: Re-reconcile plot_count and last_plot_time from deduplicated data
+UPDATE storylines s
+SET plot_count = sub.cnt,
+    last_plot_time = sub.latest
+FROM (
+  SELECT storyline_id,
+         COUNT(*) AS cnt,
+         MAX(block_timestamp) AS latest
+  FROM plots
+  GROUP BY storyline_id
+) sub
+WHERE s.storyline_id = sub.storyline_id
+  AND (s.plot_count IS DISTINCT FROM sub.cnt OR s.last_plot_time IS DISTINCT FROM sub.latest);


### PR DESCRIPTION
## Summary
- **Migration 00030**: Deduplicates any existing `(storyline_id, plot_index)` duplicates (keeps earliest), adds `UNIQUE(storyline_id, plot_index)` constraint, re-reconciles all plot counts
- **Indexer/backfill upserts**: Changed `onConflict` from `tx_hash,log_index` to `storyline_id,plot_index` with `ignoreDuplicates: true` — prevents genesis plot being double-inserted by both storyline and plot indexers
- **Root cause**: Genesis plot could be indexed twice via different tx_hash/log_index combos, inflating COUNT(*)

Fixes #763

## Test plan
- [ ] Migration runs cleanly (dedupe + constraint + reconcile)
- [ ] Plot counts are correct after migration
- [ ] New storyline creation doesn't fail on genesis plot insert
- [ ] Re-indexing a plot doesn't create duplicate rows
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)