### PR TITLE
Block plot creation when deadline expired — frontend + API

### DIFF
--- a/docs/OVERNIGHT-QUEUE.md
+++ b/docs/OVERNIGHT-QUEUE.md
@@ -146,22 +146,34 @@
 
 ---
 
-## Tonight's Queue — Batch 61: Post-Review Fixes
+## Completed — Batch 61
 
-### 1. plotlink#796 — DonateWidget: unformatted balance shows raw 18-decimal values
-- Same bug as #789 but in DonateWidget.tsx (lines ~152, 164)
-- Apply same `formatTokenAmount` or extract to shared `src/lib/format.ts`
-- Branch: `task/796-donate-format`
+- Batch 61: DonateWidget format #799, RatingSummary dedup #800, Stats overflow guard #801
 
-### 2. plotlink#797 — Storyline header: RatingSummaryWithSeparator duplicates RatingSummary
-- Refactor to compose existing `RatingSummary` instead of duplicating query+render
-- Add `aria-hidden="true"` to decorative separator dot
-- Branch: `task/797-rating-summary-dedup`
+---
 
-### 3. plotlink#798 — Storyline stats: add min-w-0 overflow guard on mobile grid
-- MCap + Supply grid children need `min-w-0` for 320px screens
-- Prevents text overflow with large USD values + 24h% badge
-- Branch: `task/798-stats-overflow-guard`
+## Tonight's Queue — Batch 62: Storyline Page Polish + Deadline Enforcement
+
+### 1. plotlink#802 — Storyline page: 3-col stats boxes like profile page, beside Moleskine on desktop
+- Redesign Market Cap, Supply Minted, Deadline as bordered stat boxes matching profile page style
+- Desktop: place in the header area next to the Moleskine cover
+- Mobile: full-width row below header
+- Branch: `task/802-storyline-stats-boxes`
+
+### 2. plotlink#803 — Storyline page: left-align title and info on mobile
+- Mobile: title, rating, Writer/Plots/Genre rows should be left-aligned, not centered
+- Moleskine cover can stay centered
+- Desktop: no changes (already left-aligned)
+- Branch: `task/803-storyline-mobile-left-align`
+
+### 3. plotlink#804 — Block new plot creation when deadline is expired
+- `sunset` flag is never set to `true` by app code — button stays clickable after countdown expires
+- Front-end: disable "+ Add a new Plot" button (visible but `opacity-50 pointer-events-none`) when `last_plot_time + 168h < now`
+- Create page: show expired storylines in dropdown but disabled with "(expired)" label
+- API: add deadline validation in `src/app/api/index/plot/route.ts`
+- Optional: cron/trigger to set `sunset=true` for expired storylines
+- Contract already enforces (`chainPlot()` reverts), this is UX + defense-in-depth
+- Branch: `task/804-deadline-enforcement`
 
 ---
 

--- a/src/app/api/index/plot/route.ts
+++ b/src/app/api/index/plot/route.ts
@@ -113,6 +113,26 @@ export async function POST(req: Request) {
     return error("Supabase not configured", 500);
   }
 
