### PR TITLE
Hide DeadlineCountdown for storylines without deadlines

### DIFF
--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -944,7 +944,7 @@ function StoryRow({
       {/* Status + Created + Deadline */}
       <div className="px-4 py-2 text-xs space-y-0.5">
         <div className="flex items-center gap-2">
-          {!storyline.sunset && storyline.last_plot_time && (
+          {!storyline.sunset && storyline.has_deadline && storyline.last_plot_time && (
             <>
               <DeadlineCountdown lastPlotTime={storyline.last_plot_time} />
               <span className="text-muted">·</span>

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -354,7 +354,7 @@ function StoryHeader({
                     <div className="text-foreground text-sm font-bold">{storyline.plot_count}</div>
                     <div className="text-muted text-[9px]">Complete</div>
                   </>
-                ) : storyline.last_plot_time ? (
+                ) : storyline.has_deadline && storyline.last_plot_time ? (
                   <>
                     <div className="text-foreground text-sm font-bold leading-tight">
                       <DeadlineCountdown lastPlotTime={storyline.last_plot_time} hideLabel valueClassName="text-foreground text-sm font-bold" />


### PR DESCRIPTION
## Summary
- Adds `has_deadline` guard before rendering `DeadlineCountdown` in both locations
- Storyline page stat box: `storyline.has_deadline && storyline.last_plot_time`
- Profile page storyline card: `storyline.has_deadline && storyline.last_plot_time`
- Two-line fix, no logic changes

## Test Plan
- [ ] Storyline with `has_deadline=false`: no countdown shown, stat box shows "—"
- [ ] Storyline with `has_deadline=true`: countdown shown as before
- [ ] Profile page: same behavior
- [ ] Sunset storylines: "Complete" shown regardless

Fixes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)