### PR TITLE
[#824] Fix Writer tab badge to use time-based deadline expiry

### DIFF
--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -868,9 +868,18 @@ function StoryRow({
     enabled: !!storyline.token_address,
   });
 
-  const [now] = useState(() => Date.now());
-  const isExpired = !storyline.sunset && storyline.has_deadline && !!storyline.last_plot_time &&
-    now > new Date(storyline.last_plot_time).getTime() + DEADLINE_MS;
+  const checkExpired = useCallback(
+    () => !storyline.sunset && storyline.has_deadline && !!storyline.last_plot_time &&
+      Date.now() > new Date(storyline.last_plot_time).getTime() + DEADLINE_MS,
+    [storyline.sunset, storyline.has_deadline, storyline.last_plot_time],
+  );
+  const [isExpired, setIsExpired] = useState(checkExpired);
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial sync needed for SSR hydration safety
+    setIsExpired(checkExpired());
+    const interval = setInterval(() => setIsExpired(checkExpired()), 60_000);
+    return () => clearInterval(interval);
+  }, [checkExpired]);
 
   return (
     <>

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -19,7 +19,7 @@ import { usePlotUsdPrice } from "../../../hooks/usePlotUsdPrice";
 import { formatUsdValue } from "../../../../lib/usd-price";
 import { DisconnectButton } from "../../../components/ConnectWallet";
 import { GENRES, LANGUAGES } from "../../../../lib/genres";
-import { DeadlineCountdown } from "../../../components/DeadlineCountdown";
+import { DeadlineCountdown, DEADLINE_MS } from "../../../components/DeadlineCountdown";
 import { ClaimRoyalties } from "../../../components/ClaimRoyalties";
 import { WriterTradingStats } from "../../../components/WriterTradingStats";
 import { DropdownSelect } from "../../../components/DropdownSelect";
@@ -952,6 +952,8 @@ function StoryRow({
           )}
           {storyline.sunset ? (
             <span className="border-border text-muted rounded border px-1.5 py-0.5 text-[10px]">complete</span>
+          ) : storyline.has_deadline && storyline.last_plot_time && Date.now() > new Date(storyline.last_plot_time).getTime() + DEADLINE_MS ? (
+            <span className="border border-red-700/30 text-red-700 rounded px-1.5 py-0.5 text-[10px]">expired</span>
           ) : (
             <span className="border border-green-700/30 text-green-700 rounded px-1.5 py-0.5 text-[10px]">active</span>
           )}

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -868,6 +868,9 @@ function StoryRow({
     enabled: !!storyline.token_address,
   });
 
+  const isExpired = !storyline.sunset && storyline.has_deadline && !!storyline.last_plot_time &&
+    Date.now() > new Date(storyline.last_plot_time).getTime() + DEADLINE_MS;
+
   return (
     <>
     <div className="border-border rounded border divide-y divide-border text-xs">
@@ -952,7 +955,7 @@ function StoryRow({
           )}
           {storyline.sunset ? (
             <span className="border-border text-muted rounded border px-1.5 py-0.5 text-[10px]">complete</span>
-          ) : storyline.has_deadline && storyline.last_plot_time && Date.now() > new Date(storyline.last_plot_time).getTime() + DEADLINE_MS ? (
+          ) : isExpired ? (
             <span className="border border-red-700/30 text-red-700 rounded px-1.5 py-0.5 text-[10px]">expired</span>
           ) : (
             <span className="border border-green-700/30 text-green-700 rounded px-1.5 py-0.5 text-[10px]">active</span>

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -877,7 +877,7 @@ function StoryRow({
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- initial sync needed for SSR hydration safety
     setIsExpired(checkExpired());
-    const interval = setInterval(() => setIsExpired(checkExpired()), 60_000);
+    const interval = setInterval(() => setIsExpired(checkExpired()), 1_000);
     return () => clearInterval(interval);
   }, [checkExpired]);
 

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -868,8 +868,9 @@ function StoryRow({
     enabled: !!storyline.token_address,
   });
 
+  const [now] = useState(() => Date.now());
   const isExpired = !storyline.sunset && storyline.has_deadline && !!storyline.last_plot_time &&
-    Date.now() > new Date(storyline.last_plot_time).getTime() + DEADLINE_MS;
+    now > new Date(storyline.last_plot_time).getTime() + DEADLINE_MS;
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Badge now checks `has_deadline && last_plot_time + 168h < now` instead of only `sunset`
- Shows "expired" (red) when deadline has passed, "complete" when sunset, "active" (green) otherwise
- Imports `DEADLINE_MS` from `DeadlineCountdown.tsx` for consistent deadline logic
- Fixes contradictory "Deadline: expired · active" display

## Test plan
- [ ] Storyline with expired deadline shows "expired" badge (red)
- [ ] Storyline with `sunset=true` shows "complete" badge
- [ ] Active storyline (within deadline) shows "active" badge (green)
- [ ] Storyline without `has_deadline` shows "active" badge

Fixes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)