### PR TITLE
Reader tab: style recent trades like Activity tab FeedRow

### DIFF
--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -1579,7 +1579,7 @@ function HoldingRecentTrades({ address, storylineId, plotUsd }: { address: strin
       if (!supabase) return [];
       const { data } = await supabase
         .from("trade_history")
-        .select("event_type, reserve_amount, block_timestamp")
+        .select("event_type, reserve_amount, block_timestamp, tx_hash")
         .eq("user_address", address)
         .eq("storyline_id", storylineId)
         .eq("contract_address", MCV2_BOND.toLowerCase())
@@ -1599,10 +1599,25 @@ function HoldingRecentTrades({ address, storylineId, plotUsd }: { address: strin
         const date = new Date(t.block_timestamp).toLocaleDateString("en-US", { month: "short", day: "numeric" });
         const amount = plotUsd != null ? formatUsdValue(t.reserve_amount * plotUsd) : `${formatPrice(t.reserve_amount)} ${RESERVE_LABEL}`;
         return (
-          <div key={i} className="flex items-center justify-between text-[10px]">
-            <span className={isBuy ? "text-accent" : "text-error"}>{isBuy ? "Buy" : "Sell"}</span>
+          <div key={i} className="border-border flex items-center gap-2 rounded border px-3 py-1.5 text-xs">
+            <span className={`font-medium shrink-0 w-8 ${isBuy ? "text-green-700" : "text-red-700"}`}>
+              {isBuy ? "Buy" : "Sell"}
+            </span>
             <span className="text-foreground">{amount}</span>
-            <span className="text-muted">{date}</span>
+            <time dateTime={t.block_timestamp} className="text-muted ml-auto whitespace-nowrap text-[10px]">
+              {date}
+            </time>
+            {t.tx_hash && (
+              <a
+                href={`${EXPLORER_URL}/tx/${t.tx_hash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted hover:text-accent transition-colors"
+                title="View on Basescan"
+              >
+                &#x2197;
+              </a>
+            )}
           </div>
         );
       })}

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -1604,19 +1604,20 @@ function HoldingRecentTrades({ address, storylineId, plotUsd }: { address: strin
               {isBuy ? "Buy" : "Sell"}
             </span>
             <span className="text-foreground">{amount}</span>
-            <time dateTime={t.block_timestamp} className="text-muted ml-auto whitespace-nowrap text-[10px]">
-              {date}
-            </time>
-            {t.tx_hash && (
+            {t.tx_hash ? (
               <a
                 href={`${EXPLORER_URL}/tx/${t.tx_hash}`}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-muted hover:text-accent transition-colors"
+                className="text-muted hover:text-accent ml-auto whitespace-nowrap text-[10px] transition-colors"
                 title="View on Basescan"
               >
-                &#x2197;
+                <time dateTime={t.block_timestamp}>{date}</time> &#x2197;
               </a>
+            ) : (
+              <time dateTime={t.block_timestamp} className="text-muted ml-auto whitespace-nowrap text-[10px]">
+                {date}
+              </time>
             )}
           </div>
         );


### PR DESCRIPTION
## Summary
- Restyles `HoldingRecentTrades` to match Activity tab `FeedRow` pattern
- Bordered card rows with `border-border rounded border px-3 py-1.5`
- Color-coded Buy/Sell labels: green (`text-green-700`) / red (`text-red-700`)
- USD value display with `formatUsdValue`
- Date as `<time>` element
- Basescan tx link (↗) for each transaction
- Fetches `tx_hash` from `trade_history` query (was not queried before)

## Test Plan
- [ ] Reader tab: verify trade rows have bordered card style
- [ ] Verify Buy = green, Sell = red labels
- [ ] Verify USD amounts display correctly
- [ ] Verify Basescan link opens correct tx
- [ ] Verify date formatting matches Activity tab

Fixes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)