### PR TITLE
[#864] Reduce PR CI cost by removing visual regression job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-and-typecheck:
     runs-on: ubuntu-latest
@@ -36,28 +40,3 @@ jobs:
       - run: npm run build
       - name: Run E2E tests (functional only)
         run: npx playwright test --grep-invert "Visual Regression"
-
-  visual-regression:
-    runs-on: ubuntu-latest
-    env:
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-      NEXT_PUBLIC_CHAIN_ID: "8453"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-      - run: npm ci
-      - run: npx playwright install --with-deps chromium
-      - run: npm run build
-      - name: Run visual regression
-        run: npx playwright test e2e/visual-regression.spec.ts --update-snapshots
-      - name: Upload snapshots
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: visual-regression-snapshots
-          path: e2e/__snapshots__/
-          retention-days: 30

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -3,9 +3,14 @@ name: Update Visual Snapshots
 on:
   workflow_dispatch:
 
+concurrency:
+  group: visual-snapshots
+  cancel-in-progress: true
+
 jobs:
   update-snapshots:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,8 @@ src/
     page.tsx    # Home page
 .github/
   workflows/
-    ci.yml      # Lint + type-check on PRs
+    ci.yml                # Lint + type-check + e2e on PRs
+    update-snapshots.yml  # Visual regression (manual-only)
 ```
 
 ## Commands
@@ -32,6 +33,10 @@ npm run build      # Production build
 npm run lint       # ESLint
 npm run typecheck  # TypeScript type-check (tsc --noEmit)
 ```
+
+## CI / Visual Regression
+
+PR CI runs `lint-and-typecheck` and `e2e` only. Visual regression snapshots are **manual-only** — trigger the `Update Visual Snapshots` workflow via GitHub Actions or `gh workflow run update-snapshots.yml` when a change is likely to impact UI layout.
 
 ## Design System
 


### PR DESCRIPTION
## Summary
- Removed `visual-regression` job from PR CI — it remains available as manual-only via `Update Visual Snapshots` workflow (`update-snapshots.yml`)
- Added `concurrency` group with `cancel-in-progress: true` so superseded PR CI runs are auto-canceled
- PR CI now runs only `lint-and-typecheck` and `e2e` (no app runtime changes)

## Changes
- **`.github/workflows/ci.yml`**: removed visual-regression job (25 lines), added concurrency block (4 lines)

## Test plan
- [ ] Open a PR → CI should run only `lint-and-typecheck` and `e2e` jobs
- [ ] Push again to same PR → previous CI run should be canceled
- [ ] `Update Visual Snapshots` workflow remains available for manual dispatch
- [ ] No app runtime code changed

Fixes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)