### PR TITLE
Fix stale nonce in Zap two-step trade flows

### DIFF
--- a/src/components/TradingWidget.tsx
+++ b/src/components/TradingWidget.tsx
@@ -28,6 +28,20 @@ function applySlippage(amount: bigint, isBuy: boolean): bigint {
 
 const isZapAvailable = ZAP_PLOTLINK !== "0x0000000000000000000000000000000000000000";
 
+/** Retry a writeContractAsync call once if it fails with a nonce error. */
+async function retryOnNonceError<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "";
+    if (msg.includes("nonce") && msg.includes("low")) {
+      await new Promise((r) => setTimeout(r, 500));
+      return await fn();
+    }
+    throw err;
+  }
+}
+
 function getTokenDecimals(payToken: PayToken): number {
   if (payToken === "USDC") return 6;
   return 18;
@@ -312,14 +326,12 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
               args: [ZAP_PLOTLINK, zapQuote.fromTokenAmount],
             });
             await publicClient.waitForTransactionReceipt({ hash: approveHash });
-            // Allow wallet provider to update its internal nonce after approval
-            await new Promise((r) => setTimeout(r, 500));
           }
         }
 
         setTxState("confirming");
         const tx = buildZapMintTx(fromToken, tokenAddress, parsedAmount, "exact-output", zapQuote);
-        const hash = await writeContractAsync(tx);
+        const hash = await retryOnNonceError(() => writeContractAsync(tx));
         setTxHash(hash);
         tradeHash = hash;
         setTxState("pending");
@@ -344,18 +356,16 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
             args: [MCV2_BOND, maxCost],
           });
           await publicClient.waitForTransactionReceipt({ hash: approveHash });
-          // Allow wallet provider to update its internal nonce after approval
-          await new Promise((r) => setTimeout(r, 500));
         }
 
         setTxState("confirming");
-        const hash = await writeContractAsync({
+        const hash = await retryOnNonceError(() => writeContractAsync({
           address: MCV2_BOND,
           abi: mcv2BondAbi,
           functionName: "mint",
           args: [tokenAddress, parsedAmount, maxCost, address],
           gas: BigInt(2_000_000),
-        });
+        }));
         setTxHash(hash);
         tradeHash = hash;
         setTxState("pending");
@@ -380,18 +390,16 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
             args: [MCV2_BOND, parsedAmount],
           });
           await publicClient.waitForTransactionReceipt({ hash: approveHash });
-          // Allow wallet provider to update its internal nonce after approval
-          await new Promise((r) => setTimeout(r, 500));
         }
 
         setTxState("confirming");
-        const hash = await writeContractAsync({
+        const hash = await retryOnNonceError(() => writeContractAsync({
           address: MCV2_BOND,
           abi: mcv2BondAbi,
           functionName: "burn",
           args: [tokenAddress, parsedAmount, minRefund, address],
           gas: BigInt(2_000_000),
-        });
+        }));
         setTxHash(hash);
         tradeHash = hash;
         setTxState("pending");

--- a/src/components/TradingWidget.tsx
+++ b/src/components/TradingWidget.tsx
@@ -312,6 +312,8 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
               args: [ZAP_PLOTLINK, zapQuote.fromTokenAmount],
             });
             await publicClient.waitForTransactionReceipt({ hash: approveHash });
+            // Allow wallet provider to update its internal nonce after approval
+            await new Promise((r) => setTimeout(r, 500));
           }
         }
 
@@ -342,6 +344,8 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
             args: [MCV2_BOND, maxCost],
           });
           await publicClient.waitForTransactionReceipt({ hash: approveHash });
+          // Allow wallet provider to update its internal nonce after approval
+          await new Promise((r) => setTimeout(r, 500));
         }
 
         setTxState("confirming");
@@ -376,6 +380,8 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
             args: [MCV2_BOND, parsedAmount],
           });
           await publicClient.waitForTransactionReceipt({ hash: approveHash });
+          // Allow wallet provider to update its internal nonce after approval
+          await new Promise((r) => setTimeout(r, 500));
         }
 
         setTxState("confirming");


### PR DESCRIPTION
## Summary
- Adds 500ms delay after `waitForTransactionReceipt` in all three approve→write paths in `TradingWidget.tsx`
- Fixes "nonce too low" error where `writeContractAsync` uses a stale cached nonce after an approval tx confirms

## Affected Flows
- Zap ERC-20 buy: approve → mint (line ~314)
- PLOT buy: approve → mint (line ~344)
- Sell: approve → burn (line ~378)

## Test Plan
- [ ] Execute a Zap buy with HUNT (requires approval) — verify mint succeeds after approval
- [ ] Execute a PLOT buy requiring approval — verify mint succeeds
- [ ] Execute a sell requiring approval — verify burn succeeds
- [ ] Verify no regression when approval is already sufficient (skip path)

Fixes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)