### PR TITLE
[#860] Show full USD token price in header

### DIFF
--- a/lib/usd-price.ts
+++ b/lib/usd-price.ts
@@ -117,3 +117,17 @@ export function formatUsdValue(value: number | null): string {
   if (value < 1_000_000) return `$${(value / 1000).toFixed(2)}K`;
   return `$${(value / 1_000_000).toFixed(2)}M`;
 }
+
+/**
+ * Format a USD token price with full precision for small values.
+ * Shows enough significant digits to expose the actual price
+ * instead of hiding it behind "< $0.01".
+ */
+export function formatUsdTokenPrice(value: number | null): string {
+  if (value === null) return "—";
+  if (value === 0) return "$0";
+  if (value >= 0.01) return formatUsdValue(value);
+  // For very small values, show 2 significant digits
+  const digits = Math.max(2, -Math.floor(Math.log10(value)) + 1);
+  return `$${value.toFixed(digits)}`;
+}

--- a/src/components/TokenPriceBox.tsx
+++ b/src/components/TokenPriceBox.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePlotUsdPrice } from "../hooks/usePlotUsdPrice";
-import { formatUsdValue } from "../../lib/usd-price";
+import { formatUsdTokenPrice } from "../../lib/usd-price";
 import { formatPrice } from "../../lib/format";
 import { RESERVE_LABEL } from "../../lib/contracts/constants";
 
@@ -16,7 +16,7 @@ export function TokenPriceBox({ pricePerToken }: { pricePerToken: number }) {
   return (
     <>
       <div className="text-foreground text-sm font-bold">
-        {usdPrice !== null ? formatUsdValue(usdPrice) : `${formatPrice(pricePerToken)} ${RESERVE_LABEL}`}
+        {usdPrice !== null ? formatUsdTokenPrice(usdPrice) : `${formatPrice(pricePerToken)} ${RESERVE_LABEL}`}
       </div>
       <div className="text-muted text-[9px]">Token Price</div>
     </>


### PR DESCRIPTION
## Summary
- Header token price box was showing `< $0.01` for small USD values, hiding the actual price
- Added `formatUsdTokenPrice()` in `lib/usd-price.ts` that shows 2 significant digits for values below $0.01 (e.g. `$0.0054`, `$0.00000012`)
- `TokenPriceBox` now uses this formatter; generic `formatUsdValue()` unchanged for other contexts

## Test plan
- [ ] View a story with a token price below $0.01 → verify header shows actual USD value (e.g. `$0.0054`) instead of `< $0.01`
- [ ] View a story with a token price above $0.01 → verify header still formats normally

Fixes #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)