### PR TITLE
[#915] Fix Farcaster referral code property name mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/airdrop/UserPoints.tsx
+++ b/src/components/airdrop/UserPoints.tsx
@@ -237,7 +237,7 @@ function ReferralSection({
       const res = await fetch("/api/airdrop/referral-code", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message, signature, useFarcaster: true }),
+        body: JSON.stringify({ message, signature, useFarcasterUsername: true }),
       });
 
       if (!res.ok) {


### PR DESCRIPTION
## Summary
- Frontend sent `useFarcaster: true` but backend expected `useFarcasterUsername` in POST `/api/airdrop/referral-code`
- One-line fix: rename property in `UserPoints.tsx` to match backend expectation
- Without this fix, "Use Farcaster username" button silently generates a random code instead
- Bumps patch version to 0.1.29

Fixes #915

## Test plan
- [ ] Click "Use Farcaster username" button on airdrop page with a connected Farcaster account
- [ ] Verify referral code is set to the Farcaster username (not a random nanoid)
- [ ] Verify `is_farcaster_username` flag is `true` in `pl_referral_codes` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)