### PR TITLE
[#852] Document and verify historical USD conversion in PriceChart

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/PriceChart.tsx
+++ b/src/components/PriceChart.tsx
@@ -53,6 +53,24 @@ function formatUsdPrice(v: number): string {
   return `$${v.toExponential(2)}`;
 }
 
+/**
+ * Price chart with historical USD conversion (resolves #776 / #852).
+ *
+ * USD pricing approach:
+ *   USD price = price_per_token (in PLOT) × reserve_usd_rate
+ *   where reserve_usd_rate = priceForNextMint(PLOT→HUNT) × HUNT/USD (1inch oracle)
+ *
+ * Data accuracy tiers (stored in trade_history.rate_source):
+ *   - "live"             — rate captured at indexing time, within ~200 blocks of head
+ *   - "backfill_exact"   — both PLOT/HUNT and HUNT/USD read from archive RPC at trade block
+ *   - "backfill_approx"  — current PLOT/HUNT × historical HUNT/USD (less accurate for older trades)
+ *
+ * Chart behavior:
+ *   - USD/PLOT toggle shown only when at least one trade has a rate
+ *   - In USD mode, only points with a rate are plotted (gaps are acceptable)
+ *   - Approximate data rendered as dashed lines to signal lower confidence
+ *   - Falls back to PLOT-only view if no USD data exists
+ */
 export function PriceChart({ tokenAddress, currentPriceRaw }: PriceChartProps) {
   const [mode, setMode] = useState<PriceMode>("usd");
   const currentPrice = Number(formatUnits(currentPriceRaw, 18));


### PR DESCRIPTION
## Summary
- Historical USD conversion was **already fully implemented** — the gap from #776 was a misidentification of column names (`usd_price_per_token` / `plot_usd_rate` were searched, but the actual column is `reserve_usd_rate`)
- Added comprehensive doc comment to `PriceChart` explaining the USD pricing formula, three-tier data accuracy model, and chart fallback behavior
- Patch version bump 0.1.20 → 0.1.21

Fixes #852

### Verification findings
The existing implementation covers all requirements from #776:
- **Formula**: `USD price = price_per_token × reserve_usd_rate` where rate = `priceForNextMint(PLOT→HUNT) × HUNT/USD`
- **Live trades**: rate captured at indexing time (`rate_source: 'live'`)
- **Historical trades**: backfill script with archive RPC (`backfill_exact`) or fallback (`backfill_approx`)
- **Chart UX**: USD/PLOT toggle, dashed lines for approximate data, auto-fallback to PLOT if no USD data
- **Recommendation**: close #776 — implementation is complete, only documentation was missing

## Test plan
- [ ] PriceChart still renders correctly in both USD and PLOT modes
- [ ] No type or lint regressions
- [ ] Doc comment is accurate per the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)