### PR TITLE
Add min-w-0 overflow guard on storyline stats grid

### DIFF
--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -341,12 +341,14 @@ function StoryHeader({
         <div className="mt-4 text-xs">
           <div className="border-border bg-surface grid grid-cols-1 sm:grid-cols-2 gap-2 rounded border px-3 py-2">
             <div className="grid grid-cols-2 gap-2">
-              <MarketCapBox
-                tokenAddress={storyline.token_address}
-                totalSupply={parseFloat(priceInfo.totalSupply)}
-                pricePerToken={parseFloat(priceInfo.pricePerToken)}
-              />
-              <div>
+              <div className="min-w-0">
+                <MarketCapBox
+                  tokenAddress={storyline.token_address}
+                  totalSupply={parseFloat(priceInfo.totalSupply)}
+                  pricePerToken={parseFloat(priceInfo.pricePerToken)}
+                />
+              </div>
+              <div className="min-w-0">
                 <span className="text-muted block text-[10px] uppercase tracking-wider">
                   Supply Minted
                 </span>


### PR DESCRIPTION
## Summary
- Wraps MCap and Supply Minted grid children in `min-w-0` divs
- Prevents text overflow on narrow screens (320px) where large USD values or 24h% badges could break the 2-col grid layout

## Test Plan
- [ ] Normal screens: no visual changes
- [ ] 320px viewport: long MCap values truncate gracefully
- [ ] Grid columns remain equal width on all sizes

Fixes #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)