### PR TITLE
Storyline page: MCap + Deadline on same line on desktop

### DIFF
--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -302,37 +302,39 @@ function StoryHeader({
       </div>
 
       {priceInfo && (
-        <div className="mt-4 space-y-2 text-xs">
+        <div className="mt-4 text-xs">
           <div className="border-border bg-surface grid grid-cols-1 sm:grid-cols-2 gap-2 rounded border px-3 py-2">
-            <MarketCapBox
-              tokenAddress={storyline.token_address}
-              totalSupply={parseFloat(priceInfo.totalSupply)}
-              pricePerToken={parseFloat(priceInfo.pricePerToken)}
-            />
-            <div>
-              <span className="text-muted block text-[10px] uppercase tracking-wider">
-                Supply Minted
-              </span>
-              <span className="font-semibold text-accent">
-                {formatSupply(priceInfo.totalSupply)} tokens
-              </span>
+            <div className="space-y-2">
+              <MarketCapBox
+                tokenAddress={storyline.token_address}
+                totalSupply={parseFloat(priceInfo.totalSupply)}
+                pricePerToken={parseFloat(priceInfo.pricePerToken)}
+              />
+              <div>
+                <span className="text-muted block text-[10px] uppercase tracking-wider">
+                  Supply Minted
+                </span>
+                <span className="font-semibold text-accent">
+                  {formatSupply(priceInfo.totalSupply)} tokens
+                </span>
+              </div>
             </div>
+            {storyline.sunset ? (
+              <div>
+                <span className="text-muted">Story complete</span>
+                <span className="text-foreground ml-2">
+                  {storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"} total
+                </span>
+              </div>
+            ) : storyline.last_plot_time ? (
+              <div>
+                <span className="text-muted block text-[10px] uppercase tracking-wider mb-1">
+                  Next Plot Publish Deadline
+                </span>
+                <DeadlineCountdown lastPlotTime={storyline.last_plot_time} hideLabel />
+              </div>
+            ) : null}
           </div>
-          {storyline.sunset ? (
-            <div className="border-border bg-surface rounded border px-3 py-2">
-              <span className="text-muted">Story complete</span>
-              <span className="text-foreground ml-2">
-                {storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"} total
-              </span>
-            </div>
-          ) : storyline.last_plot_time ? (
-            <div className="border-border bg-surface rounded border px-3 py-2">
-              <span className="text-muted block text-[10px] uppercase tracking-wider mb-1">
-                Next Plot Publish Deadline
-              </span>
-              <DeadlineCountdown lastPlotTime={storyline.last_plot_time} hideLabel />
-            </div>
-          ) : null}
         </div>
       )}
       {!storyline.sunset && (


### PR DESCRIPTION
## Summary
- Moves Deadline/Story Complete into the existing 2-col stats grid
- Desktop (sm+): MCap + Supply Minted in left column, Deadline in right column
- Mobile: Stacks vertically as before (unchanged behavior)

## Layout Change
**Before:** MCap+Supply in a 2-col grid, Deadline in a separate box below
**After:** Single bordered grid with MCap+Supply (left) and Deadline (right) on desktop

## Test Plan
- [ ] Desktop: verify MCap and Deadline appear side by side
- [ ] Mobile: verify vertical stacking is preserved
- [ ] Verify "Story complete" state renders correctly in the right column
- [ ] Verify storylines without `last_plot_time` don't show an empty right column

Fixes #783

🤖 Generated with [Claude Code](https://claude.com/claude-code)