### PR TITLE
[#929] Rename campaign to 'PLOT Big or Nothing Airdrop'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/airdrop/page.tsx
+++ b/src/app/airdrop/page.tsx
@@ -8,7 +8,7 @@ import { MilestoneTrack } from "../../components/airdrop/MilestoneTrack";
 import { AIRDROP_CONFIG } from "../../../lib/airdrop/config";
 
 export const metadata: Metadata = {
-  title: "PLOT 10x Airdrop | PlotLink",
+  title: "PLOT Big or Nothing Airdrop | PlotLink",
   description: "Earn PL points through trading, writing, and referrals.",
 };
 

--- a/src/components/airdrop/UserPoints.tsx
+++ b/src/components/airdrop/UserPoints.tsx
@@ -195,7 +195,7 @@ function ReferralSection({
 
   const handleShare = () => {
     if (!referralLink) return;
-    const text = `Earn PL points in the PLOT 10x Airdrop! ${referralLink}`;
+    const text = `Earn PL points in the PLOT Big or Nothing Airdrop! ${referralLink}`;
     window.open(
       `https://x.com/intent/tweet?text=${encodeURIComponent(text)}`,
       "_blank",


### PR DESCRIPTION
## Summary
- Rename all remaining "10x Airdrop" references to "Big or Nothing Airdrop"
- Updated page metadata title in `src/app/airdrop/page.tsx`
- Updated share tweet text in `src/components/airdrop/UserPoints.tsx`
- Hero already used correct name; `lib/airdrop/config.ts` had no campaign name reference
- Patch version bump → 0.1.36

Fixes #929

## Test plan
- [ ] Visit `/airdrop` — page title shows "PLOT Big or Nothing Airdrop | PlotLink"
- [ ] Click share button — tweet text says "PLOT Big or Nothing Airdrop"
- [ ] Hero still displays "PLOT Big or Nothing Airdrop"

🤖 Generated with [Claude Code](https://claude.com/claude-code)