### PR TITLE
Storyline page: 3-col stats boxes like profile page

### DIFF
--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -333,48 +333,45 @@ function StoryHeader({
               </span>
             </div>
           </div>
-        </div>
-      </div>
 
-      {/* Market stats */}
-      {priceInfo && (
-        <div className="mt-4 text-xs">
-          <div className="border-border bg-surface grid grid-cols-1 sm:grid-cols-2 gap-2 rounded border px-3 py-2">
-            <div className="grid grid-cols-2 gap-2">
-              <div className="min-w-0">
+          {/* Stat boxes — inside info panel on desktop, below info rows */}
+          {priceInfo && (
+            <div className="mt-3 grid grid-cols-3 gap-2">
+              <div className="border-border rounded border px-2 py-1.5 text-center min-w-0">
                 <MarketCapBox
                   tokenAddress={storyline.token_address}
                   totalSupply={parseFloat(priceInfo.totalSupply)}
                   pricePerToken={parseFloat(priceInfo.pricePerToken)}
                 />
               </div>
-              <div className="min-w-0">
-                <span className="text-muted block text-[10px] uppercase tracking-wider">
-                  Supply Minted
-                </span>
-                <span className="font-semibold text-accent">
-                  {formatSupply(priceInfo.totalSupply)} tokens
-                </span>
+              <div className="border-border rounded border px-2 py-1.5 text-center min-w-0">
+                <div className="text-foreground text-sm font-bold">{formatSupply(priceInfo.totalSupply)}</div>
+                <div className="text-muted text-[9px]">Supply Minted</div>
+              </div>
+              <div className="border-border rounded border px-2 py-1.5 text-center min-w-0">
+                {storyline.sunset ? (
+                  <>
+                    <div className="text-foreground text-sm font-bold">{storyline.plot_count}</div>
+                    <div className="text-muted text-[9px]">Complete</div>
+                  </>
+                ) : storyline.last_plot_time ? (
+                  <>
+                    <div className="text-foreground text-sm font-bold leading-tight">
+                      <DeadlineCountdown lastPlotTime={storyline.last_plot_time} hideLabel />
+                    </div>
+                    <div className="text-muted text-[9px]">Deadline</div>
+                  </>
+                ) : (
+                  <>
+                    <div className="text-foreground text-sm font-bold">—</div>
+                    <div className="text-muted text-[9px]">Deadline</div>
+                  </>
+                )}
               </div>
             </div>
-            {storyline.sunset ? (
-              <div>
-                <span className="text-muted">Story complete</span>
-                <span className="text-foreground ml-2">
-                  {storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"} total
-                </span>
-              </div>
-            ) : storyline.last_plot_time ? (
-              <div>
-                <span className="text-muted block text-[10px] uppercase tracking-wider mb-1">
-                  Next Plot Publish Deadline
-                </span>
-                <DeadlineCountdown lastPlotTime={storyline.last_plot_time} hideLabel />
-              </div>
-            ) : null}
-          </div>
+          )}
         </div>
-      )}
+      </div>
       {!storyline.sunset && (
         <AddPlotButton storylineId={storyline.storyline_id} writerAddress={storyline.writer_address} />
       )}

--- a/src/components/MarketCapBox.tsx
+++ b/src/components/MarketCapBox.tsx
@@ -33,18 +33,16 @@ export function MarketCapBox({
   const changePercent = priceChange?.changePercent ?? null;
 
   return (
-    <div>
-      <span className="text-muted block text-[10px] uppercase tracking-wider">
-        Market Cap
-      </span>
-      <span className="font-semibold text-accent">
+    <>
+      <div className="text-foreground text-sm font-bold">
         {formatUsdValue(marketCapUsd)}
         {changePercent !== null && (
-          <span className={`ml-1.5 text-[10px] font-medium ${changePercent >= 0 ? "text-accent" : "text-error"}`}>
+          <span className={`ml-1 text-[10px] font-medium ${changePercent >= 0 ? "text-accent" : "text-error"}`}>
             {changePercent >= 0 ? "+" : ""}{changePercent.toFixed(1)}%
           </span>
         )}
-      </span>
-    </div>
+      </div>
+      <div className="text-muted text-[9px]">Market Cap</div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Redesigns Market Cap, Supply Minted, and Deadline as 3 bordered stat boxes matching profile page style
- Desktop: boxes sit inside the info panel next to the Moleskine cover (within the header's right column)
- Mobile: 3-col grid below info rows
- Box style: `border-border rounded border px-2 py-1.5 text-center` with value on top, label below

## Layout
```
┌──────────┐   Title
│ Moleskine│   ★★★★★ · 👁 views
│  Cover   │   Writer / Plots / Genre
│          │   ┌─────────┬──────────┬──────────┐
└──────────┘   │ Mkt Cap │ Supply   │ Deadline │
               └─────────┴──────────┴──────────┘
```

## Test Plan
- [ ] Desktop: verify 3 stat boxes in info panel area
- [ ] Mobile: verify 3-col grid renders correctly
- [ ] Verify MarketCapBox content displays in box style
- [ ] Verify DeadlineCountdown renders in box style
- [ ] Verify "Story complete" state for sunset storylines

Fixes #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)