### PR TITLE
[#924] Redesign airdrop hero with bold campaign concept

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/airdrop/CampaignHero.tsx
+++ b/src/components/airdrop/CampaignHero.tsx
@@ -34,6 +34,29 @@ function useAirdropStatus() {
   });
 }
 
+function CountdownDisplay({ days }: { days: number }) {
+  const weeks = Math.floor(days / 7);
+  const remainingDays = days % 7;
+
+  return (
+    <div className="flex items-center gap-3 justify-center mt-3">
+      {weeks > 0 && (
+        <div className="text-center">
+          <div className="text-foreground text-2xl font-bold font-mono">{weeks}</div>
+          <div className="text-muted text-[9px] uppercase tracking-wider">weeks</div>
+        </div>
+      )}
+      {weeks > 0 && (
+        <div className="text-muted text-lg">:</div>
+      )}
+      <div className="text-center">
+        <div className="text-foreground text-2xl font-bold font-mono">{weeks > 0 ? remainingDays : days}</div>
+        <div className="text-muted text-[9px] uppercase tracking-wider">days</div>
+      </div>
+    </div>
+  );
+}
+
 export function CampaignHero() {
   const { data, isLoading } = useAirdropStatus();
 
@@ -45,88 +68,33 @@ export function CampaignHero() {
     );
   }
 
