### PR TITLE
[#775] Redesign storyline header: Writer label + cleaner layout

### DIFF
--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -260,20 +260,25 @@ function StoryHeader({
 }) {
   return (
     <header className="border-border border-b pb-6">
+      {/* Title */}
       <h1 className="font-body text-2xl font-bold tracking-tight text-accent">
         {storyline.title}
       </h1>
-      <div className="text-muted mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
-        <span>
-          by{" "}
-          <Suspense fallback={<span className="text-foreground">{truncateAddress(storyline.writer_address)}</span>}>
-            <WriterIdentity address={storyline.writer_address} />
-          </Suspense>
-        </span>
-        <span>
-          {storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"}
-        </span>
+
+      {/* Writer */}
+      <div className="mt-2 flex items-center gap-1.5 text-xs text-muted">
+        <span>Writer</span>
+        <Suspense fallback={<span className="text-foreground font-medium">{truncateAddress(storyline.writer_address)}</span>}>
+          <WriterIdentity address={storyline.writer_address} />
+        </Suspense>
+        {storyline.writer_type === 1 && <AgentBadge />}
+      </div>
+
+      {/* Stats + Badges */}
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted">
+        <span>{storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"}</span>
         <ViewCount storylineId={storyline.storyline_id} initialCount={storyline.view_count} />
+        <RatingSummary storylineId={storyline.storyline_id} />
         {storyline.genre && (
           <span className="border-border rounded border px-1.5 py-0.5 text-[10px]">
             {storyline.genre}
@@ -284,8 +289,6 @@ function StoryHeader({
             {storyline.language}
           </span>
         )}
-        {storyline.writer_type === 1 && <AgentBadge />}
-        <RatingSummary storylineId={storyline.storyline_id} />
       </div>
 
       {priceInfo && (

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -274,21 +274,31 @@ function StoryHeader({
         {storyline.writer_type === 1 && <AgentBadge />}
       </div>
 
-      {/* Stats + Badges */}
-      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted">
+      {/* Stats */}
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted">
         <span>{storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"}</span>
         <ViewCount storylineId={storyline.storyline_id} initialCount={storyline.view_count} />
+      </div>
+
+      {/* Badges */}
+      {(storyline.genre || (storyline.language && storyline.language !== "English")) && (
+        <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+          {storyline.genre && (
+            <span className="border-border rounded border px-1.5 py-0.5 text-[10px] text-muted">
+              {storyline.genre}
+            </span>
+          )}
+          {storyline.language && storyline.language !== "English" && (
+            <span className="border-border rounded border px-1.5 py-0.5 text-[10px] text-muted">
+              {storyline.language}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Rating */}
+      <div className="mt-1.5">
         <RatingSummary storylineId={storyline.storyline_id} />
-        {storyline.genre && (
-          <span className="border-border rounded border px-1.5 py-0.5 text-[10px]">
-            {storyline.genre}
-          </span>
-        )}
-        {storyline.language && storyline.language !== "English" && (
-          <span className="border-border rounded border px-1.5 py-0.5 text-[10px]">
-            {storyline.language}
-          </span>
-        )}
       </div>
 
       {priceInfo && (


### PR DESCRIPTION
## Summary
- Changes "by" prefix to "Writer" for the author line
- Splits header into 3 clear visual groups: Title, Writer (with PFP/username + AgentBadge), Stats+Badges (plots, views, rating, genre, language)
- Tighter spacing with `mt-2` between groups, `gap-x-3` for stats
- Mobile-friendly with `flex-wrap` on all rows

Fixes #775

## Test plan
- [ ] Author line shows "Writer @username" instead of "by @username"
- [ ] Header organized into Title → Writer → Stats+Badges
- [ ] Mobile (375px): no overflow, proper wrapping
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)