### PR TITLE
Fix deadline enforcement: check has_deadline, use block timestamp

### DIFF
--- a/src/app/api/index/plot/route.ts
+++ b/src/app/api/index/plot/route.ts
@@ -117,7 +117,7 @@ export async function POST(req: Request) {
   const DEADLINE_MS = 168 * 60 * 60 * 1000; // 7 days — matches DEADLINE_HOURS in DeadlineCountdown
   const { data: storylineRow } = await supabase
     .from("storylines")
-    .select("last_plot_time, sunset")
+    .select("last_plot_time, sunset, has_deadline")
     .eq("storyline_id", Number(storylineId))
     .single();
 
@@ -125,9 +125,12 @@ export async function POST(req: Request) {
     if (storylineRow.sunset) {
       return error("Storyline has sunset — no new plots allowed", 400);
     }
-    if (storylineRow.last_plot_time) {
+    if (storylineRow.has_deadline && storylineRow.last_plot_time) {
       const deadline = new Date(storylineRow.last_plot_time).getTime() + DEADLINE_MS;
-      if (Date.now() > deadline) {
+      // Use block timestamp (when tx was mined) instead of Date.now() to avoid
+      // rejecting plots that the contract already accepted near the deadline edge
+      const blockTimeMs = Number(blockTimestamp) * 1000;
+      if (blockTimeMs > deadline) {
         return error("Storyline deadline expired — no new plots allowed", 400);
       }
     }

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -65,6 +65,7 @@ async function fetchWriterStorylines(address: string): Promise<Storyline[]> {
 
 function isStorylineExpired(s: Storyline): boolean {
   if (s.sunset) return true;
+  if (!s.has_deadline) return false;
   if (!s.last_plot_time) return false;
   return Date.now() > new Date(s.last_plot_time).getTime() + DEADLINE_MS;
 }

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -372,7 +372,7 @@ function StoryHeader({
           )}
         </div>
       </div>
-      <AddPlotButton storylineId={storyline.storyline_id} writerAddress={storyline.writer_address} lastPlotTime={storyline.last_plot_time} sunset={storyline.sunset} />
+      <AddPlotButton storylineId={storyline.storyline_id} writerAddress={storyline.writer_address} lastPlotTime={storyline.last_plot_time} sunset={storyline.sunset} hasDeadline={storyline.has_deadline} />
     </header>
   );
 }

--- a/src/components/AddPlotButton.tsx
+++ b/src/components/AddPlotButton.tsx
@@ -15,25 +15,27 @@ export function AddPlotButton({
   writerAddress,
   lastPlotTime,
   sunset,
+  hasDeadline,
 }: {
   storylineId: number;
   writerAddress: string;
   lastPlotTime?: string | null;
   sunset?: boolean;
+  hasDeadline?: boolean;
 }) {
   const { address } = useAccount();
   if (!address || address.toLowerCase() !== writerAddress.toLowerCase())
     return null;
 
-  const expired = sunset || (lastPlotTime ? isDeadlineExpired(lastPlotTime) : false);
+  const expired = sunset || (hasDeadline !== false && lastPlotTime ? isDeadlineExpired(lastPlotTime) : false);
 
   if (expired) {
     return (
       <div
         className="border-border text-muted mt-3 block w-full rounded border py-2 text-center text-xs font-medium opacity-50"
-        title="The 7-day deadline has expired"
+        title={sunset ? "This story has sunset" : "The 7-day deadline has expired"}
       >
-        Deadline expired
+        {sunset ? "Story complete" : "Deadline expired"}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
**Critical fix:** PR #807's deadline enforcement was incorrectly blocking storylines with `has_deadline=false`.

### Bug 1 Fix: `has_deadline` check added
- `AddPlotButton.tsx`: skips deadline check when `hasDeadline` is false
- `create/page.tsx`: `isStorylineExpired()` checks `s.has_deadline` before time comparison
- `api/index/plot/route.ts`: selects `has_deadline`, skips deadline check when false

### Bug 2 Fix: Block timestamp instead of `Date.now()`
- API indexer now compares `blockTimestamp` (when tx was mined) vs deadline, not `Date.now()` — prevents rejecting plots the contract already accepted near the deadline edge

## Test Plan
- [ ] Storyline with `has_deadline=false`: button clickable, dropdown selectable, API accepts
- [ ] Storyline with `has_deadline=true` + expired: button disabled, dropdown disabled, API rejects
- [ ] Storyline with `has_deadline=true` + active: all works normally
- [ ] Sunset storyline: disabled state in all locations

Fixes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)