### PR TITLE
[#927] Update milestone tiers: add Diamond, adjust percentages, use emojis

### DIFF
--- a/lib/airdrop/config.ts
+++ b/lib/airdrop/config.ts
@@ -18,6 +18,7 @@ export interface AirdropConfig {
     readonly BRONZE: Milestone;
     readonly SILVER: Milestone;
     readonly GOLD: Milestone;
+    readonly DIAMOND: Milestone;
   };
   readonly LOCKER_ID: string | null;
   readonly POINTS: {
@@ -58,7 +59,8 @@ const TEST_CONFIG: AirdropConfig = {
   MILESTONES: {
     BRONZE: { mcap: 7_000, pct: 10 },
     SILVER: { mcap: 10_000, pct: 30 },
-    GOLD: { mcap: 50_000, pct: 100 },
+    GOLD: { mcap: 35_000, pct: 50 },
+    DIAMOND: { mcap: 50_000, pct: 100 },
   },
   LOCKER_ID: null,
   POINTS,
@@ -73,7 +75,8 @@ const PROD_CONFIG: AirdropConfig = {
   MILESTONES: {
     BRONZE: { mcap: 1_000_000, pct: 10 },
     SILVER: { mcap: 10_000_000, pct: 30 },
-    GOLD: { mcap: 70_000_000, pct: 100 },
+    GOLD: { mcap: 50_000_000, pct: 50 },
+    DIAMOND: { mcap: 100_000_000, pct: 100 },
   },
   LOCKER_ID: null,
   POINTS,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/scripts/airdrop-finalize.ts
+++ b/scripts/airdrop-finalize.ts
@@ -66,14 +66,17 @@ async function computeTwap(): Promise<number> {
 function determineMilestone(twapMcap: number): { tier: string; pct: number } {
   const { MILESTONES } = AIRDROP_CONFIG;
 
+  if (twapMcap >= MILESTONES.DIAMOND.mcap) {
+    return { tier: "\uD83D\uDC8E Diamond", pct: MILESTONES.DIAMOND.pct };
+  }
   if (twapMcap >= MILESTONES.GOLD.mcap) {
-    return { tier: "Gold", pct: MILESTONES.GOLD.pct };
+    return { tier: "\uD83E\uDD47 Gold", pct: MILESTONES.GOLD.pct };
   }
   if (twapMcap >= MILESTONES.SILVER.mcap) {
-    return { tier: "Silver", pct: MILESTONES.SILVER.pct };
+    return { tier: "\uD83E\uDD48 Silver", pct: MILESTONES.SILVER.pct };
   }
   if (twapMcap >= MILESTONES.BRONZE.mcap) {
-    return { tier: "Bronze", pct: MILESTONES.BRONZE.pct };
+    return { tier: "\uD83E\uDD49 Bronze", pct: MILESTONES.BRONZE.pct };
   }
   return { tier: "None", pct: 0 };
 }

--- a/src/app/api/airdrop/points/route.ts
+++ b/src/app/api/airdrop/points/route.ts
@@ -82,8 +82,9 @@ export async function GET(req: NextRequest) {
         bronze: Math.round((sharePercent / 100) * AIRDROP_CONFIG.POOL_AMOUNT * (AIRDROP_CONFIG.MILESTONES.BRONZE.pct / 100)),
         silver: Math.round((sharePercent / 100) * AIRDROP_CONFIG.POOL_AMOUNT * (AIRDROP_CONFIG.MILESTONES.SILVER.pct / 100)),
         gold: Math.round((sharePercent / 100) * AIRDROP_CONFIG.POOL_AMOUNT * (AIRDROP_CONFIG.MILESTONES.GOLD.pct / 100)),
+        diamond: Math.round((sharePercent / 100) * AIRDROP_CONFIG.POOL_AMOUNT * (AIRDROP_CONFIG.MILESTONES.DIAMOND.pct / 100)),
       }
-    : { bronze: 0, silver: 0, gold: 0 };
+    : { bronze: 0, silver: 0, gold: 0, diamond: 0 };
 
   return NextResponse.json({
     address,

--- a/src/app/api/airdrop/results/route.ts
+++ b/src/app/api/airdrop/results/route.ts
@@ -38,12 +38,14 @@ export async function GET() {
   // Determine milestone from distributed percentage
   const distributedPct = (distributedPlot / poolAmount) * 100;
   let milestone: string;
-  if (distributedPct >= AIRDROP_CONFIG.MILESTONES.GOLD.pct - 0.1) {
-    milestone = "Gold";
+  if (distributedPct >= AIRDROP_CONFIG.MILESTONES.DIAMOND.pct - 0.1) {
+    milestone = "\uD83D\uDC8E Diamond";
+  } else if (distributedPct >= AIRDROP_CONFIG.MILESTONES.GOLD.pct - 0.1) {
+    milestone = "\uD83E\uDD47 Gold";
   } else if (distributedPct >= AIRDROP_CONFIG.MILESTONES.SILVER.pct - 0.1) {
-    milestone = "Silver";
+    milestone = "\uD83E\uDD48 Silver";
   } else if (distributedPct >= AIRDROP_CONFIG.MILESTONES.BRONZE.pct - 0.1) {
-    milestone = "Bronze";
+    milestone = "\uD83E\uDD49 Bronze";
   } else {
     milestone = "None";
   }

--- a/src/app/api/airdrop/status/route.ts
+++ b/src/app/api/airdrop/status/route.ts
@@ -59,6 +59,11 @@ export async function GET() {
       pct: AIRDROP_CONFIG.MILESTONES.GOLD.pct,
       reached: currentMcap >= AIRDROP_CONFIG.MILESTONES.GOLD.mcap,
     },
+    diamond: {
+      mcap: AIRDROP_CONFIG.MILESTONES.DIAMOND.mcap,
+      pct: AIRDROP_CONFIG.MILESTONES.DIAMOND.pct,
+      reached: currentMcap >= AIRDROP_CONFIG.MILESTONES.DIAMOND.mcap,
+    },
   };
 
   return NextResponse.json({

--- a/src/components/airdrop/CampaignHero.tsx
+++ b/src/components/airdrop/CampaignHero.tsx
@@ -15,6 +15,7 @@ interface StatusData {
     bronze: { mcap: number; pct: number; reached: boolean };
     silver: { mcap: number; pct: number; reached: boolean };
     gold: { mcap: number; pct: number; reached: boolean };
+    diamond: { mcap: number; pct: number; reached: boolean };
   };
   totalPointsEarned: number;
   totalParticipants: number;

--- a/src/components/airdrop/MilestoneTrack.tsx
+++ b/src/components/airdrop/MilestoneTrack.tsx
@@ -12,6 +12,7 @@ interface StatusData {
     bronze: { mcap: number; pct: number; reached: boolean };
     silver: { mcap: number; pct: number; reached: boolean };
     gold: { mcap: number; pct: number; reached: boolean };
+    diamond: { mcap: number; pct: number; reached: boolean };
   };
 }
 

--- a/src/components/airdrop/UserPoints.tsx
+++ b/src/components/airdrop/UserPoints.tsx
@@ -25,7 +25,7 @@ interface PointsData {
     referredBy: string | null;
     referredUsersCount: number;
   };
-  estimatedAirdrop: { bronze: number; silver: number; gold: number };
+  estimatedAirdrop: { bronze: number; silver: number; gold: number; diamond: number };
 }
 
 interface StatusData {
@@ -109,12 +109,17 @@ function UserPointsInner({ address }: { address: string }) {
 
         {/* Estimated airdrop */}
         <div className="text-muted text-[10px] mt-2 space-y-0.5">
-          {(["bronze", "silver", "gold"] as const).map((tier) => {
-            const amount = data.estimatedAirdrop[tier];
+          {([
+            { key: "bronze", label: "\uD83E\uDD49 Bronze" },
+            { key: "silver", label: "\uD83E\uDD48 Silver" },
+            { key: "gold", label: "\uD83E\uDD47 Gold" },
+            { key: "diamond", label: "\uD83D\uDC8E Diamond" },
+          ] as const).map(({ key, label }) => {
+            const amount = data.estimatedAirdrop[key];
             const usdVal = price && amount > 0 ? formatUsdValue(amount * price) : null;
             return (
-              <div key={tier}>
-                Est. if {tier.charAt(0).toUpperCase() + tier.slice(1)}:{" "}
+              <div key={key}>
+                Est. if {label}:{" "}
                 <span className="text-foreground font-medium">
                   {amount.toLocaleString()} PLOT
                 </span>


### PR DESCRIPTION
## Summary

Fixes #927

Full-stack update from 3 tiers to 4 tiers with emoji indicators:

| Tier | FDV Target | Pool % | Emoji |
|------|-----------|--------|-------|
| Bronze | $1M | 10% | 🥉 |
| Silver | $10M | 30% | 🥈 |
| Gold | $50M | 50% | 🥇 |
| Diamond | $100M | 100% | 💎 |

**Files changed (9):**
- `lib/airdrop/config.ts` — Add DIAMOND, change GOLD from $70M/100% to $50M/50%
- `src/app/api/airdrop/status/route.ts` — Return 4 milestones
- `src/app/api/airdrop/points/route.ts` — Add diamond to estimatedAirdrop
- `src/app/api/airdrop/results/route.ts` — Add Diamond check + emoji prefixes
- `scripts/airdrop-finalize.ts` — 4-tier determination logic
- `src/components/airdrop/UserPoints.tsx` — 4-tier estimates with emojis
- `src/components/airdrop/CampaignHero.tsx` — StatusData interface update
- `src/components/airdrop/MilestoneTrack.tsx` — StatusData interface update

## Test plan

- [ ] Verify config exports 4 tiers with correct FDV/pct values
- [ ] Verify `/api/airdrop/status` returns 4 milestones
- [ ] Verify `/api/airdrop/points` returns diamond in estimatedAirdrop
- [ ] Verify UserPoints displays 4 tier estimates with emoji labels
- [ ] Verify MilestoneTrack chart still renders correctly (already had 4 presentation tiers)
- [ ] Verify finalize script handles Diamond tier (code review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)