### PR TITLE
[#774] Restructure storyline deadline + stats into 2-col grid

### DIFF
--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -290,7 +290,7 @@ function StoryHeader({
 
       {priceInfo && (
         <div className="mt-4 space-y-2 text-xs">
-          <div className="border-border bg-surface grid grid-cols-2 gap-2 rounded border px-3 py-2">
+          <div className="border-border bg-surface grid grid-cols-1 sm:grid-cols-2 gap-2 rounded border px-3 py-2">
             <MarketCapBox
               tokenAddress={storyline.token_address}
               totalSupply={parseFloat(priceInfo.totalSupply)}
@@ -317,7 +317,7 @@ function StoryHeader({
               <span className="text-muted block text-[10px] uppercase tracking-wider mb-1">
                 Next Plot Publish Deadline
               </span>
-              <DeadlineCountdown lastPlotTime={storyline.last_plot_time} />
+              <DeadlineCountdown lastPlotTime={storyline.last_plot_time} hideLabel />
             </div>
           ) : null}
         </div>

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -289,32 +289,39 @@ function StoryHeader({
       </div>
 
       {priceInfo && (
-        <div className="border-border bg-surface mt-4 grid grid-cols-2 gap-2 rounded border px-3 py-2 text-xs">
-          <MarketCapBox
-            tokenAddress={storyline.token_address}
-            totalSupply={parseFloat(priceInfo.totalSupply)}
-            pricePerToken={parseFloat(priceInfo.pricePerToken)}
-          />
-          <div>
-            <span className="text-muted block text-[10px] uppercase tracking-wider">
-              Supply Minted
-            </span>
-            <span className="font-semibold text-accent">
-              {formatSupply(priceInfo.totalSupply)} tokens
-            </span>
+        <div className="mt-4 space-y-2 text-xs">
+          <div className="border-border bg-surface grid grid-cols-2 gap-2 rounded border px-3 py-2">
+            <MarketCapBox
+              tokenAddress={storyline.token_address}
+              totalSupply={parseFloat(priceInfo.totalSupply)}
+              pricePerToken={parseFloat(priceInfo.pricePerToken)}
+            />
+            <div>
+              <span className="text-muted block text-[10px] uppercase tracking-wider">
+                Supply Minted
+              </span>
+              <span className="font-semibold text-accent">
+                {formatSupply(priceInfo.totalSupply)} tokens
+              </span>
+            </div>
           </div>
+          {storyline.sunset ? (
+            <div className="border-border bg-surface rounded border px-3 py-2">
+              <span className="text-muted">Story complete</span>
+              <span className="text-foreground ml-2">
+                {storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"} total
+              </span>
+            </div>
+          ) : storyline.last_plot_time ? (
+            <div className="border-border bg-surface rounded border px-3 py-2">
+              <span className="text-muted block text-[10px] uppercase tracking-wider mb-1">
+                Next Plot Publish Deadline
+              </span>
+              <DeadlineCountdown lastPlotTime={storyline.last_plot_time} />
+            </div>
+          ) : null}
         </div>
       )}
-      {storyline.sunset ? (
-        <div className="border-border bg-surface mt-4 rounded border px-3 py-2 text-xs">
-          <span className="text-muted">Story complete</span>
-          <span className="text-foreground ml-2">
-            {storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"} total
-          </span>
-        </div>
-      ) : storyline.last_plot_time ? (
-        <DeadlineCountdown lastPlotTime={storyline.last_plot_time} />
-      ) : null}
       {!storyline.sunset && (
         <AddPlotButton storylineId={storyline.storyline_id} writerAddress={storyline.writer_address} />
       )}

--- a/src/components/DeadlineCountdown.tsx
+++ b/src/components/DeadlineCountdown.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 
 const DEADLINE_HOURS = 168;
 
-export function DeadlineCountdown({ lastPlotTime }: { lastPlotTime: string }) {
+export function DeadlineCountdown({ lastPlotTime, hideLabel }: { lastPlotTime: string; hideLabel?: boolean }) {
   const [remaining, setRemaining] = useState<number | null>(null);
 
   useEffect(() => {
@@ -19,7 +19,7 @@ export function DeadlineCountdown({ lastPlotTime }: { lastPlotTime: string }) {
   if (remaining === null) {
     return (
       <div className="text-xs">
-        <span className="text-muted">Deadline:</span>{" "}
+        {!hideLabel && <><span className="text-muted">Deadline:</span>{" "}</>}
         <span className="text-accent font-medium">--</span>
       </div>
     );
@@ -28,7 +28,7 @@ export function DeadlineCountdown({ lastPlotTime }: { lastPlotTime: string }) {
   if (remaining <= 0) {
     return (
       <div className="text-xs">
-        <span className="text-muted">Deadline:</span>{" "}
+        {!hideLabel && <><span className="text-muted">Deadline:</span>{" "}</>}
         <span className="text-error font-medium">expired</span>
       </div>
     );

--- a/src/components/DeadlineCountdown.tsx
+++ b/src/components/DeadlineCountdown.tsx
@@ -50,7 +50,7 @@ export function DeadlineCountdown({ lastPlotTime, hideLabel }: { lastPlotTime: s
 
   return (
     <div className="text-xs">
-      <span className="text-muted">Deadline:</span>{" "}
+      {!hideLabel && <><span className="text-muted">Deadline:</span>{" "}</>}
       <span className="text-accent font-medium">{formatted}</span>
     </div>
   );


### PR DESCRIPTION
## Summary
- Market Cap + Supply Minted in a 2-column bordered grid
- Deadline countdown wrapped in a full-width bordered box with "Next Plot Publish Deadline" label
- Story complete state also in a bordered box within the same layout
- All boxes stack vertically on mobile via `space-y-2`

Fixes #774

## Test plan
- [ ] Market Cap and Supply Minted side by side on desktop
- [ ] Deadline box full-width below with proper label
- [ ] Mobile: all boxes stack vertically
- [ ] Story complete state displays properly
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)