### PR TITLE
[#867] Distinguish direct agents from linked OWS writer owners

### DIFF
--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -111,10 +111,12 @@ export async function getFullUserProfile(
 
   // Detect if this address is the agent OWNER (not the agent itself).
   // When true, the profile should display human identity, not agent identity.
+  // Direct agents (agent_type='direct') are the agent themselves — isAgentOwner stays false.
+  // OWS-linked writers (agent_type='ows-writer') have a separate human owner — isAgentOwner is true.
   const normalized = address.toLowerCase();
   const isAgentOwner = agentMeta !== null
     && agentMeta.owner?.toLowerCase() === normalized
-    && (dbUser?.agent_wallet == null || dbUser.agent_wallet.toLowerCase() !== normalized);
+    && dbUser?.agent_type === "ows-writer";
 
   return { dbUser, fcProfile, agentMeta, isAgentOwner };
 }
@@ -289,12 +291,12 @@ export async function getAgentOwnerProfile(
   const agentUser = await getAgentUserFromDB(writerAddress);
   if (!agentUser?.agent_id) return null;
 
-  // If the queried address IS the agent owner (not the agent wallet),
+  // If the queried address is an OWS-linked owner (not the agent itself),
   // this address belongs to the human owner — not an agent.
+  // Direct agents (agent_type='direct') are the agent themselves and should not be excluded.
   const normalized = writerAddress.toLowerCase();
   const isOwnerAddress = agentUser.agent_owner?.toLowerCase() === normalized;
-  const isAgentWallet = agentUser.agent_wallet?.toLowerCase() === normalized;
-  if (isOwnerAddress && !isAgentWallet) return null;
+  if (isOwnerAddress && agentUser.agent_type === "ows-writer") return null;
 
   const ownerProfile = agentUser.agent_owner
     ? await getFarcasterProfile(agentUser.agent_owner)

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -113,10 +113,13 @@ export async function getFullUserProfile(
   // When true, the profile should display human identity, not agent identity.
   // Direct agents (agent_type='direct') are the agent themselves — isAgentOwner stays false.
   // OWS-linked writers (agent_type='ows-writer') have a separate human owner — isAgentOwner is true.
+  // Legacy rows (agent_type=null) fall back to the old wallet-null heuristic for backward compat.
   const normalized = address.toLowerCase();
-  const isAgentOwner = agentMeta !== null
-    && agentMeta.owner?.toLowerCase() === normalized
-    && dbUser?.agent_type === "ows-writer";
+  const isOwner = agentMeta !== null && agentMeta.owner?.toLowerCase() === normalized;
+  const isAgentOwner = isOwner
+    && (dbUser?.agent_type === "ows-writer"
+      || (dbUser?.agent_type == null
+        && (dbUser?.agent_wallet == null || dbUser.agent_wallet.toLowerCase() !== normalized)));
 
   return { dbUser, fcProfile, agentMeta, isAgentOwner };
 }
@@ -294,9 +297,14 @@ export async function getAgentOwnerProfile(
   // If the queried address is an OWS-linked owner (not the agent itself),
   // this address belongs to the human owner — not an agent.
   // Direct agents (agent_type='direct') are the agent themselves and should not be excluded.
+  // Legacy rows (agent_type=null) fall back to the old wallet-null heuristic.
   const normalized = writerAddress.toLowerCase();
   const isOwnerAddress = agentUser.agent_owner?.toLowerCase() === normalized;
-  if (isOwnerAddress && agentUser.agent_type === "ows-writer") return null;
+  const isAgentWallet = agentUser.agent_wallet?.toLowerCase() === normalized;
+  const isLinkedOwner = isOwnerAddress
+    && (agentUser.agent_type === "ows-writer"
+      || (agentUser.agent_type == null && !isAgentWallet));
+  if (isLinkedOwner) return null;
 
   const ownerProfile = agentUser.agent_owner
     ? await getFarcasterProfile(agentUser.agent_owner)

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -435,6 +435,7 @@ export interface Database {
         agent_llm_model: string | null;
         agent_wallet: string | null;
         agent_owner: string | null;
+        agent_type: string | null;
         agent_registered_at: string | null;
         stats_fetched_at: string | null;
         steemhunt_fetched_at: string | null;
@@ -478,6 +479,7 @@ export interface Database {
         agent_llm_model?: string | null;
         agent_wallet?: string | null;
         agent_owner?: string | null;
+        agent_type?: string | null;
         agent_registered_at?: string | null;
         stats_fetched_at?: string | null;
         steemhunt_fetched_at?: string | null;
@@ -521,6 +523,7 @@ export interface Database {
         agent_llm_model?: string | null;
         agent_wallet?: string | null;
         agent_owner?: string | null;
+        agent_type?: string | null;
         agent_registered_at?: string | null;
         stats_fetched_at?: string | null;
         steemhunt_fetched_at?: string | null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/api/user/agent-register/route.ts
+++ b/src/app/api/user/agent-register/route.ts
@@ -8,7 +8,7 @@ import { createServiceRoleClient } from "../../../../../lib/supabase";
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { walletAddress, agentId, name, description, genre, llmModel, agentWallet, agentOwner } = body;
+    const { walletAddress, agentId, name, description, genre, llmModel, agentWallet, agentOwner, agentType } = body;
 
     if (!walletAddress || typeof walletAddress !== "string" || !agentId) {
       return NextResponse.json({ error: "walletAddress and agentId are required" }, { status: 400 });
@@ -57,6 +57,7 @@ export async function POST(request: NextRequest) {
       agent_llm_model: llmModel || null,
       agent_wallet: agentWallet?.toLowerCase() || null,
       agent_owner: (agentOwner || walletAddress).toLowerCase(),
+      agent_type: agentType || null,
       agent_registered_at: new Date().toISOString(),
     };
 

--- a/src/app/api/user/agent-register/route.ts
+++ b/src/app/api/user/agent-register/route.ts
@@ -14,6 +14,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "walletAddress and agentId are required" }, { status: 400 });
     }
 
+    const VALID_AGENT_TYPES = ["direct", "ows-writer"] as const;
+    const validatedAgentType = VALID_AGENT_TYPES.includes(agentType) ? agentType : null;
+
     const supabase = createServiceRoleClient();
     if (!supabase) {
       return NextResponse.json({ error: "Database not configured" }, { status: 500 });
@@ -57,7 +60,7 @@ export async function POST(request: NextRequest) {
       agent_llm_model: llmModel || null,
       agent_wallet: agentWallet?.toLowerCase() || null,
       agent_owner: (agentOwner || walletAddress).toLowerCase(),
-      agent_type: agentType || null,
+      agent_type: validatedAgentType,
       agent_registered_at: new Date().toISOString(),
     };
 

--- a/src/components/AgentRegister.tsx
+++ b/src/components/AgentRegister.tsx
@@ -128,6 +128,7 @@ function LinkAIWriter() {
           name: "AI Writer",
           description: "AI fiction writer linked via PlotLink OWS",
           agentOwner: address,
+          agentType: "ows-writer",
         }),
       });
       if (!cacheRes.ok) {
@@ -362,6 +363,7 @@ function DirectRegister() {
             genre: meta.genre,
             llmModel: meta.llmModel,
             agentOwner: address,
+            agentType: "direct",
           }),
         });
         if (!cacheRes.ok) {

--- a/supabase/migrations/00032_users_agent_type.sql
+++ b/supabase/migrations/00032_users_agent_type.sql
@@ -1,0 +1,4 @@
+-- Distinguish direct agent registrations from linked OWS writer owners.
+-- 'direct' = owner IS the agent (show agent profile)
+-- 'ows-writer' = owner linked an OWS writer (show human profile with linked AI card)
+ALTER TABLE users ADD COLUMN IF NOT EXISTS agent_type TEXT;


### PR DESCRIPTION
## Summary
- Adds `agent_type` column (`'direct'` / `'ows-writer'`) to the `users` table to explicitly classify agent registrations
- Updates `isAgentOwner` logic in `getFullUserProfile()` and `getAgentOwnerProfile()` to use `agent_type` instead of the overly broad wallet-null heuristic
- Direct agents now correctly render as AI agent profiles; OWS-linked owners continue to render as human profiles with linked AI writer cards

## Changes
- **Migration**: `00032_users_agent_type.sql` — adds `agent_type TEXT` column
- **Supabase types**: Row/Insert/Update types updated with `agent_type`
- **API** (`agent-register/route.ts`): accepts and persists `agentType`
- **Registration** (`AgentRegister.tsx`): OWS flow sends `agentType: "ows-writer"`, direct flow sends `agentType: "direct"`
- **Classification** (`lib/actions.ts`): `isAgentOwner` now checks `agent_type === "ows-writer"` instead of wallet-null heuristic
- **Version**: patch bump 0.1.23 → 0.1.24

## Test plan
- [ ] Register a direct agent → profile page should show "Agent Identity" card (not "Linked AI Writer")
- [ ] Register an OWS-linked writer → owner profile should show human identity with "Linked AI Writer" card
- [ ] Existing agents without `agent_type` (null) should default to agent display (not misclassified as owner)
- [ ] Agent management page (`/agents`) continues to work for both registration types

Fixes #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)