### PR TITLE
Format balance and est. cost values in trading widget

### DIFF
--- a/src/components/TradingWidget.tsx
+++ b/src/components/TradingWidget.tsx
@@ -38,7 +38,10 @@ function formatTokenAmount(value: bigint, decimals: number): string {
   if (num >= 0.001) {
     return num.toFixed(4);
   }
-  return num.toFixed(6);
+  if (num >= 0.000001) {
+    return num.toFixed(6);
+  }
+  return num.toExponential(2);
 }
 
 /** Retry a writeContractAsync call once if it fails with a nonce error. */

--- a/src/components/TradingWidget.tsx
+++ b/src/components/TradingWidget.tsx
@@ -28,6 +28,19 @@ function applySlippage(amount: bigint, isBuy: boolean): bigint {
 
 const isZapAvailable = ZAP_PLOTLINK !== "0x0000000000000000000000000000000000000000";
 
+/** Format a raw bigint token amount for display with appropriate precision. */
+function formatTokenAmount(value: bigint, decimals: number): string {
+  const num = Number(formatUnits(value, decimals));
+  if (num === 0) return "0";
+  if (num >= 1) {
+    return num.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }
+  if (num >= 0.001) {
+    return num.toFixed(4);
+  }
+  return num.toFixed(6);
+}
+
 /** Retry a writeContractAsync call once if it fails with a nonce error. */
 async function retryOnNonceError<T>(fn: () => Promise<T>): Promise<T> {
   try {
@@ -499,7 +512,7 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
           </div>
           {balance !== undefined && (
             <p className="text-muted mt-1 text-[10px]">
-              Balance: {formatUnits(balance, balanceDecimals)} {balanceLabel}
+              Balance: {formatTokenAmount(balance, balanceDecimals)} {balanceLabel}
             </p>
           )}
           {insufficientBalance && (
@@ -548,7 +561,7 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
         {/* Balance for sell tab and non-zap buy (PLOT direct) */}
         {(tab === "sell" || !isZapAvailable) && balance !== undefined && (
           <p className="text-muted mt-1 text-[10px]">
-            Balance: {formatUnits(balance, balanceDecimals)} {balanceLabel}
+            Balance: {formatTokenAmount(balance, balanceDecimals)} {balanceLabel}
           </p>
         )}
         {(tab === "sell" || !isZapAvailable) && insufficientBalance && (
@@ -561,7 +574,7 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
         <div className="text-muted mt-2 text-xs">
           Est. cost:{" "}
           <span className="font-semibold text-accent">
-            {formatUnits(zapQuote.fromTokenAmount, estimateDecimals)} {payToken}
+            {formatTokenAmount(zapQuote.fromTokenAmount, estimateDecimals)} {payToken}
           </span>
           <span className="ml-2">(incl. 3% slippage)</span>
         </div>
@@ -570,7 +583,7 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
         <div className="text-muted mt-2 text-xs">
           {tab === "buy" ? "Max cost" : "Min return"}:{" "}
           <span className="font-semibold text-accent">
-            {formatUnits(applySlippage(estimate, tab === "buy"), 18)} {RESERVE_LABEL}
+            {formatTokenAmount(applySlippage(estimate, tab === "buy"), 18)} {RESERVE_LABEL}
           </span>
           <span className="ml-2">(incl. 3% slippage)</span>
         </div>


### PR DESCRIPTION
## Summary
- Adds `formatTokenAmount()` helper to `TradingWidget.tsx` with tiered precision:
  - Values >= 1: 2 decimal places with thousands separators (e.g. `5,034.43`)
  - Values >= 0.001: 4 decimal places (e.g. `0.0033`)
  - Values < 0.001: 6 decimal places (e.g. `0.000001`)
- Applied to all balance displays (2 locations) and estimate cost/return values (2 locations)
- Works across all pay token modes (ETH, USDC, HUNT, PLOT)

## Before/After
- Balance: `5034.425044895956140455 HUNT` → `5,034.43 HUNT`
- Est. cost: `68.623631443223832041 HUNT` → `68.62 HUNT`

## Test Plan
- [ ] Verify balance formatting in buy tab (ETH, USDC, HUNT, PLOT modes)
- [ ] Verify balance formatting in sell tab
- [ ] Verify est. cost formatting for Zap buys
- [ ] Verify max cost / min return formatting for PLOT direct trades
- [ ] Verify small values (< 0.001) display correctly

Fixes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)