### PR TITLE
[#916] Fix streak tier drop logic to drop to previous tier

### DIFF
--- a/lib/airdrop/streak.ts
+++ b/lib/airdrop/streak.ts
@@ -25,14 +25,14 @@ export function getStreakBoost(currentStreak: number): number {
 
 /**
  * Drop one tier after a missed day. Returns the new streak value.
- * Per spec: streak snaps down to the current tier's threshold.
- *   100+ → 100, 50-99 → 50, 30-49 → 30, 14-29 → 14, 7-13 → 7, 1-6 → 0
+ * Per spec: streak drops to the previous tier's threshold.
+ *   100+ → 50, 50-99 → 30, 30-49 → 14, 14-29 → 7, 7-13 → 0, 1-6 → 0
  */
 export function dropOneTier(streak: number): number {
-  // Find the current tier and snap to its threshold
+  // Find the current tier and drop to the one below it
   for (let i = TIER_THRESHOLDS.length - 1; i >= 0; i--) {
     if (streak >= TIER_THRESHOLDS[i]) {
-      return TIER_THRESHOLDS[i];
+      return i > 0 ? TIER_THRESHOLDS[i - 1] : 0;
     }
   }
   return 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/api/airdrop/checkin/route.ts
+++ b/src/app/api/airdrop/checkin/route.ts
@@ -102,7 +102,7 @@ export async function POST(req: Request) {
         // Consecutive day — increment streak
         newStreak = existing.current_streak + 1;
       } else {
-        // Missed 2+ days — snap to current tier threshold
+        // Missed 2+ days — drop to previous tier threshold
         newStreak = dropOneTier(existing.current_streak);
       }
     } else {


### PR DESCRIPTION
## Summary
- `dropOneTier()` was snapping to the **current** tier threshold instead of the **previous** one
- streak 50 + miss → stayed at 50 (no penalty). Now correctly drops to 30
- streak 100 + miss → stayed at 100. Now correctly drops to 50
- streak 7 + miss → stayed at 7. Now correctly drops to 0
- streak 3 + miss → already returned 0 (unchanged)
- Updated comment in checkin route to match new behavior
- Bumps patch version to 0.1.30

Fixes #916

## Test plan
- [ ] Verify `dropOneTier(100)` returns 50
- [ ] Verify `dropOneTier(50)` returns 30
- [ ] Verify `dropOneTier(7)` returns 0
- [ ] Verify `dropOneTier(3)` returns 0
- [ ] Check-in flow: miss a day with streak 50, confirm streak drops to 30

🤖 Generated with [Claude Code](https://claude.com/claude-code)