### PR TITLE
[#768] Fix Farcaster auto-connect in Warpcast miniapp

### DIFF
--- a/lib/wagmi.ts
+++ b/lib/wagmi.ts
@@ -46,8 +46,7 @@ const walletConnectors = connectorsForWallets(
   },
 );
 
-// Farcaster miniapp connector first for auto-connect in Warpcast
-const connectors = [farcasterMiniApp(), ...walletConnectors];
+const connectors = walletConnectors;
 
 export const config = createConfig({
   chains: [base, baseSepolia],

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1009.0",
         "@farcaster/miniapp-node": "^0.1.13",
-        "@farcaster/miniapp-sdk": "^0.2.3",
-        "@farcaster/miniapp-wagmi-connector": "^1.1.1",
+        "@farcaster/miniapp-sdk": "^0.3.0",
+        "@farcaster/miniapp-wagmi-connector": "^2.0.0",
         "@rainbow-me/rainbowkit": "^2.2.10",
         "@supabase/supabase-js": "^2.99.1",
         "@tanstack/react-query": "^5.90.21",
@@ -2428,60 +2428,45 @@
       }
     },
     "node_modules/@farcaster/miniapp-sdk": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@farcaster/miniapp-sdk/-/miniapp-sdk-0.2.3.tgz",
-      "integrity": "sha512-FwxqGcYCXw3HyGfDuchFUmQN9Gd49jTJs585zzQv6l1Oba6A/vVVCYohEG6QxRT6b/UrdemImpNMGTnqAZ3hKw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@farcaster/miniapp-sdk/-/miniapp-sdk-0.3.0.tgz",
+      "integrity": "sha512-mxze24B5SSLwqpPqUmzthfsGGPeevJvDuOEbLJay1DDgPS/B0LswA0XXfz4d6pViA7Y4TkbeAPMAfuVZ9nIqgQ==",
       "license": "MIT",
       "dependencies": {
-        "@farcaster/miniapp-core": "0.5.1",
+        "@farcaster/miniapp-core": "0.6.0",
         "@farcaster/quick-auth": "^0.0.6",
         "comlink": "^4.4.2",
         "eventemitter3": "^5.0.1",
-        "ox": "^0.4.4"
+        "ox": "^0.14.0"
       }
     },
-    "node_modules/@farcaster/miniapp-sdk/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
-    },
-    "node_modules/@farcaster/miniapp-sdk/node_modules/ox": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.4.4.tgz",
-      "integrity": "sha512-oJPEeCDs9iNiPs6J0rTx+Y0KGeCGyCAA3zo94yZhm8G5WpOxrwUtn2Ie/Y8IyARSqqY/j9JTKA3Fc1xs1DvFnw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
+    "node_modules/@farcaster/miniapp-sdk/node_modules/@farcaster/miniapp-core": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@farcaster/miniapp-core/-/miniapp-core-0.6.0.tgz",
+      "integrity": "sha512-sgDQdU6fQDXYbNbjuvvwhww1rwf/S0JCnKsp/o2K+ubtboA3SOiy3Wrc+taBnAh56CCxVbZN9Hck3OpYh9wINw==",
       "license": "MIT",
       "dependencies": {
-        "@adraffy/ens-normalize": "^1.10.1",
-        "@noble/curves": "^1.6.0",
-        "@noble/hashes": "^1.5.0",
-        "@scure/bip32": "^1.5.0",
-        "@scure/bip39": "^1.4.0",
-        "abitype": "^1.0.6",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "@solana/web3.js": "^1.98.2",
+        "ox": "^0.14.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@farcaster/miniapp-sdk/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@farcaster/miniapp-wagmi-connector": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@farcaster/miniapp-wagmi-connector/-/miniapp-wagmi-connector-1.1.1.tgz",
-      "integrity": "sha512-sdKhRRZcbM1XXl6Z49UTLlgRBYMmyxM6z4KE3LTWQtjRzlc0JwGaxmjvhjl3mZNZFnyUAlhpoU7RfCJ4c2aTGg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@farcaster/miniapp-wagmi-connector/-/miniapp-wagmi-connector-2.0.0.tgz",
+      "integrity": "sha512-Ek41lXTc79SJSZYL06EXMSpz4q4fnrisMaU8B9IZWH/pt7L4IrblnjjYZGC/a0PITCqWgOPkgLNbP08+4Q3PDg==",
       "license": "MIT",
       "peerDependencies": {
-        "@farcaster/miniapp-sdk": "^0.2.3",
+        "@farcaster/miniapp-sdk": "^0.3.0",
         "@wagmi/core": "^2.14.1",
         "viem": "^2.21.55"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "workspaces": [
     "packages/*"
@@ -17,8 +17,8 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1009.0",
     "@farcaster/miniapp-node": "^0.1.13",
-    "@farcaster/miniapp-sdk": "^0.2.3",
-    "@farcaster/miniapp-wagmi-connector": "^1.1.1",
+    "@farcaster/miniapp-sdk": "^0.3.0",
+    "@farcaster/miniapp-wagmi-connector": "^2.0.0",
     "@rainbow-me/rainbowkit": "^2.2.10",
     "@supabase/supabase-js": "^2.99.1",
     "@tanstack/react-query": "^5.90.21",

--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -36,11 +36,7 @@ export function ConnectWallet({ onNavigate, compact }: ConnectWalletProps = {}) 
     const farcasterConnector = connectors.find((c) => c.type === "farcasterMiniApp");
     if (!farcasterConnector) return;
 
-    farcasterConnector.isAuthorized().then((authorized) => {
-      if (authorized) {
-        connect({ connector: farcasterConnector });
-      }
-    });
+    connect({ connector: farcasterConnector });
   }, [inMiniApp, connectors, connect, isConnected]);
 
   // Connected state


### PR DESCRIPTION
## Summary
- **Removes duplicate connector**: bare `farcasterMiniApp()` on line 50 of `wagmi.ts` removed; only the one inside `walletConnectors` via `farcasterWallet` remains
- **Removes isAuthorized() gate**: auto-connect now calls `connect()` directly when inside miniapp — Warpcast manages auth, so the gate was causing silent failures
- **Updates Farcaster packages**: `@farcaster/miniapp-wagmi-connector` 1.1.1 → 2.0.0, `@farcaster/miniapp-sdk` 0.2.3 → 0.3.0 (no breaking API changes)
- **Bumps version** to 0.1.13

Fixes #768

## Test plan
- [ ] Warpcast miniapp: wallet auto-connects without showing modal
- [ ] Web browser: RainbowKit modal shows standard wallets (MetaMask, etc.)
- [ ] Farcaster wallet option still appears in RainbowKit modal
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)