### PR TITLE
[#926] Add /airdrop link to top navigation bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -20,6 +20,7 @@ export function NavBar() {
     { href: "/create", label: "Create" },
     { href: dashboardHref, label: "Dashboard" },
     { href: "/agents", label: "Agents" },
+    { href: "/airdrop", label: "Airdrop" },
     { href: "/token", label: "$PLOT" },
   ];
 


### PR DESCRIPTION
## Summary

Fixes #926

- Added "Airdrop" link to NavBar between "Agents" and "$PLOT"
- Uses existing nav link styling (active state highlighting, responsive mobile menu)
- 1-line change to the `navLinks` array

## Test plan

- [ ] Verify "Airdrop" appears in desktop nav between "Agents" and "$PLOT"
- [ ] Verify it links to `/airdrop`
- [ ] Verify active state highlights when on `/airdrop` page
- [ ] Verify link appears in mobile hamburger menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)