### PR TITLE
[#846] Display "{human}'s AI Writer" via ERC-8004 owner + FID

### DIFF
--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -269,18 +269,20 @@ export async function getAgentUserFromDB(
 }
 
 /**
- * For a writer address, check if it's an ERC-8004 agent and return the
- * owner's Farcaster profile. Returns null if not an agent or owner has no FID.
+ * For a writer address, check if it's an ERC-8004 agent and return agent info
+ * plus the owner's Farcaster profile (if available).
+ * Returns null only if the address is NOT an agent.
  */
 export async function getAgentOwnerProfile(
   writerAddress: string,
-): Promise<{ ownerProfile: FarcasterProfile; agentName: string; agentId: number } | null> {
+): Promise<{ ownerProfile: FarcasterProfile | null; agentName: string; agentId: number } | null> {
   "use server";
   const agentUser = await getAgentUserFromDB(writerAddress);
-  if (!agentUser?.agent_id || !agentUser.agent_owner) return null;
+  if (!agentUser?.agent_id) return null;
 
-  const ownerProfile = await getFarcasterProfile(agentUser.agent_owner);
-  if (!ownerProfile) return null;
+  const ownerProfile = agentUser.agent_owner
+    ? await getFarcasterProfile(agentUser.agent_owner)
+    : null;
 
   return {
     ownerProfile,

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -267,3 +267,24 @@ export async function getAgentUserFromDB(
 
   return byPrimary ?? null;
 }
+
+/**
+ * For a writer address, check if it's an ERC-8004 agent and return the
+ * owner's Farcaster profile. Returns null if not an agent or owner has no FID.
+ */
+export async function getAgentOwnerProfile(
+  writerAddress: string,
+): Promise<{ ownerProfile: FarcasterProfile; agentName: string; agentId: number } | null> {
+  "use server";
+  const agentUser = await getAgentUserFromDB(writerAddress);
+  if (!agentUser?.agent_id || !agentUser.agent_owner) return null;
+
+  const ownerProfile = await getFarcasterProfile(agentUser.agent_owner);
+  if (!ownerProfile) return null;
+
+  return {
+    ownerProfile,
+    agentName: agentUser.agent_name || `Agent #${agentUser.agent_id}`,
+    agentId: agentUser.agent_id,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -8,7 +8,7 @@ import { formatUnits, type Address } from "viem";
 import Link from "next/link";
 import { supabase, type Storyline, type Donation, type TradeHistory, type User } from "../../../../lib/supabase";
 import { STORY_FACTORY, RESERVE_LABEL, EXPLORER_URL, MCV2_BOND, PLOT_TOKEN } from "../../../../lib/contracts/constants";
-import { getFullUserProfile } from "../../../../lib/actions";
+import { getFullUserProfile, getFarcasterProfile } from "../../../../lib/actions";
 import { truncateAddress } from "../../../../lib/utils";
 import { formatPrice, formatSupply } from "../../../../lib/format";
 import { getTokenPrice, mcv2BondAbi, erc20Abi, type TokenPriceInfo, get24hPriceChange, getTokenTVL } from "../../../../lib/price";
@@ -237,6 +237,15 @@ function ProfileHeader({
   onCooldown: boolean;
   cooldownRemaining: number;
 }) {
+  // Fetch owner's Farcaster profile for "Operated by" section
+  const ownerAddress = agentMeta?.owner;
+  const hasOwner = !!ownerAddress && ownerAddress.toLowerCase() !== address.toLowerCase();
+  const { data: ownerFcProfile } = useQuery({
+    queryKey: ["owner-fc-profile", ownerAddress],
+    queryFn: () => getFarcasterProfile(ownerAddress!),
+    enabled: hasOwner,
+  });
+
   const displayName = agentMeta?.name ?? fcProfile?.displayName ?? null;
   const hasFarcaster = dbUser?.fid != null && dbUser?.username != null;
   const hasX = dbUser?.twitter != null;
@@ -430,12 +439,19 @@ function ProfileHeader({
                   </span>
                 </div>
               )}
-              {agentMeta.owner && agentMeta.owner.toLowerCase() !== address.toLowerCase() && (
-                <div className="text-xs">
-                  <span className="text-muted">Owner: </span>
-                  <Link href={`/profile/${agentMeta.owner}`} className="text-accent hover:underline font-mono text-[11px]">
-                    {agentMeta.owner.slice(0, 6)}...{agentMeta.owner.slice(-4)}
-                  </Link>
+              {hasOwner && (
+                <div className="border-border border-t mt-2 pt-2">
+                  <span className="text-muted text-[10px] font-medium uppercase tracking-wider">Operated by</span>
+                  <div className="mt-1 flex items-center gap-2">
+                    {ownerFcProfile?.pfpUrl && (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={ownerFcProfile.pfpUrl} alt="" width={20} height={20} className="rounded-full" />
+                    )}
+                    <Link href={`/profile/${ownerAddress}`} className="text-accent hover:underline text-xs font-medium">
+                      {ownerFcProfile?.displayName || ownerFcProfile?.username || `${ownerAddress!.slice(0, 6)}...${ownerAddress!.slice(-4)}`}
+                    </Link>
+                    <span className="bg-accent/10 text-accent rounded px-1 py-0.5 text-[8px] font-medium">ERC-8004 Verified</span>
+                  </div>
                 </div>
               )}
             </div>

--- a/src/app/story/[storylineId]/[plotIndex]/page.tsx
+++ b/src/app/story/[storylineId]/[plotIndex]/page.tsx
@@ -136,7 +136,7 @@ export default async function PlotDetailPage({ params }: { params: Params }) {
           <span>
             by{" "}
             <Suspense fallback={<span className="text-foreground">{truncateAddress(sl.writer_address)}</span>}>
-              <WriterIdentity address={sl.writer_address} />
+              <WriterIdentity address={sl.writer_address} writerType={sl.writer_type} />
             </Suspense>
           </span>
           {p.block_timestamp && (

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -364,7 +364,7 @@ function StoryHeader({
           <div className="flex items-center gap-1.5">
             <span className="text-muted w-12 shrink-0">Writer</span>
             <Suspense fallback={<span className="text-foreground font-medium">{truncateAddress(storyline.writer_address)}</span>}>
-              <WriterIdentity address={storyline.writer_address} />
+              <WriterIdentity address={storyline.writer_address} writerType={storyline.writer_type} />
             </Suspense>
             {storyline.writer_type === 1 && <AgentBadge />}
           </div>

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -116,7 +116,7 @@ export function StoryCard({
       {/* Metadata below notebook: author → TVL → rating */}
       <div className="mt-2.5 flex flex-col gap-0.5 pl-1 pr-1 text-[10px] text-[var(--text-muted)]">
         <span className="inline-flex items-center gap-1">
-          <WriterIdentityClient address={storyline.writer_address} />
+          <WriterIdentityClient address={storyline.writer_address} writerType={storyline.writer_type} />
           {storyline.writer_type === 1 && <AgentBadge />}
         </span>
         {storyline.token_address && (

--- a/src/components/WriterIdentity.tsx
+++ b/src/components/WriterIdentity.tsx
@@ -5,23 +5,33 @@ import { truncateAddress } from "../../lib/utils";
 /**
  * Server component that displays a writer identity.
  * For agents with an owner who has a Farcaster profile, shows "{owner}'s AI Writer".
- * Falls back to Farcaster profile or truncated address.
+ * For agents without owner FID, shows "AI Writer #{id}".
+ * Falls back to Farcaster profile or truncated address for non-agents.
  */
 export async function WriterIdentity({ address, writerType }: { address: string; writerType?: number | null }) {
   // For agents (or unknown), try owner lookup first
   if (writerType === 1 || writerType === undefined || writerType === null) {
     const ownerInfo = await getAgentOwnerProfile(address);
     if (ownerInfo) {
+      // Agent with owner FID: "{owner}'s AI Writer"
+      if (ownerInfo.ownerProfile) {
+        return (
+          <Link
+            href={`/profile/${address}`}
+            className="inline-flex items-center gap-1 text-foreground hover:text-accent transition-colors"
+          >
+            {ownerInfo.ownerProfile.pfpUrl && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={ownerInfo.ownerProfile.pfpUrl} alt="" width={14} height={14} className="rounded-full" />
+            )}
+            {ownerInfo.ownerProfile.displayName || ownerInfo.ownerProfile.username}&apos;s AI Writer
+          </Link>
+        );
+      }
+      // Agent without owner FID: plain "AI Writer #{id}"
       return (
-        <Link
-          href={`/profile/${address}`}
-          className="inline-flex items-center gap-1 text-foreground hover:text-accent transition-colors"
-        >
-          {ownerInfo.ownerProfile.pfpUrl && (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img src={ownerInfo.ownerProfile.pfpUrl} alt="" width={14} height={14} className="rounded-full" />
-          )}
-          {ownerInfo.ownerProfile.displayName || ownerInfo.ownerProfile.username}&apos;s AI Writer
+        <Link href={`/profile/${address}`} className="text-foreground hover:text-accent transition-colors">
+          AI Writer #{ownerInfo.agentId}
         </Link>
       );
     }

--- a/src/components/WriterIdentity.tsx
+++ b/src/components/WriterIdentity.tsx
@@ -1,21 +1,37 @@
 import Link from "next/link";
-import { getFarcasterProfile } from "../../lib/actions";
+import { getFarcasterProfile, getAgentOwnerProfile } from "../../lib/actions";
 import { truncateAddress } from "../../lib/utils";
 
 /**
- * Server component that displays a Farcaster identity (avatar + username)
- * when available, falling back to a truncated Ethereum address.
- * Links to the internal profile page at /profile/[address].
+ * Server component that displays a writer identity.
+ * For agents with an owner who has a Farcaster profile, shows "{owner}'s AI Writer".
+ * Falls back to Farcaster profile or truncated address.
  */
-export async function WriterIdentity({ address }: { address: string }) {
+export async function WriterIdentity({ address, writerType }: { address: string; writerType?: number | null }) {
+  // For agents (or unknown), try owner lookup first
+  if (writerType === 1 || writerType === undefined || writerType === null) {
+    const ownerInfo = await getAgentOwnerProfile(address);
+    if (ownerInfo) {
+      return (
+        <Link
+          href={`/profile/${address}`}
+          className="inline-flex items-center gap-1 text-foreground hover:text-accent transition-colors"
+        >
+          {ownerInfo.ownerProfile.pfpUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={ownerInfo.ownerProfile.pfpUrl} alt="" width={14} height={14} className="rounded-full" />
+          )}
+          {ownerInfo.ownerProfile.displayName || ownerInfo.ownerProfile.username}&apos;s AI Writer
+        </Link>
+      );
+    }
+  }
+
   const profile = await getFarcasterProfile(address);
 
   if (!profile) {
     return (
-      <Link
-        href={`/profile/${address}`}
-        className="text-foreground hover:text-accent transition-colors"
-      >
+      <Link href={`/profile/${address}`} className="text-foreground hover:text-accent transition-colors">
         {truncateAddress(address)}
       </Link>
     );
@@ -28,13 +44,7 @@ export async function WriterIdentity({ address }: { address: string }) {
     >
       {profile.pfpUrl && (
         // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={profile.pfpUrl}
-          alt=""
-          width={14}
-          height={14}
-          className="rounded-full"
-        />
+        <img src={profile.pfpUrl} alt="" width={14} height={14} className="rounded-full" />
       )}
       @{profile.username}
     </Link>

--- a/src/components/WriterIdentityClient.tsx
+++ b/src/components/WriterIdentityClient.tsx
@@ -7,7 +7,7 @@ import { truncateAddress } from "../../lib/utils";
 import type { FarcasterProfile } from "../../lib/farcaster";
 
 interface OwnerInfo {
-  ownerProfile: FarcasterProfile;
+  ownerProfile: FarcasterProfile | null;
   agentName: string;
   agentId: number;
 }
@@ -66,7 +66,7 @@ export function WriterIdentityClient({
   }
 
   // Agent with owner Farcaster profile: "{owner}'s AI Writer"
-  if (ownerInfo) {
+  if (ownerInfo && ownerInfo.ownerProfile) {
     const inner = (
       <span className="inline-flex items-center gap-1">
         {ownerInfo.ownerProfile.pfpUrl && (
@@ -80,6 +80,17 @@ export function WriterIdentityClient({
     return (
       <Link href={`/profile/${address}`} className="text-foreground hover:text-accent transition-colors">
         {inner}
+      </Link>
+    );
+  }
+
+  // Agent without owner FID: plain "AI Writer #{id}"
+  if (ownerInfo) {
+    const label = `AI Writer #${ownerInfo.agentId}`;
+    if (!linkProfile) return <span>{label}</span>;
+    return (
+      <Link href={`/profile/${address}`} className="text-foreground hover:text-accent transition-colors">
+        {label}
       </Link>
     );
   }

--- a/src/components/WriterIdentityClient.tsx
+++ b/src/components/WriterIdentityClient.tsx
@@ -2,72 +2,113 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { getFarcasterProfile } from "../../lib/actions";
+import { getFarcasterProfile, getAgentOwnerProfile } from "../../lib/actions";
 import { truncateAddress } from "../../lib/utils";
 import type { FarcasterProfile } from "../../lib/farcaster";
 
+interface OwnerInfo {
+  ownerProfile: FarcasterProfile;
+  agentName: string;
+  agentId: number;
+}
+
 /**
- * Client component that resolves a Farcaster identity via server action.
- * Shows a truncated address while loading, then replaces with avatar + username.
- * Links to the internal profile page at /profile/[address].
+ * Client component that resolves a writer identity via server action.
+ * For agents with an owner who has a Farcaster profile, shows "{owner}'s AI Writer".
+ * Falls back to Farcaster profile or truncated address.
  */
-export function WriterIdentityClient({ address, linkProfile = true }: { address: string; linkProfile?: boolean }) {
+export function WriterIdentityClient({
+  address,
+  linkProfile = true,
+  writerType,
+}: {
+  address: string;
+  linkProfile?: boolean;
+  writerType?: number | null;
+}) {
   const [profile, setProfile] = useState<FarcasterProfile | null>(null);
+  const [ownerInfo, setOwnerInfo] = useState<OwnerInfo | null>(null);
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    getFarcasterProfile(address).then((p) => {
+
+    async function resolve() {
+      // For agents (or unknown), try owner lookup first
+      if (writerType === 1 || writerType === undefined || writerType === null) {
+        const owner = await getAgentOwnerProfile(address);
+        if (!cancelled && owner) {
+          setOwnerInfo(owner);
+          setLoaded(true);
+          return;
+        }
+      }
+      // Fall back to writer's own Farcaster profile
+      const p = await getFarcasterProfile(address);
       if (!cancelled) {
         setProfile(p);
         setLoaded(true);
       }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [address]);
+    }
 
-  const label = !loaded || !profile
-    ? truncateAddress(address)
-    : null;
+    resolve();
+    return () => { cancelled = true; };
+  }, [address, writerType]);
 
-  if (!loaded || !profile) {
+  if (!loaded) {
+    const label = truncateAddress(address);
     if (!linkProfile) return <span>{label}</span>;
     return (
-      <Link
-        href={`/profile/${address}`}
-        className="text-foreground hover:text-accent transition-colors"
-      >
+      <Link href={`/profile/${address}`} className="text-foreground hover:text-accent transition-colors">
         {label}
       </Link>
     );
   }
 
-  const inner = (
-    <span className="inline-flex items-center gap-1">
-      {profile.pfpUrl && (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={profile.pfpUrl}
-          alt=""
-          width={14}
-          height={14}
-          className="rounded-full"
-        />
-      )}
-      <span>@{profile.username}</span>
-    </span>
-  );
+  // Agent with owner Farcaster profile: "{owner}'s AI Writer"
+  if (ownerInfo) {
+    const inner = (
+      <span className="inline-flex items-center gap-1">
+        {ownerInfo.ownerProfile.pfpUrl && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={ownerInfo.ownerProfile.pfpUrl} alt="" width={14} height={14} className="rounded-full" />
+        )}
+        <span>{ownerInfo.ownerProfile.displayName || ownerInfo.ownerProfile.username}&apos;s AI Writer</span>
+      </span>
+    );
+    if (!linkProfile) return inner;
+    return (
+      <Link href={`/profile/${address}`} className="text-foreground hover:text-accent transition-colors">
+        {inner}
+      </Link>
+    );
+  }
 
-  if (!linkProfile) return inner;
+  // Regular writer with Farcaster profile
+  if (profile) {
+    const inner = (
+      <span className="inline-flex items-center gap-1">
+        {profile.pfpUrl && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={profile.pfpUrl} alt="" width={14} height={14} className="rounded-full" />
+        )}
+        <span>@{profile.username}</span>
+      </span>
+    );
+    if (!linkProfile) return inner;
+    return (
+      <Link href={`/profile/${address}`} className="text-foreground hover:text-accent transition-colors">
+        {inner}
+      </Link>
+    );
+  }
 
+  // Fallback: truncated address
+  const label = truncateAddress(address);
+  if (!linkProfile) return <span>{label}</span>;
   return (
-    <Link
-      href={`/profile/${address}`}
-      className="text-foreground hover:text-accent transition-colors"
-    >
-      {inner}
+    <Link href={`/profile/${address}`} className="text-foreground hover:text-accent transition-colors">
+      {label}
     </Link>
   );
 }


### PR DESCRIPTION
## Summary
- Added `getAgentOwnerProfile` server action: looks up agent's owner Farcaster profile via DB
- Updated `WriterIdentity` (server) and `WriterIdentityClient` to show "{owner}'s AI Writer" for ERC-8004 agents
- Story cards, story detail, and plot detail pages now pass `writerType` to identity components
- Profile page shows "Operated by" section with owner's Farcaster avatar, name, and "ERC-8004 Verified" badge
- Falls back to regular Farcaster profile or truncated address when owner has no FID
- Version bumped to 0.1.18

## Test plan
- [ ] Story cards show "{owner_name}'s AI Writer" for agent-written stories
- [ ] Story detail header shows "{owner_name}'s AI Writer"
- [ ] Profile page shows "Operated by" section with owner info for agents
- [ ] "ERC-8004 Verified" badge displayed next to owner
- [ ] Falls back to regular display when owner has no Farcaster profile
- [ ] Human-written stories still show normal Farcaster identity
- [ ] Truncated address fallback works when no profiles available

Fixes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)