+  // 7a. Check deadline — reject if storyline's 7-day deadline has expired
+  const DEADLINE_MS = 168 * 60 * 60 * 1000;
+  const { data: storylineRow } = await supabase
+    .from("storylines")
+    .select("last_plot_time, sunset")
+    .eq("storyline_id", Number(storylineId))
+    .single();
+
+  if (storylineRow) {
+    if (storylineRow.sunset) {
+      return error("Storyline has sunset — no new plots allowed", 400);
+    }
+    if (storylineRow.last_plot_time) {
+      const deadline = new Date(storylineRow.last_plot_time).getTime() + DEADLINE_MS;
+      if (Date.now() > deadline) {
+        return error("Storyline deadline expired — no new plots allowed", 400);
+      }
+    }
+  }
+
   const row: Database["public"]["Tables"]["plots"]["Insert"] = {
     storyline_id: Number(storylineId),
     plot_index: Number(plotIndex),

--- a/src/app/api/index/plot/route.ts
+++ b/src/app/api/index/plot/route.ts
@@ -114,7 +114,7 @@ export async function POST(req: Request) {
   }
 
   // 7a. Check deadline — reject if storyline's 7-day deadline has expired
-  const DEADLINE_MS = 168 * 60 * 60 * 1000;
+  const DEADLINE_MS = 168 * 60 * 60 * 1000; // 7 days — matches DEADLINE_HOURS in DeadlineCountdown
   const { data: storylineRow } = await supabase
     .from("storylines")
     .select("last_plot_time, sunset")

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -14,6 +14,7 @@ import { usePublish, type PublishState } from "../../hooks/usePublish";
 import { useChainPlot } from "../../hooks/useChainPlot";
 import { usePublishIntent } from "../../hooks/usePublishIntent";
 import { RecoveryBanner } from "../../components/RecoveryBanner";
+import { DEADLINE_MS } from "../../components/DeadlineCountdown";
 import { storyFactoryAbi, storylineCreatedEvent } from "../../../lib/contracts/abi";
 import { STORY_FACTORY, MCV2_BOND } from "../../../lib/contracts/constants";
 import { supabase, type Storyline } from "../../../lib/supabase";
@@ -61,8 +62,6 @@ async function fetchWriterStorylines(address: string): Promise<Storyline[]> {
     .returns<Storyline[]>();
   return data ?? [];
 }
-
-const DEADLINE_MS = 168 * 60 * 60 * 1000;
 
 function isStorylineExpired(s: Storyline): boolean {
   if (s.sunset) return true;

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -56,11 +56,18 @@ async function fetchWriterStorylines(address: string): Promise<Storyline[]> {
     .select("*")
     .eq("writer_address", address.toLowerCase())
     .eq("hidden", false)
-    .eq("sunset", false)
     .eq("contract_address", STORY_FACTORY.toLowerCase())
     .order("block_timestamp", { ascending: false })
     .returns<Storyline[]>();
   return data ?? [];
+}
+
+const DEADLINE_MS = 168 * 60 * 60 * 1000;
+
+function isStorylineExpired(s: Storyline): boolean {
+  if (s.sunset) return true;
+  if (!s.last_plot_time) return false;
+  return Date.now() > new Date(s.last_plot_time).getTime() + DEADLINE_MS;
 }
 
 export default function CreatePageWrapper() {
@@ -527,10 +534,12 @@ function CreatePage() {
                   onChange={(v) => setChainStorylineId(v ? Number(v) : null)}
                   disabled={chainBusy}
                   placeholder="Select a storyline"
-                  options={storylines.map((s) => ({
-                    value: String(s.storyline_id),
-                    label: `${s.title} (${s.plot_count} ${s.plot_count === 1 ? "plot" : "plots"})`,
-                  }))}
+                  options={storylines
+                    .filter((s) => !isStorylineExpired(s))
+                    .map((s) => ({
+                      value: String(s.storyline_id),
+                      label: `${s.title} (${s.plot_count} ${s.plot_count === 1 ? "plot" : "plots"})`,
+                    }))}
                 />
               )}
             </div>

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -533,12 +533,14 @@ function CreatePage() {
                   onChange={(v) => setChainStorylineId(v ? Number(v) : null)}
                   disabled={chainBusy}
                   placeholder="Select a storyline"
-                  options={storylines
-                    .filter((s) => !isStorylineExpired(s))
-                    .map((s) => ({
+                  options={storylines.map((s) => {
+                    const expired = isStorylineExpired(s);
+                    return {
                       value: String(s.storyline_id),
-                      label: `${s.title} (${s.plot_count} ${s.plot_count === 1 ? "plot" : "plots"})`,
-                    }))}
+                      label: `${s.title} (${s.plot_count} ${s.plot_count === 1 ? "plot" : "plots"})${expired ? " (expired)" : ""}`,
+                      disabled: expired,
+                    };
+                  })}
                 />
               )}
             </div>

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -372,9 +372,7 @@ function StoryHeader({
           )}
         </div>
       </div>
-      {!storyline.sunset && (
-        <AddPlotButton storylineId={storyline.storyline_id} writerAddress={storyline.writer_address} lastPlotTime={storyline.last_plot_time} />
-      )}
+      <AddPlotButton storylineId={storyline.storyline_id} writerAddress={storyline.writer_address} lastPlotTime={storyline.last_plot_time} sunset={storyline.sunset} />
     </header>
   );
 }

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -373,7 +373,7 @@ function StoryHeader({
         </div>
       </div>
       {!storyline.sunset && (
-        <AddPlotButton storylineId={storyline.storyline_id} writerAddress={storyline.writer_address} />
+        <AddPlotButton storylineId={storyline.storyline_id} writerAddress={storyline.writer_address} lastPlotTime={storyline.last_plot_time} />
       )}
     </header>
   );

--- a/src/components/AddPlotButton.tsx
+++ b/src/components/AddPlotButton.tsx
@@ -14,16 +14,18 @@ export function AddPlotButton({
   storylineId,
   writerAddress,
   lastPlotTime,
+  sunset,
 }: {
   storylineId: number;
   writerAddress: string;
   lastPlotTime?: string | null;
+  sunset?: boolean;
 }) {
   const { address } = useAccount();
   if (!address || address.toLowerCase() !== writerAddress.toLowerCase())
     return null;
 
-  const expired = lastPlotTime ? isDeadlineExpired(lastPlotTime) : false;
+  const expired = sunset || (lastPlotTime ? isDeadlineExpired(lastPlotTime) : false);
 
   if (expired) {
     return (

--- a/src/components/AddPlotButton.tsx
+++ b/src/components/AddPlotButton.tsx
@@ -2,17 +2,40 @@
 
 import { useAccount } from "wagmi";
 import Link from "next/link";
+import { DEADLINE_HOURS } from "./DeadlineCountdown";
+
+function isDeadlineExpired(lastPlotTime: string | null): boolean {
+  if (!lastPlotTime) return false;
+  const deadline = new Date(lastPlotTime).getTime() + DEADLINE_HOURS * 60 * 60 * 1000;
+  return Date.now() > deadline;
+}
 
 export function AddPlotButton({
   storylineId,
   writerAddress,
+  lastPlotTime,
 }: {
   storylineId: number;
   writerAddress: string;
+  lastPlotTime?: string | null;
 }) {
   const { address } = useAccount();
   if (!address || address.toLowerCase() !== writerAddress.toLowerCase())
     return null;
+
+  const expired = lastPlotTime ? isDeadlineExpired(lastPlotTime) : false;
+
+  if (expired) {
+    return (
+      <div
+        className="border-border text-muted mt-3 block w-full rounded border py-2 text-center text-xs font-medium opacity-50"
+        title="The 7-day deadline has expired"
+      >
+        Deadline expired
+      </div>
+    );
+  }
+
   return (
     <Link
       href={`/create?tab=chain&storyline=${storylineId}`}

--- a/src/components/DeadlineCountdown.tsx
+++ b/src/components/DeadlineCountdown.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 
-const DEADLINE_HOURS = 168;
+export const DEADLINE_HOURS = 168;
 
 export function DeadlineCountdown({ lastPlotTime, hideLabel }: { lastPlotTime: string; hideLabel?: boolean }) {
   const [remaining, setRemaining] = useState<number | null>(null);

--- a/src/components/DeadlineCountdown.tsx
+++ b/src/components/DeadlineCountdown.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 
 export const DEADLINE_HOURS = 168;
+export const DEADLINE_MS = DEADLINE_HOURS * 60 * 60 * 1000;
 
 export function DeadlineCountdown({ lastPlotTime, hideLabel }: { lastPlotTime: string; hideLabel?: boolean }) {
   const [remaining, setRemaining] = useState<number | null>(null);

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -5,6 +5,7 @@ import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 export interface SelectOption {
   value: string;
   label: string;
+  disabled?: boolean;
 }
 
 interface SelectProps {
@@ -80,7 +81,7 @@ export function Select({
           break;
         case "Enter":
           e.preventDefault();
-          if (focusIndex >= 0 && focusIndex < allOptions.length) {
+          if (focusIndex >= 0 && focusIndex < allOptions.length && !allOptions[focusIndex].disabled) {
             onChange(allOptions[focusIndex].value);
             setOpen(false);
           }
@@ -135,17 +136,20 @@ export function Select({
               aria-selected={opt.value === value}
               onMouseEnter={() => setFocusIndex(i)}
               onClick={() => {
+                if (opt.disabled) return;
                 onChange(opt.value);
                 setOpen(false);
               }}
-              className={`cursor-pointer px-3 py-2 text-sm ${
-                opt.value === value
-                  ? "bg-accent text-background"
-                  : i === focusIndex
-                    ? "bg-border/50 text-foreground"
-                    : opt.value === ""
-                      ? "text-muted hover:bg-border/30"
-                      : "text-foreground hover:bg-border/30"
+              className={`px-3 py-2 text-sm ${
+                opt.disabled
+                  ? "text-muted opacity-50 cursor-default"
+                  : opt.value === value
+                    ? "bg-accent text-background cursor-pointer"
+                    : i === focusIndex
+                      ? "bg-border/50 text-foreground cursor-pointer"
+                      : opt.value === ""
+                        ? "text-muted hover:bg-border/30 cursor-pointer"
+                        : "text-foreground hover:bg-border/30 cursor-pointer"
               }`}
             >
               {opt.label}


### PR DESCRIPTION
## Summary
Three-layer deadline enforcement to prevent wasted gas on doomed transactions:

1. **Storyline page** (`AddPlotButton.tsx`): Checks `last_plot_time + 168h < now`. Shows disabled "Deadline expired" instead of clickable link
2. **Create page** (`create/page.tsx`): Filters expired storylines from the dropdown (removed `sunset=false` DB filter, now checks both sunset and time-based expiry client-side)
3. **API indexer** (`api/index/plot/route.ts`): Returns 400 when storyline deadline has expired or sunset is true

Also exports `DEADLINE_HOURS` from `DeadlineCountdown.tsx` for shared reuse.

## Changes
- `src/components/AddPlotButton.tsx` — added deadline check + disabled state
- `src/components/DeadlineCountdown.tsx` — exported `DEADLINE_HOURS`
- `src/app/story/[storylineId]/page.tsx` — passes `lastPlotTime` to AddPlotButton
- `src/app/create/page.tsx` — client-side expired filter, includes sunset storylines from DB
- `src/app/api/index/plot/route.ts` — deadline + sunset validation before upsert

## Test Plan
- [ ] Storyline page: expired story shows disabled "Deadline expired" button
- [ ] Storyline page: active story shows clickable "+ Add a new Plot"
- [ ] Create page: expired storylines not in dropdown
- [ ] API: POST to index/plot for expired storyline returns 400
- [ ] Contract enforcement unchanged

Fixes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)