### PR TITLE
[#771] Fix Reader holdings grid full width on mobile

### DIFF
--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -1521,7 +1521,7 @@ function PortfolioTab({ address, isOwnProfile }: { address: string; isOwnProfile
                 </div>
               </div>
             </Link>
-            <div className="min-w-0 flex-1">
+            <div className="min-w-0 w-full sm:flex-1">
               <div className="grid grid-cols-2 gap-2">
                 {/* Value */}
                 <div className="border-border rounded border px-2 py-1.5 text-center">


### PR DESCRIPTION
## Summary
- Changes grid container class from `min-w-0 flex-1` to `min-w-0 w-full sm:flex-1`
- On mobile (flex-col): `w-full` ensures the stat grid stretches to full card width
- On desktop (sm:flex-row): `sm:flex-1` fills remaining space beside the Moleskine
- Matches the Portfolio grid's full-width appearance on mobile

Fixes #771

## Test plan
- [ ] Mobile (375px): 4-box grid spans full card width below Moleskine
- [ ] Desktop: grid fills space beside Moleskine (unchanged)
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)