### PR TITLE
[#823] Increase mobile Moleskine cover width to 130px

### DIFF
--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -316,7 +316,7 @@ function StoryHeader({
 
   return (
     <header
-      className="pb-6 grid gap-x-4 sm:gap-x-6 grid-cols-[100px_1fr] sm:grid-cols-[160px_1fr] [grid-template-areas:'cover_info'_'stats_stats'] sm:[grid-template-areas:'cover_info'_'._stats']"
+      className="pb-6 grid gap-x-4 sm:gap-x-6 grid-cols-[130px_1fr] sm:grid-cols-[160px_1fr] [grid-template-areas:'cover_info'_'stats_stats'] sm:[grid-template-areas:'cover_info'_'._stats']"
     >
       {/* Moleskine book cover */}
       <div className="[grid-area:cover]">


### PR DESCRIPTION
## Summary
- Increased mobile grid column from `100px` to `130px` so genre tags like "SCIENCE FICTION" fit on one line
- Desktop cover unchanged at `160px`
- Matches the Moleskine size from the Writer tab on the profile page
- On 320px screens: 320 - 130 - 16 gap = 174px for info column

## Test plan
- [ ] Mobile: genre tags like "SCIENCE FICTION" fit on one line
- [ ] Mobile: cover width visually matches Writer tab reference
- [ ] Desktop: cover unchanged at 160px
- [ ] 320px viewport: info column still has adequate space

Fixes #823

🤖 Generated with [Claude Code](https://claude.com/claude-code)