### PR TITLE
[#836] Fix desktop stats boxes falling below Moleskine cover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -316,10 +316,10 @@ function StoryHeader({
 
   return (
     <header
-      className="pb-6 grid gap-x-4 sm:gap-x-6 grid-cols-[130px_1fr] sm:grid-cols-[160px_1fr] [grid-template-areas:'cover_info'_'stats_stats'] sm:[grid-template-areas:'cover_info'_'cover_stats']"
+      className="pb-6 grid gap-x-4 sm:gap-x-6 grid-cols-[130px_1fr] sm:grid-cols-[160px_1fr]"
     >
       {/* Moleskine book cover */}
-      <div className="[grid-area:cover]">
+      <div className="sm:row-span-2">
         <div
           className="relative flex flex-col overflow-hidden border border-[var(--border)]"
           style={{
@@ -352,7 +352,7 @@ function StoryHeader({
       </div>
 
       {/* Info column */}
-      <div className="[grid-area:info] min-w-0">
+      <div className="min-w-0">
         <h1 className="font-body text-xl sm:text-2xl font-bold tracking-tight text-accent">
           {storyline.title}
         </h1>
@@ -380,8 +380,8 @@ function StoryHeader({
         </div>
       </div>
 
-      {/* Stats + CTA — rendered once, repositioned via grid areas */}
-      <div className="[grid-area:stats]">
+      {/* Stats + CTA */}
+      <div className="col-span-2 sm:col-span-1 sm:col-start-2">
         {statsGrid && <div className="mt-4 sm:mt-6">{statsGrid}</div>}
         <div className="[&_a]:w-full [&_div]:w-full sm:[&_a]:w-auto sm:[&_div]:w-auto">{ctaButton}</div>
       </div>


### PR DESCRIPTION
## Summary
- Replaced `grid-template-areas` with explicit grid placement (`row-span-2` on cover, `col-span-2 sm:col-span-1 sm:col-start-2` on stats) so the cover spans both rows on desktop and stats sit in the right column beside it
- Mobile layout is completely unchanged — stats still span full width below cover on small screens
- Patch version bump 0.1.18 → 0.1.19

Fixes #836

## Test plan
- [ ] Desktop (≥640px): stats boxes appear to the RIGHT of the Moleskine cover, not below
- [ ] Desktop: "Add a new Plot" button also in the right column
- [ ] Mobile (<640px): layout unchanged — stats span full width below cover+info row
- [ ] No visual regressions on story detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)