### PR TITLE
[#835] Fix SSR hydration mismatch in Writer tab expired badge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -886,7 +886,11 @@ function StoryRow({
 
   const [isExpired, setIsExpired] = useState(false);
   useEffect(() => {
-    if (storyline.sunset || !storyline.has_deadline || !storyline.last_plot_time) return;
+    if (storyline.sunset || !storyline.has_deadline || !storyline.last_plot_time) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset when props change (e.g. deadline extension)
+      setIsExpired(false);
+      return;
+    }
     const expiryTime = new Date(storyline.last_plot_time).getTime() + DEADLINE_MS;
     const remaining = expiryTime - Date.now();
     if (remaining <= 0) {
@@ -894,6 +898,8 @@ function StoryRow({
       setIsExpired(true);
       return;
     }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset in case props changed from expired to active
+    setIsExpired(false);
     const timeout = setTimeout(() => setIsExpired(true), remaining);
     return () => clearTimeout(timeout);
   }, [storyline.sunset, storyline.has_deadline, storyline.last_plot_time]);

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -884,18 +884,19 @@ function StoryRow({
     enabled: !!storyline.token_address,
   });
 
-  const checkExpired = useCallback(
-    () => !storyline.sunset && storyline.has_deadline && !!storyline.last_plot_time &&
-      Date.now() > new Date(storyline.last_plot_time).getTime() + DEADLINE_MS,
-    [storyline.sunset, storyline.has_deadline, storyline.last_plot_time],
-  );
-  const [isExpired, setIsExpired] = useState(checkExpired);
+  const [isExpired, setIsExpired] = useState(false);
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial sync needed for SSR hydration safety
-    setIsExpired(checkExpired());
-    const interval = setInterval(() => setIsExpired(checkExpired()), 1_000);
-    return () => clearInterval(interval);
-  }, [checkExpired]);
+    if (storyline.sunset || !storyline.has_deadline || !storyline.last_plot_time) return;
+    const expiryTime = new Date(storyline.last_plot_time).getTime() + DEADLINE_MS;
+    const remaining = expiryTime - Date.now();
+    if (remaining <= 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time sync for already-expired storylines
+      setIsExpired(true);
+      return;
+    }
+    const timeout = setTimeout(() => setIsExpired(true), remaining);
+    return () => clearTimeout(timeout);
+  }, [storyline.sunset, storyline.has_deadline, storyline.last_plot_time]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Changed `useState(checkExpired)` to `useState(false)` — avoids calling `Date.now()` during server render which caused hydration mismatch near expiry boundary
- Replaced 1-second `setInterval` polling with a single `setTimeout` targeting the exact expiry time — fires once when the storyline actually expires
- Proper cleanup on unmount
- Patch version bump 0.1.19 → 0.1.20

Fixes #835

## Test plan
- [ ] No React hydration mismatch warnings in console
- [ ] Badge shows "active" for non-expired storylines, transitions to "expired" at the right time
- [ ] Badge shows "complete" for sunset storylines
- [ ] Badge shows "expired" immediately for already-expired storylines on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)