-  // Find the next milestone target
-  const nextMilestone = !data.milestones.bronze.reached
-    ? { name: "Bronze", mcap: data.milestones.bronze.mcap }
-    : !data.milestones.silver.reached
-      ? { name: "Silver", mcap: data.milestones.silver.mcap }
-      : !data.milestones.gold.reached
-        ? { name: "Gold", mcap: data.milestones.gold.mcap }
-        : null;
-
-  const mcapProgress = nextMilestone
-    ? Math.min(100, (data.currentMcap / nextMilestone.mcap) * 100)
-    : 100;
-
   return (
-    <div className="border-border rounded border p-4 space-y-4">
-      <div>
-        <h2 className="text-foreground text-lg font-bold">PLOT 10x Airdrop</h2>
-        <p className="text-muted text-xs mt-1">
-          {data.poolAmount.toLocaleString()} PLOT locked. Big or nothing.
+    <div className="border-border rounded border p-5 space-y-4">
+      {/* Title + Tagline */}
+      <div className="text-center">
+        <h2 className="text-foreground text-xl font-bold leading-tight">
+          PLOT Big or Nothing Airdrop
+        </h2>
+        <p className="text-accent text-sm font-medium mt-1">
+          {data.poolAmount.toLocaleString()} PLOT locked. Earn or burn.
         </p>
       </div>
 
-      {/* Time progress */}
-      <div>
-        <div className="flex justify-between text-xs mb-1">
-          <span className="text-muted">Time remaining</span>
-          <span className="text-foreground font-medium">{data.timeRemainingDays} days</span>
-        </div>
-        <div className="bg-surface border-border h-2 rounded border overflow-hidden">
-          <div
-            className="bg-accent h-full transition-all"
-            style={{ width: `${data.timeElapsedPercent}%` }}
-          />
-        </div>
-        <div className="text-muted text-[10px] mt-0.5 text-right">{data.timeElapsedPercent}% elapsed</div>
-      </div>
-
-      {/* Market Cap progress */}
-      <div>
-        <div className="flex justify-between text-xs mb-1">
-          <span className="text-muted">Market Cap</span>
-          <span className="text-foreground font-medium">{formatUsdValue(data.currentMcap)}</span>
-        </div>
-        <div className="bg-surface border-border h-2 rounded border overflow-hidden">
-          <div
-            className="bg-accent h-full transition-all"
-            style={{ width: `${mcapProgress}%` }}
-          />
-        </div>
-        <div className="text-muted text-[10px] mt-0.5 text-right">
-          {nextMilestone ? `< ${nextMilestone.name} (${formatUsdValue(nextMilestone.mcap)})` : "Gold reached"}
-        </div>
-      </div>
-
-      {/* Pool value at next milestone */}
-      {data.latestPriceUsd != null && data.latestPriceUsd > 0 && (
-        <div className="text-center text-xs">
-          {nextMilestone ? (
-            <span className="text-muted">
-              Pool value if {nextMilestone.name}:{" "}
-              <span className="text-foreground font-medium">
-                {formatUsdValue(
-                  data.poolAmount *
-                    (data.milestones[
-                      nextMilestone.name.toLowerCase() as keyof typeof data.milestones
-                    ].pct / 100) *
-                    data.latestPriceUsd
-                )}
-              </span>
-            </span>
-          ) : (
-            <span className="text-muted">
-              Pool value at Gold:{" "}
-              <span className="text-foreground font-medium">
-                {formatUsdValue(
-                  data.poolAmount *
-                    (data.milestones.gold.pct / 100) *
-                    data.latestPriceUsd
-                )}
-              </span>
-            </span>
-          )}
+      {/* Countdown */}
+      {data.timeRemainingDays > 0 && (
+        <div>
+          <CountdownDisplay days={data.timeRemainingDays} />
+          <div className="mt-2">
+            <div className="bg-surface border-border h-1.5 rounded border overflow-hidden">
+              <div
+                className="bg-accent h-full transition-all"
+                style={{ width: `${data.timeElapsedPercent}%` }}
+              />
+            </div>
+            <div className="text-muted text-[10px] mt-0.5 text-right">
+              {data.timeElapsedPercent}% elapsed
+            </div>
+          </div>
         </div>
       )}
 
@@ -142,7 +110,7 @@ export function CampaignHero() {
         </div>
         <div className="border-border rounded border px-2 py-1.5">
           <div className="text-foreground text-sm font-bold">
-            {data.latestPriceUsd ? formatUsdValue(data.latestPriceUsd) : "—"}
+            {data.latestPriceUsd ? formatUsdValue(data.latestPriceUsd) : "\u2014"}
           </div>
           <div className="text-muted text-[9px]">PLOT Price</div>
         </div>

--- a/src/components/airdrop/MilestoneTrack.tsx
+++ b/src/components/airdrop/MilestoneTrack.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { formatUsdValue } from "../../../lib/usd-price";
 
@@ -14,15 +15,28 @@ interface StatusData {
   };
 }
 
-/* ─── Chart milestones (presentation layer) ─── */
+/* ─── Chart tier definitions (presentation layer) ─── */
 
 const MAX_SUPPLY = 1_000_000;
-const CHART_MILESTONES = [
-  { label: "Bronze", emoji: "\uD83E\uDD49", fdv: 1_000_000, poolPct: 10, poolUsd: 5_000 },
-  { label: "Silver", emoji: "\uD83E\uDD48", fdv: 10_000_000, poolPct: 30, poolUsd: 150_000 },
-  { label: "Gold", emoji: "\uD83E\uDD47", fdv: 50_000_000, poolPct: 50, poolUsd: 1_250_000 },
-  { label: "Diamond", emoji: "\uD83D\uDC8E", fdv: 100_000_000, poolPct: 100, poolUsd: 5_000_000 },
+const CHART_TIERS = [
+  { label: "Bronze", emoji: "\uD83E\uDD49", fdv: 1_000_000, poolPct: 10 },
+  { label: "Silver", emoji: "\uD83E\uDD48", fdv: 10_000_000, poolPct: 30 },
+  { label: "Gold", emoji: "\uD83E\uDD47", fdv: 50_000_000, poolPct: 50 },
+  { label: "Diamond", emoji: "\uD83D\uDC8E", fdv: 100_000_000, poolPct: 100 },
 ] as const;
+
+/** Pool USD value at a given FDV milestone: poolAmount * (pct/100) * (fdv / maxSupply) */
+function poolUsdAt(fdv: number, poolPct: number, poolAmount: number): number {
+  return poolAmount * (poolPct / 100) * (fdv / MAX_SUPPLY);
+}
+
+type ChartMilestone = {
+  fdv: number;
+  poolUsd: number;
+  label: string;
+  emoji: string;
+  poolPct: number;
+};
 
 /* ─── SVG layout constants ─── */
 
@@ -33,8 +47,8 @@ const CHART_W = SVG_W - PAD.left - PAD.right;
 const CHART_H = SVG_H - PAD.top - PAD.bottom;
 
 // Log scale helpers — FDV axis from 10k to 200M
-const LOG_MIN = Math.log10(10_000);      // 4
-const LOG_MAX = Math.log10(200_000_000); // ~8.3
+const LOG_MIN = Math.log10(10_000);
+const LOG_MAX = Math.log10(200_000_000);
 
 function fdvToX(fdv: number): number {
   if (fdv <= 0) return PAD.left;
@@ -43,49 +57,35 @@ function fdvToX(fdv: number): number {
   return PAD.left + t * CHART_W;
 }
 
-// Y axis: pool USD value (linear, 0 to 5.5M)
-const Y_MAX = 5_500_000;
-
-function usdToY(usd: number): number {
-  const t = usd / Y_MAX;
+function usdToY(usd: number, yMax: number): number {
+  const t = usd / yMax;
   return PAD.top + CHART_H * (1 - t);
 }
 
-/* ─── Y-axis tick values ─── */
-const Y_TICKS = [0, 1_000_000, 2_500_000, 5_000_000];
+/* ─── Path builders ─── */
 
-/* ─── Step area path builder ─── */
-
-function buildAreaPath(): string {
-  const baseline = usdToY(0);
-  // Start at origin
+function buildAreaPath(milestones: ChartMilestone[], yMax: number): string {
+  const baseline = usdToY(0, yMax);
   let path = `M ${fdvToX(10_000)} ${baseline}`;
-  // Step up at each milestone
   let prevY = baseline;
-  for (const m of CHART_MILESTONES) {
+  for (const m of milestones) {
     const x = fdvToX(m.fdv);
-    const y = usdToY(m.poolUsd);
-    // Horizontal to milestone x at previous level
-    path += ` L ${x} ${prevY}`;
-    // Step up to new level
-    path += ` L ${x} ${y}`;
+    const y = usdToY(m.poolUsd, yMax);
+    path += ` L ${x} ${prevY} L ${x} ${y}`;
     prevY = y;
   }
-  // Extend to right edge at last level
   path += ` L ${PAD.left + CHART_W} ${prevY}`;
-  // Close back down to baseline
-  path += ` L ${PAD.left + CHART_W} ${baseline}`;
-  path += " Z";
+  path += ` L ${PAD.left + CHART_W} ${baseline} Z`;
   return path;
 }
 
-function buildLinePath(): string {
+function buildLinePath(milestones: ChartMilestone[], yMax: number): string {
   let path = "";
-  let prevY = usdToY(0);
-  for (let i = 0; i < CHART_MILESTONES.length; i++) {
-    const m = CHART_MILESTONES[i];
+  let prevY = usdToY(0, yMax);
+  for (let i = 0; i < milestones.length; i++) {
+    const m = milestones[i];
     const x = fdvToX(m.fdv);
-    const y = usdToY(m.poolUsd);
+    const y = usdToY(m.poolUsd, yMax);
     if (i === 0) {
       path = `M ${fdvToX(10_000)} ${prevY} L ${x} ${prevY} L ${x} ${y}`;
     } else {
@@ -110,6 +110,15 @@ export function MilestoneTrack() {
     staleTime: 60_000,
   });
 
+  const milestones: ChartMilestone[] = useMemo(
+    () =>
+      CHART_TIERS.map((t) => ({
+        ...t,
+        poolUsd: poolUsdAt(t.fdv, t.poolPct, data?.poolAmount ?? 50_000),
+      })),
+    [data?.poolAmount],
+  );
+
   if (isLoading || !data) {
     return (
       <div className="border-border rounded border p-4">
@@ -118,6 +127,13 @@ export function MilestoneTrack() {
     );
   }
 
+  // Y-axis max with 10% headroom above Diamond
+  const yMax = milestones[milestones.length - 1].poolUsd * 1.1;
+
+  // Y-axis ticks: evenly space 4 ticks from 0 to Diamond poolUsd
+  const diamondUsd = milestones[milestones.length - 1].poolUsd;
+  const yTicks = [0, diamondUsd * 0.2, diamondUsd * 0.5, diamondUsd];
+
   // FDV = price * max supply
   const currentFdv =
     data.latestPriceUsd != null && data.latestPriceUsd > 0
@@ -125,24 +141,21 @@ export function MilestoneTrack() {
       : 0;
 
   // Determine current zone
-  const currentZone = CHART_MILESTONES.reduce(
+  const currentZone = milestones.reduce(
     (zone, m, i) => (currentFdv >= m.fdv ? i + 1 : zone),
     0,
   );
   const currentZoneLabel =
-    currentZone === 0
-      ? "Pre-Bronze"
-      : CHART_MILESTONES[currentZone - 1].label;
+    currentZone === 0 ? "Pre-Bronze" : milestones[currentZone - 1].label;
 
-  // Current pool value based on FDV position
   const currentPoolUsd =
-    currentZone > 0 ? CHART_MILESTONES[currentZone - 1].poolUsd : 0;
+    currentZone > 0 ? milestones[currentZone - 1].poolUsd : 0;
 
   const dotX = fdvToX(Math.max(currentFdv, 10_000));
-  const dotY = usdToY(currentPoolUsd);
+  const dotY = usdToY(currentPoolUsd, yMax);
 
-  const areaPath = buildAreaPath();
-  const linePath = buildLinePath();
+  const areaPath = buildAreaPath(milestones, yMax);
+  const linePath = buildLinePath(milestones, yMax);
 
   return (
     <div className="border-border rounded border p-4">
@@ -150,7 +163,8 @@ export function MilestoneTrack() {
         FDV Milestone Chart
       </h3>
       <p className="text-muted text-[10px] mb-3">
-        Pool unlock curve across FDV milestones &middot; FDV = PLOT price &times; {MAX_SUPPLY.toLocaleString()} max supply
+        Pool unlock curve across FDV milestones &middot; FDV = PLOT price
+        &times; {MAX_SUPPLY.toLocaleString()} max supply
       </p>
 
       <div className="w-full overflow-x-auto -mx-1 px-1">
@@ -158,6 +172,8 @@ export function MilestoneTrack() {
           viewBox={`0 0 ${SVG_W} ${SVG_H}`}
           className="w-full h-auto"
           style={{ minWidth: 320 }}
+          role="img"
+          aria-label="FDV milestone chart showing pool value unlock curve across Bronze, Silver, Gold, and Diamond tiers"
         >
           <defs>
             <linearGradient id="area-grad" x1="0" y1="0" x2="0" y2="1">
@@ -167,26 +183,30 @@ export function MilestoneTrack() {
           </defs>
 
           {/* Y-axis grid lines */}
-          {Y_TICKS.map((val) => (
+          {yTicks.map((val) => (
             <g key={val}>
               <line
                 x1={PAD.left}
-                y1={usdToY(val)}
+                y1={usdToY(val, yMax)}
                 x2={PAD.left + CHART_W}
-                y2={usdToY(val)}
+                y2={usdToY(val, yMax)}
                 stroke="#D4C5B0"
                 strokeWidth={0.5}
                 strokeDasharray={val === 0 ? "0" : "3,3"}
               />
               <text
                 x={PAD.left - 6}
-                y={usdToY(val) + 3}
+                y={usdToY(val, yMax) + 3}
                 textAnchor="end"
                 fill="#8B7355"
                 fontSize={9}
                 fontFamily="Inter, system-ui, sans-serif"
               >
-                {val === 0 ? "$0" : `$${(val / 1_000_000).toFixed(1)}M`}
+                {val === 0
+                  ? "$0"
+                  : val >= 1_000_000
+                    ? `$${(val / 1_000_000).toFixed(1)}M`
+                    : `$${(val / 1_000).toFixed(0)}K`}
               </text>
             </g>
           ))}
@@ -195,20 +215,14 @@ export function MilestoneTrack() {
           <path d={areaPath} fill="url(#area-grad)" />
 
           {/* Step line */}
-          <path
-            d={linePath}
-            fill="none"
-            stroke="#8B4513"
-            strokeWidth={2}
-          />
+          <path d={linePath} fill="none" stroke="#8B4513" strokeWidth={2} />
 
           {/* Vertical zone dividers + annotations */}
-          {CHART_MILESTONES.map((m) => {
+          {milestones.map((m) => {
             const x = fdvToX(m.fdv);
-            const y = usdToY(m.poolUsd);
+            const y = usdToY(m.poolUsd, yMax);
             return (
               <g key={m.label}>
-                {/* Vertical divider */}
                 <line
                   x1={x}
                   y1={PAD.top}
@@ -218,7 +232,6 @@ export function MilestoneTrack() {
                   strokeWidth={0.5}
                   strokeDasharray="4,3"
                 />
-                {/* Annotation at top of zone */}
                 <text
                   x={x}
                   y={PAD.top - 6}
@@ -238,9 +251,12 @@ export function MilestoneTrack() {
                   fontSize={8}
                   fontFamily="Inter, system-ui, sans-serif"
                 >
-                  {m.poolPct}% (${m.poolUsd >= 1_000_000 ? `${(m.poolUsd / 1_000_000).toFixed(1)}M` : `${(m.poolUsd / 1_000).toFixed(0)}K`})
+                  {m.poolPct}% ($
+                  {m.poolUsd >= 1_000_000
+                    ? `${(m.poolUsd / 1_000_000).toFixed(1)}M`
+                    : `${(m.poolUsd / 1_000).toFixed(0)}K`}
+                  )
                 </text>
-                {/* Dot at step corner */}
                 <circle
                   cx={x}
                   cy={y}
@@ -254,7 +270,7 @@ export function MilestoneTrack() {
           })}
 
           {/* X-axis labels */}
-          {CHART_MILESTONES.map((m) => (
+          {milestones.map((m) => (
             <text
               key={m.label}
               x={fdvToX(m.fdv)}
@@ -268,7 +284,7 @@ export function MilestoneTrack() {
             </text>
           ))}
 
-          {/* X-axis label */}
+          {/* Axis labels */}
           <text
             x={PAD.left + CHART_W / 2}
             y={SVG_H - 4}
@@ -279,8 +295,6 @@ export function MilestoneTrack() {
           >
             FDV &rarr;
           </text>
-
-          {/* Y-axis label */}
           <text
             x={12}
             y={PAD.top + CHART_H / 2}
@@ -296,7 +310,6 @@ export function MilestoneTrack() {
           {/* Current FDV indicator */}
           {currentFdv > 0 && (
             <g>
-              {/* Vertical dashed line from dot to x-axis */}
               <line
                 x1={dotX}
                 y1={dotY}
@@ -378,10 +391,11 @@ export function MilestoneTrack() {
           Current FDV: {currentFdv > 0 ? formatUsdValue(currentFdv) : "\u2014"}
           <span className="text-muted"> &middot; Zone: {currentZoneLabel}</span>
         </div>
-        {currentFdv > 0 && currentZone < CHART_MILESTONES.length && (
+        {currentFdv > 0 && currentZone < milestones.length && (
           <div className="text-muted text-[10px]">
-            Next: {CHART_MILESTONES[currentZone].emoji} {CHART_MILESTONES[currentZone].label} at{" "}
-            {formatUsdValue(CHART_MILESTONES[currentZone].fdv)} FDV
+            Next: {milestones[currentZone].emoji}{" "}
+            {milestones[currentZone].label} at{" "}
+            {formatUsdValue(milestones[currentZone].fdv)} FDV
           </div>
         )}
       </div>

--- a/src/components/airdrop/MilestoneTrack.tsx
+++ b/src/components/airdrop/MilestoneTrack.tsx
@@ -307,23 +307,32 @@ export function MilestoneTrack() {
             Pool Value
           </text>
 
-          {/* Current FDV indicator */}
+          {/* Current FDV indicator — dot on x-axis, dashed line up to area */}
           {currentFdv > 0 && (
             <g>
+              {/* Vertical dashed line from x-axis up to the step level */}
               <line
                 x1={dotX}
-                y1={dotY}
+                y1={PAD.top + CHART_H}
                 x2={dotX}
-                y2={PAD.top + CHART_H}
+                y2={dotY}
                 stroke="#8B4513"
                 strokeWidth={1}
                 strokeDasharray="3,3"
                 opacity={0.6}
               />
-              {/* Pulse ring */}
+              {/* Small marker at the step intersection */}
               <circle
                 cx={dotX}
                 cy={dotY}
+                r={2.5}
+                fill="#8B4513"
+                opacity={0.5}
+              />
+              {/* Pulse ring on x-axis */}
+              <circle
+                cx={dotX}
+                cy={PAD.top + CHART_H}
                 r={6}
                 fill="none"
                 stroke="#8B4513"
@@ -343,8 +352,8 @@ export function MilestoneTrack() {
                   repeatCount="indefinite"
                 />
               </circle>
-              {/* Heartbeat dot */}
-              <circle cx={dotX} cy={dotY} r={4} fill="#8B4513">
+              {/* Heartbeat dot on x-axis */}
+              <circle cx={dotX} cy={PAD.top + CHART_H} r={4} fill="#8B4513">
                 <animate
                   attributeName="r"
                   values="4;5.6;4"

--- a/src/components/airdrop/MilestoneTrack.tsx
+++ b/src/components/airdrop/MilestoneTrack.tsx
@@ -14,11 +14,90 @@ interface StatusData {
   };
 }
 
-const TIERS = [
-  { key: "bronze" as const, label: "Bronze", color: "text-[#cd7f32]" },
-  { key: "silver" as const, label: "Silver", color: "text-[#c0c0c0]" },
-  { key: "gold" as const, label: "Gold", color: "text-[#ffd700]" },
-];
+/* ─── Chart milestones (presentation layer) ─── */
+
+const MAX_SUPPLY = 1_000_000;
+const CHART_MILESTONES = [
+  { label: "Bronze", emoji: "\uD83E\uDD49", fdv: 1_000_000, poolPct: 10, poolUsd: 5_000 },
+  { label: "Silver", emoji: "\uD83E\uDD48", fdv: 10_000_000, poolPct: 30, poolUsd: 150_000 },
+  { label: "Gold", emoji: "\uD83E\uDD47", fdv: 50_000_000, poolPct: 50, poolUsd: 1_250_000 },
+  { label: "Diamond", emoji: "\uD83D\uDC8E", fdv: 100_000_000, poolPct: 100, poolUsd: 5_000_000 },
+] as const;
+
+/* ─── SVG layout constants ─── */
+
+const SVG_W = 600;
+const SVG_H = 300;
+const PAD = { top: 40, right: 20, bottom: 50, left: 65 };
+const CHART_W = SVG_W - PAD.left - PAD.right;
+const CHART_H = SVG_H - PAD.top - PAD.bottom;
+
+// Log scale helpers — FDV axis from 10k to 200M
+const LOG_MIN = Math.log10(10_000);      // 4
+const LOG_MAX = Math.log10(200_000_000); // ~8.3
+
+function fdvToX(fdv: number): number {
+  if (fdv <= 0) return PAD.left;
+  const logVal = Math.log10(Math.max(fdv, 10_000));
+  const t = (logVal - LOG_MIN) / (LOG_MAX - LOG_MIN);
+  return PAD.left + t * CHART_W;
+}
+
+// Y axis: pool USD value (linear, 0 to 5.5M)
+const Y_MAX = 5_500_000;
+
+function usdToY(usd: number): number {
+  const t = usd / Y_MAX;
+  return PAD.top + CHART_H * (1 - t);
+}
+
+/* ─── Y-axis tick values ─── */
+const Y_TICKS = [0, 1_000_000, 2_500_000, 5_000_000];
+
+/* ─── Step area path builder ─── */
+
+function buildAreaPath(): string {
+  const baseline = usdToY(0);
+  // Start at origin
+  let path = `M ${fdvToX(10_000)} ${baseline}`;
+  // Step up at each milestone
+  let prevY = baseline;
+  for (const m of CHART_MILESTONES) {
+    const x = fdvToX(m.fdv);
+    const y = usdToY(m.poolUsd);
+    // Horizontal to milestone x at previous level
+    path += ` L ${x} ${prevY}`;
+    // Step up to new level
+    path += ` L ${x} ${y}`;
+    prevY = y;
+  }
+  // Extend to right edge at last level
+  path += ` L ${PAD.left + CHART_W} ${prevY}`;
+  // Close back down to baseline
+  path += ` L ${PAD.left + CHART_W} ${baseline}`;
+  path += " Z";
+  return path;
+}
+
+function buildLinePath(): string {
+  let path = "";
+  let prevY = usdToY(0);
+  for (let i = 0; i < CHART_MILESTONES.length; i++) {
+    const m = CHART_MILESTONES[i];
+    const x = fdvToX(m.fdv);
+    const y = usdToY(m.poolUsd);
+    if (i === 0) {
+      path = `M ${fdvToX(10_000)} ${prevY} L ${x} ${prevY} L ${x} ${y}`;
+    } else {
+      path += ` L ${x} ${prevY} L ${x} ${y}`;
+    }
+    prevY = y;
+  }
+  path += ` L ${PAD.left + CHART_W} ${prevY}`;
+  return path;
+}
+
+/* ─── Component ─── */
 
 export function MilestoneTrack() {
   const { data, isLoading } = useQuery<StatusData>({
@@ -39,94 +118,272 @@ export function MilestoneTrack() {
     );
   }
 
-  // Progress across all three tiers (0–100 mapped to full track)
-  const goldMcap = data.milestones.gold.mcap;
-  const overallProgress = Math.min(100, (data.currentMcap / goldMcap) * 100);
+  // FDV = price * max supply
+  const currentFdv =
+    data.latestPriceUsd != null && data.latestPriceUsd > 0
+      ? data.latestPriceUsd * MAX_SUPPLY
+      : 0;
+
+  // Determine current zone
+  const currentZone = CHART_MILESTONES.reduce(
+    (zone, m, i) => (currentFdv >= m.fdv ? i + 1 : zone),
+    0,
+  );
+  const currentZoneLabel =
+    currentZone === 0
+      ? "Pre-Bronze"
+      : CHART_MILESTONES[currentZone - 1].label;
+
+  // Current pool value based on FDV position
+  const currentPoolUsd =
+    currentZone > 0 ? CHART_MILESTONES[currentZone - 1].poolUsd : 0;
+
+  const dotX = fdvToX(Math.max(currentFdv, 10_000));
+  const dotY = usdToY(currentPoolUsd);
+
+  const areaPath = buildAreaPath();
+  const linePath = buildLinePath();
 
   return (
     <div className="border-border rounded border p-4">
-      <h3 className="text-foreground text-sm font-bold mb-4">Milestone Progress</h3>
+      <h3 className="text-foreground text-sm font-bold mb-1">
+        FDV Milestone Chart
+      </h3>
+      <p className="text-muted text-[10px] mb-3">
+        Pool unlock curve across FDV milestones &middot; FDV = PLOT price &times; {MAX_SUPPLY.toLocaleString()} max supply
+      </p>
 
-      {/* Track bar */}
-      <div className="relative mb-6">
-        <div className="bg-surface border-border h-3 rounded-full border overflow-hidden">
-          <div
-            className="bg-accent h-full rounded-full transition-all"
-            style={{ width: `${overallProgress}%` }}
-          />
-        </div>
-
-        {/* Current mcap marker */}
-        <div
-          className="absolute top-0 -translate-x-1/2"
-          style={{ left: `${overallProgress}%` }}
+      <div className="w-full overflow-x-auto -mx-1 px-1">
+        <svg
+          viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+          className="w-full h-auto"
+          style={{ minWidth: 320 }}
         >
-          <div className="bg-foreground w-1.5 h-3 rounded-sm" />
-          <div className="text-foreground text-[8px] font-bold mt-0.5 whitespace-nowrap -translate-x-1/4">
-            {formatUsdValue(data.currentMcap)}
-          </div>
-        </div>
+          <defs>
+            <linearGradient id="area-grad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#8B4513" stopOpacity="0.35" />
+              <stop offset="100%" stopColor="#8B4513" stopOpacity="0.05" />
+            </linearGradient>
+          </defs>
 
-        {/* Milestone markers */}
-        {TIERS.map((tier) => {
-          const milestone = data.milestones[tier.key];
-          const position = (milestone.mcap / goldMcap) * 100;
-          return (
-            <div
-              key={tier.key}
-              className="absolute top-0 -translate-x-1/2"
-              style={{ left: `${position}%` }}
-            >
-              <div
-                className={`w-3 h-3 rounded-full border-2 ${
-                  milestone.reached
-                    ? "bg-accent border-accent"
-                    : "bg-surface border-border"
-                }`}
+          {/* Y-axis grid lines */}
+          {Y_TICKS.map((val) => (
+            <g key={val}>
+              <line
+                x1={PAD.left}
+                y1={usdToY(val)}
+                x2={PAD.left + CHART_W}
+                y2={usdToY(val)}
+                stroke="#D4C5B0"
+                strokeWidth={0.5}
+                strokeDasharray={val === 0 ? "0" : "3,3"}
               />
-            </div>
-          );
-        })}
-      </div>
+              <text
+                x={PAD.left - 6}
+                y={usdToY(val) + 3}
+                textAnchor="end"
+                fill="#8B7355"
+                fontSize={9}
+                fontFamily="Inter, system-ui, sans-serif"
+              >
+                {val === 0 ? "$0" : `$${(val / 1_000_000).toFixed(1)}M`}
+              </text>
+            </g>
+          ))}
 
-      {/* Tier details */}
-      <div className="grid grid-cols-3 gap-2">
-        {TIERS.map((tier) => {
-          const milestone = data.milestones[tier.key];
-          const poolValue = data.poolAmount * (milestone.pct / 100);
-          return (
-            <div
-              key={tier.key}
-              className={`border-border rounded border px-2 py-2 text-center ${
-                milestone.reached ? "border-accent" : ""
-              }`}
+          {/* Filled area */}
+          <path d={areaPath} fill="url(#area-grad)" />
+
+          {/* Step line */}
+          <path
+            d={linePath}
+            fill="none"
+            stroke="#8B4513"
+            strokeWidth={2}
+          />
+
+          {/* Vertical zone dividers + annotations */}
+          {CHART_MILESTONES.map((m) => {
+            const x = fdvToX(m.fdv);
+            const y = usdToY(m.poolUsd);
+            return (
+              <g key={m.label}>
+                {/* Vertical divider */}
+                <line
+                  x1={x}
+                  y1={PAD.top}
+                  x2={x}
+                  y2={PAD.top + CHART_H}
+                  stroke="#D4C5B0"
+                  strokeWidth={0.5}
+                  strokeDasharray="4,3"
+                />
+                {/* Annotation at top of zone */}
+                <text
+                  x={x}
+                  y={PAD.top - 6}
+                  textAnchor="middle"
+                  fill="#2C1810"
+                  fontSize={10}
+                  fontFamily="Inter, system-ui, sans-serif"
+                  fontWeight="600"
+                >
+                  {m.emoji} {m.label}
+                </text>
+                <text
+                  x={x}
+                  y={PAD.top - 18}
+                  textAnchor="middle"
+                  fill="#8B7355"
+                  fontSize={8}
+                  fontFamily="Inter, system-ui, sans-serif"
+                >
+                  {m.poolPct}% (${m.poolUsd >= 1_000_000 ? `${(m.poolUsd / 1_000_000).toFixed(1)}M` : `${(m.poolUsd / 1_000).toFixed(0)}K`})
+                </text>
+                {/* Dot at step corner */}
+                <circle
+                  cx={x}
+                  cy={y}
+                  r={3}
+                  fill="#8B4513"
+                  stroke="#F0EBE1"
+                  strokeWidth={1.5}
+                />
+              </g>
+            );
+          })}
+
+          {/* X-axis labels */}
+          {CHART_MILESTONES.map((m) => (
+            <text
+              key={m.label}
+              x={fdvToX(m.fdv)}
+              y={PAD.top + CHART_H + 14}
+              textAnchor="middle"
+              fill="#8B7355"
+              fontSize={9}
+              fontFamily="Inter, system-ui, sans-serif"
             >
-              <div className={`text-xs font-bold ${tier.color}`}>
-                {tier.label}
-                {milestone.reached && " \u2713"}
-              </div>
-              <div className="text-foreground text-sm font-bold mt-1">
-                {formatUsdValue(milestone.mcap)}
-              </div>
-              <div className="text-muted text-[9px]">MCap target</div>
-              <div className="text-foreground text-xs font-medium mt-1">
-                {milestone.pct}% &middot; {poolValue.toLocaleString()} PLOT
-              </div>
-              {data.latestPriceUsd != null && data.latestPriceUsd > 0 && (
-                <div className="text-accent text-[10px] font-medium mt-0.5">
-                  Pool: {formatUsdValue(poolValue * data.latestPriceUsd)}
-                </div>
-              )}
-            </div>
-          );
-        })}
+              ${m.fdv >= 1_000_000 ? `${m.fdv / 1_000_000}M` : `${m.fdv / 1_000}K`}
+            </text>
+          ))}
+
+          {/* X-axis label */}
+          <text
+            x={PAD.left + CHART_W / 2}
+            y={SVG_H - 4}
+            textAnchor="middle"
+            fill="#8B7355"
+            fontSize={10}
+            fontFamily="Inter, system-ui, sans-serif"
+          >
+            FDV &rarr;
+          </text>
+
+          {/* Y-axis label */}
+          <text
+            x={12}
+            y={PAD.top + CHART_H / 2}
+            textAnchor="middle"
+            fill="#8B7355"
+            fontSize={10}
+            fontFamily="Inter, system-ui, sans-serif"
+            transform={`rotate(-90, 12, ${PAD.top + CHART_H / 2})`}
+          >
+            Pool Value
+          </text>
+
+          {/* Current FDV indicator */}
+          {currentFdv > 0 && (
+            <g>
+              {/* Vertical dashed line from dot to x-axis */}
+              <line
+                x1={dotX}
+                y1={dotY}
+                x2={dotX}
+                y2={PAD.top + CHART_H}
+                stroke="#8B4513"
+                strokeWidth={1}
+                strokeDasharray="3,3"
+                opacity={0.6}
+              />
+              {/* Pulse ring */}
+              <circle
+                cx={dotX}
+                cy={dotY}
+                r={6}
+                fill="none"
+                stroke="#8B4513"
+                strokeWidth={1.5}
+                opacity={0.4}
+              >
+                <animate
+                  attributeName="r"
+                  values="6;12;6"
+                  dur="1.5s"
+                  repeatCount="indefinite"
+                />
+                <animate
+                  attributeName="opacity"
+                  values="0.4;0;0.4"
+                  dur="1.5s"
+                  repeatCount="indefinite"
+                />
+              </circle>
+              {/* Heartbeat dot */}
+              <circle cx={dotX} cy={dotY} r={4} fill="#8B4513">
+                <animate
+                  attributeName="r"
+                  values="4;5.6;4"
+                  dur="1.5s"
+                  repeatCount="indefinite"
+                />
+                <animate
+                  attributeName="opacity"
+                  values="1;0.7;1"
+                  dur="1.5s"
+                  repeatCount="indefinite"
+                />
+              </circle>
+              {/* FDV label below axis */}
+              <text
+                x={dotX}
+                y={PAD.top + CHART_H + 28}
+                textAnchor="middle"
+                fill="#8B4513"
+                fontSize={9}
+                fontWeight="bold"
+                fontFamily="Inter, system-ui, sans-serif"
+              >
+                {formatUsdValue(currentFdv)}
+              </text>
+              <text
+                x={dotX}
+                y={PAD.top + CHART_H + 39}
+                textAnchor="middle"
+                fill="#8B4513"
+                fontSize={7}
+                fontFamily="Inter, system-ui, sans-serif"
+              >
+                Current
+              </text>
+            </g>
+          )}
+        </svg>
       </div>
 
-      {/* Current position label */}
-      <div className="text-center mt-3">
-        <span className="text-muted text-[10px]">
-          Current: {formatUsdValue(data.currentMcap)} / {formatUsdValue(goldMcap)}
-        </span>
+      {/* Current position summary */}
+      <div className="text-center mt-3 space-y-0.5">
+        <div className="text-foreground text-xs font-medium">
+          Current FDV: {currentFdv > 0 ? formatUsdValue(currentFdv) : "\u2014"}
+          <span className="text-muted"> &middot; Zone: {currentZoneLabel}</span>
+        </div>
+        {currentFdv > 0 && currentZone < CHART_MILESTONES.length && (
+          <div className="text-muted text-[10px]">
+            Next: {CHART_MILESTONES[currentZone].emoji} {CHART_MILESTONES[currentZone].label} at{" "}
+            {formatUsdValue(CHART_MILESTONES[currentZone].fdv)} FDV
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Fixes #924

- **CampaignHero**: Bold "PLOT Big or Nothing Airdrop" title with "50,000 PLOT locked. Earn or burn." tagline and weeks/days countdown timer
- **MilestoneTrack**: Replaced linear progress bar with SVG area/step chart showing FDV milestone unlock curve (Bronze → Silver → Gold → Diamond) inspired by ultrasound.money
- Heartbeat-animated pulsing dot shows current FDV position with vertical dashed line
- Logarithmic x-axis ($10K–$200M), vertical zone dividers, milestone annotations with emoji + pool % + USD value
- PlotLink brown/cream palette throughout, responsive on mobile

> **Note:** The chart uses 4-tier presentation data (including Diamond at $100M FDV / 100%) per the issue spec. The backend config still uses the 3-tier system — a config update may be needed as a follow-up if Diamond is to be enforced in distribution logic.

## Test plan

- [ ] Verify hero displays "PLOT Big or Nothing Airdrop" with tagline and countdown
- [ ] Verify area chart renders with 4 milestone zones and vertical dividers
- [ ] Verify current FDV dot pulses with heartbeat animation
- [ ] Verify chart is readable on mobile viewports (min-width 320px)
- [ ] Verify FDV label (not "Market Cap") appears throughout
- [ ] Verify stats row (participants, PL earned, price) still renders
- [ ] Verify lockup proof link still appears when lockerId is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)