### PR TITLE
[#861] Fix incorrect farcaster.com link to farcaster.xyz

### DIFF
--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -330,7 +330,7 @@ function ProfileHeader({
               </div>
             </div>
             <a
-              href={`https://farcaster.com/${dbUser!.username}`}
+              href={`https://farcaster.xyz/${dbUser!.username}`}
               target="_blank"
               rel="noopener noreferrer"
               className="text-foreground hover:text-accent text-sm font-medium transition-colors"


### PR DESCRIPTION
## Summary
- Single-line fix: profile page Farcaster link was pointing to `farcaster.com` (wrong domain) instead of `farcaster.xyz`
- Only one incorrect link found in the codebase; other Farcaster links (ShareButtons, Footer) already use `farcaster.xyz`

## Test plan
- [ ] Go to any profile with a Farcaster account → click the Farcaster username link → verify it opens `farcaster.xyz/{username}`

Fixes #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)