### PR TITLE
Storyline page: MCap + Supply inline on mobile

### DIFF
--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -304,7 +304,7 @@ function StoryHeader({
       {priceInfo && (
         <div className="mt-4 text-xs">
           <div className="border-border bg-surface grid grid-cols-1 sm:grid-cols-2 gap-2 rounded border px-3 py-2">
-            <div className="space-y-2">
+            <div className="grid grid-cols-2 gap-2">
               <MarketCapBox
                 tokenAddress={storyline.token_address}
                 totalSupply={parseFloat(priceInfo.totalSupply)}


### PR DESCRIPTION
## Summary
- Changes MCap + Supply Minted from vertical stack to `grid grid-cols-2` layout
- Market Cap and Supply Minted now display side by side on all screen sizes including mobile

## Change
One-line CSS change: `space-y-2` → `grid grid-cols-2 gap-2` on the stats left column.

## Test Plan
- [ ] Mobile: verify MCap and Supply appear side by side
- [ ] Desktop: verify no regression (MCap+Supply left, Deadline right still works)
- [ ] Verify MarketCapBox content doesn't overflow on narrow screens

Fixes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)