### PR TITLE
[#764] Close mobile nav on outside tap via backdrop overlay

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -104,9 +104,17 @@ export function NavBar() {
         </div>
       </div>
 
+      {/* Mobile backdrop — closes menu on outside tap */}
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 z-40 md:hidden"
+          onClick={() => setMobileOpen(false)}
+        />
+      )}
+
       {/* Mobile dropdown */}
       {mobileOpen && (
-        <div className="border-t border-[var(--border)] bg-[var(--bg)] px-4 pb-3 pt-2 md:hidden">
+        <div className="relative z-50 border-t border-[var(--border)] bg-[var(--bg)] px-4 pb-3 pt-2 md:hidden">
           <div className="flex flex-col gap-1">
             {navLinks.map(({ href, label }) => {
               const active = isActive(href, label);


### PR DESCRIPTION
## Summary
- Adds a fixed transparent backdrop (`z-40`, `md:hidden`) behind the mobile nav dropdown (`z-50`) when menu is open
- Tapping the backdrop calls `setMobileOpen(false)` to dismiss the menu
- Desktop layout unaffected (backdrop is `md:hidden`)

Fixes #764

## Test plan
- [ ] Mobile: tapping outside the menu closes it
- [ ] Mobile: tapping menu links still works (navigates and closes)
- [ ] Mobile: hamburger toggle still works
- [ ] Desktop: no visible changes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)