### PR TITLE
[#925] Redesign /airdrop page with 2-column grid layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/airdrop/page.tsx
+++ b/src/app/airdrop/page.tsx
@@ -16,12 +16,24 @@ export default function AirdropPage() {
   const campaignEnded = new Date() > AIRDROP_CONFIG.CAMPAIGN_END;
 
   return (
-    <main className="mx-auto max-w-xl px-4 py-8 space-y-6">
+    <main className="mx-auto max-w-5xl px-6 py-8 pb-24 lg:pb-8">
+      {/* Hero spans full width */}
       <CampaignHero />
-      {campaignEnded ? <ClaimPanel /> : <UserPoints />}
-      <Leaderboard />
-      <WeeklySnapshots />
-      <MilestoneTrack />
+
+      {/* 2-column grid below hero */}
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]">
+        {/* Left column: user-specific */}
+        <div className="min-w-0 space-y-6">
+          {campaignEnded ? <ClaimPanel /> : <UserPoints />}
+        </div>
+
+        {/* Right column: global sections */}
+        <div className="space-y-6">
+          <MilestoneTrack />
+          <Leaderboard />
+          <WeeklySnapshots />
+        </div>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #925

- Restructured `/airdrop` page to use 2-column grid matching the story detail page (`/story/[id]`) layout
- **Left column (1fr):** UserPoints (or ClaimPanel post-campaign) — points breakdown, streak, referral
- **Right column (320px):** MilestoneTrack, Leaderboard, WeeklySnapshots
- Hero section spans full width above the grid
- Container widened from `max-w-xl` to `max-w-5xl` to accommodate the grid
- Responsive: single column on mobile, 2-col on `lg+`

## Test plan

- [ ] Verify 2-column layout renders on desktop (lg+ breakpoint)
- [ ] Verify left column contains user points/streak/referral sections
- [ ] Verify right column contains milestone chart, leaderboard, weekly snapshots
- [ ] Verify columns stack vertically on mobile viewport
- [ ] Verify hero section spans full width above the grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)