### PR TITLE
Move stats + CTA inside flex-1 column next to Moleskine cover

### DIFF
--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -325,13 +325,10 @@ function StoryHeader({
               </span>
             </div>
           </div>
-        </div>
-      </div>
 
-      {/* Stats grid — below cover+info on mobile, aligned with right column on desktop */}
-      {priceInfo && (
-        <div className="sm:pl-[176px]">
-          <div className="mt-3 grid grid-cols-2 sm:grid-cols-3 gap-1.5">
+          {/* Stats grid — inside right column, next to cover */}
+          {priceInfo && (
+            <div className="mt-3 grid grid-cols-2 sm:grid-cols-3 gap-1.5">
               <div className="border-border rounded border px-2 py-1.5 text-center min-w-0">
                 <MarketCapBox
                   tokenAddress={storyline.token_address}
@@ -375,13 +372,12 @@ function StoryHeader({
                 <div className="text-foreground text-sm font-bold">{createdDate ?? "—"}</div>
                 <div className="text-muted text-[9px]">Created</div>
               </div>
-          </div>
-        </div>
-      )}
+            </div>
+          )}
 
-      {/* CTA — below stats, aligned with right column on desktop */}
-      <div className="sm:pl-[176px]">
-        <AddPlotButton storylineId={storyline.storyline_id} writerAddress={storyline.writer_address} lastPlotTime={storyline.last_plot_time} sunset={storyline.sunset} hasDeadline={storyline.has_deadline} />
+          {/* CTA — in right column */}
+          <AddPlotButton storylineId={storyline.storyline_id} writerAddress={storyline.writer_address} lastPlotTime={storyline.last_plot_time} sunset={storyline.sunset} hasDeadline={storyline.has_deadline} />
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- Moves stats grid and AddPlotButton back inside the `min-w-0 flex-1` info column div
- Flexbox naturally places them next to the cover on both mobile and desktop
- Removes the `sm:pl-[176px]` padding hack — no longer needed

## Before/After
- Before: stats + CTA below the cover+info flex-row with padding indent
- After: stats + CTA inside the right column, naturally next to the cover

## Test Plan
- [ ] Desktop: stats grid sits next to cover in right column
- [ ] Desktop: CTA button in right column
- [ ] Mobile: cover + info + stats all flow naturally side by side
- [ ] No `sm:pl-[176px]` remaining

Fixes #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)