### PR TITLE
[#922] Fix Vercel deploy: change OG route from Edge to Node.js runtime

### DIFF
--- a/src/app/story/[storylineId]/og/route.tsx
+++ b/src/app/story/[storylineId]/og/route.tsx
@@ -8,7 +8,7 @@ import { formatPrice } from "../../../../../lib/format";
 import { truncateAddress } from "../../../../../lib/utils";
 import { getPlotUsdPrice, formatUsdValue } from "../../../../../lib/usd-price";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 
 async function loadFont(): Promise<ArrayBuffer | null> {
   try {


### PR DESCRIPTION
## Summary
- Changed `export const runtime = "edge"` to `"nodejs"` in `src/app/story/[storylineId]/og/route.tsx`
- **All Vercel deployments have been failing since Apr 15** (PR #896) because the Edge bundler includes `mint.club-v2-sdk` which is unsupported in the Edge runtime
- OG image generation doesn't benefit from Edge — Node.js runtime is fine

## Root Cause
PR #896 refactored `lib/usd-price.ts`:
1. Added `import { createServiceRoleClient } from "./supabase"` (DB fallback)
2. Restructured Mint Club SDK import into a `fetchFromMintClub()` function called via `Promise.any()`

The OG route imports `getPlotUsdPrice` from `usd-price.ts`. The Edge bundler (Turbopack) can no longer tree-shake the `mint.club-v2-sdk` dynamic import through the new function indirection, so it bundles it — and Vercel rejects it.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors)
- [x] No other Edge routes exist (`grep` confirmed)
- [ ] Vercel deploy succeeds after merge
- [ ] OG images still render correctly (`/story/[id]/og`)

Fixes #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)