### PR TITLE
[#895] Show "Open" for stories without deadlines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -289,6 +289,11 @@ function StoryHeader({
             </div>
             <div className="text-muted text-[9px]">Deadline</div>
           </>
+        ) : !storyline.has_deadline ? (
+          <>
+            <div className="text-foreground text-sm font-bold">Open</div>
+            <div className="text-muted text-[9px]">Deadline</div>
+          </>
         ) : (
           <>
             <div className="text-foreground text-sm font-bold">—</div>


### PR DESCRIPTION
## Summary
- Deadline stat box now shows "Open" for stories with `has_deadline=false` instead of ambiguous "—"
- Stories with `has_deadline=true` but missing `last_plot_time` still show "—" (rare data gap)
- Existing behavior unchanged: sunset stories show "Complete", deadline stories show countdown

## Files Changed
- `src/app/story/[storylineId]/page.tsx` — split fallback branch into two cases
- `package.json` — patch bump 0.1.25 → 0.1.26

## Test plan
- [ ] Open a story with `has_deadline=false` (e.g. The Holloway Manuscript #35) — verify "Open" label
- [ ] Open a story with a deadline — verify countdown still works
- [ ] Open a sunset story — verify "Complete" still shows

Fixes #895

🤖 Generated with [Claude Code](https://claude.com/claude-code)