### PR TITLE
Fix DeadlineCountdown style mismatch in stat boxes

### DIFF
--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -357,7 +357,7 @@ function StoryHeader({
                 ) : storyline.last_plot_time ? (
                   <>
                     <div className="text-foreground text-sm font-bold leading-tight">
-                      <DeadlineCountdown lastPlotTime={storyline.last_plot_time} hideLabel />
+                      <DeadlineCountdown lastPlotTime={storyline.last_plot_time} hideLabel valueClassName="text-foreground text-sm font-bold" />
                     </div>
                     <div className="text-muted text-[9px]">Deadline</div>
                   </>

--- a/src/components/DeadlineCountdown.tsx
+++ b/src/components/DeadlineCountdown.tsx
@@ -5,7 +5,15 @@ import { useState, useEffect } from "react";
 export const DEADLINE_HOURS = 168;
 export const DEADLINE_MS = DEADLINE_HOURS * 60 * 60 * 1000;
 
-export function DeadlineCountdown({ lastPlotTime, hideLabel }: { lastPlotTime: string; hideLabel?: boolean }) {
+export function DeadlineCountdown({
+  lastPlotTime,
+  hideLabel,
+  valueClassName,
+}: {
+  lastPlotTime: string;
+  hideLabel?: boolean;
+  valueClassName?: string;
+}) {
   const [remaining, setRemaining] = useState<number | null>(null);
 
   useEffect(() => {
@@ -17,11 +25,14 @@ export function DeadlineCountdown({ lastPlotTime, hideLabel }: { lastPlotTime: s
     return () => clearInterval(interval);
   }, [lastPlotTime]);
 
+  const defaultValueClass = "text-accent font-medium";
+  const activeClass = valueClassName ?? defaultValueClass;
+
   if (remaining === null) {
     return (
       <div className="text-xs">
         {!hideLabel && <><span className="text-muted">Deadline:</span>{" "}</>}
-        <span className="text-accent font-medium">--</span>
+        <span className={activeClass}>--</span>
       </div>
     );
   }
@@ -30,7 +41,7 @@ export function DeadlineCountdown({ lastPlotTime, hideLabel }: { lastPlotTime: s
     return (
       <div className="text-xs">
         {!hideLabel && <><span className="text-muted">Deadline:</span>{" "}</>}
-        <span className="text-error font-medium">expired</span>
+        <span className={valueClassName ? `${valueClassName} text-error` : "text-error font-medium"}>expired</span>
       </div>
     );
   }
@@ -52,7 +63,7 @@ export function DeadlineCountdown({ lastPlotTime, hideLabel }: { lastPlotTime: s
   return (
     <div className="text-xs">
       {!hideLabel && <><span className="text-muted">Deadline:</span>{" "}</>}
-      <span className="text-accent font-medium">{formatted}</span>
+      <span className={activeClass}>{formatted}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `valueClassName` prop to `DeadlineCountdown` that overrides the default `text-accent font-medium` styling
- Storyline stat box passes `text-foreground text-sm font-bold` to match Market Cap and Supply Minted boxes
- Expired state preserves `text-error` color
- No change to DeadlineCountdown in other contexts (storyline cards, etc.)

## Before/After
- Before: Deadline value rendered as `text-xs text-accent font-medium` (mismatched)
- After: Deadline value rendered as `text-sm font-bold text-foreground` (matches other stat boxes)

## Test Plan
- [ ] Deadline stat box text matches Market Cap and Supply Minted styling
- [ ] Expired state shows in error color
- [ ] DeadlineCountdown in other contexts (cards, etc.) unchanged

Fixes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)