### PR TITLE
[#936] Redesign airdrop hero + chart as combined section

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/airdrop/page.tsx
+++ b/src/app/airdrop/page.tsx
@@ -4,7 +4,6 @@ import { UserPoints } from "../../components/airdrop/UserPoints";
 import { ClaimPanel } from "../../components/airdrop/ClaimPanel";
 import { Leaderboard } from "../../components/airdrop/Leaderboard";
 import { WeeklySnapshots } from "../../components/airdrop/WeeklySnapshots";
-import { MilestoneTrack } from "../../components/airdrop/MilestoneTrack";
 import { AIRDROP_CONFIG } from "../../../lib/airdrop/config";
 
 export const metadata: Metadata = {
@@ -29,7 +28,6 @@ export default function AirdropPage() {
 
         {/* Right column: global sections */}
         <div className="space-y-6">
-          <MilestoneTrack />
           <Leaderboard />
           <WeeklySnapshots />
         </div>

--- a/src/app/api/airdrop/daily-prices/route.ts
+++ b/src/app/api/airdrop/daily-prices/route.ts
@@ -1,0 +1,34 @@
+/**
+ * Daily FDV history for the campaign timeline chart (#936)
+ * GET /api/airdrop/daily-prices — no auth required
+ *
+ * Returns array of { date, fdv } ordered by date ascending.
+ */
+
+import { NextResponse } from "next/server";
+import { createServerClient } from "../../../../../lib/supabase";
+
+export async function GET() {
+  const supabase = createServerClient();
+  if (!supabase) {
+    return NextResponse.json({ error: "Supabase not configured" }, { status: 500 });
+  }
+
+  const { data, error } = await supabase
+    .from("pl_daily_prices")
+    .select("recorded_at, mcap_usd")
+    .order("recorded_at", { ascending: true });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const points = (data ?? []).map((row) => ({
+    date: row.recorded_at,
+    fdv: Number(row.mcap_usd),
+  }));
+
+  return NextResponse.json(points, {
+    headers: { "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60" },
+  });
+}

--- a/src/components/airdrop/CampaignHero.tsx
+++ b/src/components/airdrop/CampaignHero.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { formatUsdValue } from "../../../lib/usd-price";
+
+/* ─── Types ─── */
 
 interface StatusData {
   campaignStart: string;
@@ -22,6 +25,32 @@ interface StatusData {
   lockerId: string | null;
 }
 
+interface DailyPrice {
+  date: string;
+  fdv: number;
+}
+
+/* ─── Constants ─── */
+
+const MAX_SUPPLY = 1_000_000;
+
+const TIERS = [
+  { key: "bronze", emoji: "\uD83E\uDD49", label: "Bronze", fdv: 1_000_000, pct: 10 },
+  { key: "silver", emoji: "\uD83E\uDD48", label: "Silver", fdv: 10_000_000, pct: 30 },
+  { key: "gold", emoji: "\uD83E\uDD47", label: "Gold", fdv: 50_000_000, pct: 50 },
+  { key: "diamond", emoji: "\uD83D\uDC8E", label: "Diamond", fdv: 100_000_000, pct: 100 },
+] as const;
+
+/* ─── SVG layout ─── */
+
+const SVG_W = 700;
+const SVG_H = 340;
+const PAD = { top: 30, right: 70, bottom: 40, left: 70 };
+const CW = SVG_W - PAD.left - PAD.right;
+const CH = SVG_H - PAD.top - PAD.bottom;
+
+/* ─── Helpers ─── */
+
 function useAirdropStatus() {
   return useQuery<StatusData>({
     queryKey: ["airdrop-status"],
@@ -35,31 +64,404 @@ function useAirdropStatus() {
   });
 }
 
-function CountdownDisplay({ days }: { days: number }) {
-  const weeks = Math.floor(days / 7);
-  const remainingDays = days % 7;
+function useDailyPrices() {
+  return useQuery<DailyPrice[]>({
+    queryKey: ["airdrop-daily-prices"],
+    queryFn: async () => {
+      const res = await fetch("/api/airdrop/daily-prices");
+      if (!res.ok) throw new Error("Failed to fetch daily prices");
+      return res.json();
+    },
+    staleTime: 300_000,
+  });
+}
+
+/** Pool value at current FDV: highest reached tier pct * pool * price */
+function poolValueAtFdv(fdv: number, poolAmount: number): number {
+  const price = fdv / MAX_SUPPLY;
+  if (fdv >= 100_000_000) return poolAmount * 1.0 * price;
+  if (fdv >= 50_000_000) return poolAmount * 0.5 * price;
+  if (fdv >= 10_000_000) return poolAmount * 0.3 * price;
+  if (fdv >= 1_000_000) return poolAmount * 0.1 * price;
+  return 0;
+}
+
+function currentZoneLabel(fdv: number): string {
+  if (fdv >= 100_000_000) return "Diamond";
+  if (fdv >= 50_000_000) return "Gold";
+  if (fdv >= 10_000_000) return "Silver";
+  if (fdv >= 1_000_000) return "Bronze";
+  return "Pre-Bronze";
+}
+
+function formatCompact(val: number): string {
+  if (val >= 1_000_000) return `$${(val / 1_000_000).toFixed(1)}M`;
+  if (val >= 1_000) return `$${(val / 1_000).toFixed(0)}K`;
+  return `$${val.toFixed(0)}`;
+}
+
+/* ─── Countdown hook ─── */
+
+function useCountdown(endDateStr: string) {
+  const [remaining, setRemaining] = useState({ d: 0, h: 0, m: 0, s: 0 });
+
+  useEffect(() => {
+    const endMs = new Date(endDateStr + "T00:00:00Z").getTime();
+    function update() {
+      const diff = Math.max(0, endMs - Date.now());
+      const totalSec = Math.floor(diff / 1000);
+      setRemaining({
+        d: Math.floor(totalSec / 86400),
+        h: Math.floor((totalSec % 86400) / 3600),
+        m: Math.floor((totalSec % 3600) / 60),
+        s: totalSec % 60,
+      });
+    }
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [endDateStr]);
+
+  return remaining;
+}
+
+/* ─── Pure chart helpers (outside component to avoid unstable refs) ─── */
+
+const DIAMOND_FDV = 100_000_000;
+const FDV_LOG_MIN = Math.log10(100);
+const FDV_LOG_MAX = Math.log10(200_000_000);
+
+function timeToX(ms: number, startMs: number, totalMs: number): number {
+  return PAD.left + ((ms - startMs) / totalMs) * CW;
+}
+
+function poolToY(usd: number, yLeftMax: number): number {
+  return PAD.top + CH * (1 - usd / yLeftMax);
+}
+
+function fdvToY(fdv: number): number {
+  if (fdv <= 0) return PAD.top + CH;
+  const t = (Math.log10(Math.max(fdv, 100)) - FDV_LOG_MIN) / (FDV_LOG_MAX - FDV_LOG_MIN);
+  return PAD.top + CH * (1 - t);
+}
+
+/* ─── Chart sub-component ─── */
+
+function TimelineChart({
+  campaignStart,
+  campaignEnd,
+  currentFdv,
+  poolAmount,
+}: {
+  campaignStart: string;
+  campaignEnd: string;
+  currentFdv: number;
+  poolAmount: number;
+}) {
+  const { data: dailyPrices } = useDailyPrices();
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  // Refresh current time once per minute (chart doesn't need per-second updates)
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const startMs = new Date(campaignStart + "T00:00:00Z").getTime();
+  const endMs = new Date(campaignEnd + "T00:00:00Z").getTime();
+  const totalMs = endMs - startMs;
+
+  const nowX = timeToX(Math.min(nowMs, endMs), startMs, totalMs);
+
+  const diamondPoolUsd = poolAmount * (DIAMOND_FDV / MAX_SUPPLY);
+  const yLeftMax = diamondPoolUsd * 1.1;
+
+  // Month labels for x-axis
+  const months = useMemo(() => {
+    const result: { label: string; ms: number }[] = [];
+    const d = new Date(campaignStart + "T00:00:00Z");
+    for (let i = 0; i < 7; i++) {
+      const ms = d.getTime();
+      if (ms <= endMs) {
+        result.push({ label: `M${i + 1}`, ms });
+      }
+      d.setUTCMonth(d.getUTCMonth() + 1);
+    }
+    return result;
+  }, [campaignStart, endMs]);
+
+  // Pool value step line from daily price data
+  const poolStepPath = useMemo(() => {
+    if (!dailyPrices?.length) return "";
+    const parts: string[] = [];
+    let lastPoolVal = 0;
+    for (const dp of dailyPrices) {
+      const dpMs = new Date(dp.date + "T00:00:00Z").getTime();
+      if (dpMs < startMs || dpMs > endMs) continue;
+      const x = timeToX(dpMs, startMs, totalMs);
+      const pv = poolValueAtFdv(dp.fdv, poolAmount);
+      if (pv !== lastPoolVal && parts.length > 0) {
+        parts.push(`L ${x.toFixed(1)} ${poolToY(lastPoolVal, yLeftMax).toFixed(1)}`);
+      }
+      parts.push(`${parts.length === 0 ? "M" : "L"} ${x.toFixed(1)} ${poolToY(pv, yLeftMax).toFixed(1)}`);
+      lastPoolVal = pv;
+    }
+    if (parts.length > 0) {
+      parts.push(`L ${nowX.toFixed(1)} ${poolToY(lastPoolVal, yLeftMax).toFixed(1)}`);
+    }
+    return parts.join(" ");
+  }, [dailyPrices, startMs, endMs, totalMs, poolAmount, nowX, yLeftMax]);
+
+  // Pool value area fill
+  const poolAreaPath = useMemo(() => {
+    if (!poolStepPath) return "";
+    const baseline = poolToY(0, yLeftMax);
+    const firstX = dailyPrices?.length
+      ? timeToX(new Date(dailyPrices[0].date + "T00:00:00Z").getTime(), startMs, totalMs)
+      : PAD.left;
+    return `M ${firstX.toFixed(1)} ${baseline.toFixed(1)} ${poolStepPath.replace(/^M/, "L")} L ${nowX.toFixed(1)} ${baseline.toFixed(1)} Z`;
+  }, [poolStepPath, dailyPrices, startMs, totalMs, nowX, yLeftMax]);
+
+  // Actual FDV line
+  const actualFdvPath = useMemo(() => {
+    if (!dailyPrices?.length) return "";
+    const parts: string[] = [];
+    for (const dp of dailyPrices) {
+      const dpMs = new Date(dp.date + "T00:00:00Z").getTime();
+      if (dpMs < startMs || dpMs > endMs) continue;
+      const x = timeToX(dpMs, startMs, totalMs);
+      const y = fdvToY(dp.fdv);
+      parts.push(`${parts.length === 0 ? "M" : "L"} ${x.toFixed(1)} ${y.toFixed(1)}`);
+    }
+    if (parts.length > 0 && currentFdv > 0) {
+      parts.push(`L ${nowX.toFixed(1)} ${fdvToY(currentFdv).toFixed(1)}`);
+    }
+    return parts.join(" ");
+  }, [dailyPrices, startMs, endMs, totalMs, currentFdv, nowX]);
+
+  // Linear projection: current FDV → Diamond at campaign end
+  const projectionPath = useMemo(() => {
+    const fromX = PAD.left;
+    const toX = PAD.left + CW;
+    const fromY = fdvToY(currentFdv > 0 ? currentFdv : 100);
+    const toY = fdvToY(DIAMOND_FDV);
+    return `M ${fromX} ${fromY} L ${toX} ${toY}`;
+  }, [currentFdv]);
+
+  const dotY = fdvToY(currentFdv > 0 ? currentFdv : 100);
+
+  const milestoneLines = TIERS.map((t) => ({
+    ...t,
+    y: fdvToY(t.fdv),
+  }));
+
+  const yLeftTicks = [0, diamondPoolUsd * 0.25, diamondPoolUsd * 0.5, diamondPoolUsd];
+  const yRightTicks = [1_000, 100_000, 1_000_000, 10_000_000, 100_000_000];
 
   return (
-    <div className="flex items-center gap-3 justify-center mt-3">
-      {weeks > 0 && (
-        <div className="text-center">
-          <div className="text-foreground text-2xl font-bold font-mono">{weeks}</div>
-          <div className="text-muted text-[9px] uppercase tracking-wider">weeks</div>
-        </div>
-      )}
-      {weeks > 0 && (
-        <div className="text-muted text-lg">:</div>
-      )}
-      <div className="text-center">
-        <div className="text-foreground text-2xl font-bold font-mono">{weeks > 0 ? remainingDays : days}</div>
-        <div className="text-muted text-[9px] uppercase tracking-wider">days</div>
+    <div className="w-full overflow-x-auto -mx-1 px-1">
+      <svg
+        viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+        className="w-full h-auto"
+        style={{ minWidth: 320 }}
+        role="img"
+        aria-label="6-month timeline chart showing actual FDV, linear projection to Diamond, and airdrop pool value"
+      >
+        <defs>
+          <linearGradient id="pool-area-grad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#8B4513" stopOpacity="0.25" />
+            <stop offset="100%" stopColor="#8B4513" stopOpacity="0.03" />
+          </linearGradient>
+        </defs>
+
+        {/* Grid lines (horizontal at each milestone FDV) */}
+        {milestoneLines.map((m) => (
+          <g key={m.key}>
+            <line
+              x1={PAD.left}
+              y1={m.y}
+              x2={PAD.left + CW}
+              y2={m.y}
+              stroke="#D4C5B0"
+              strokeWidth={0.5}
+              strokeDasharray="4,4"
+            />
+            {/* Right-side label */}
+            <text
+              x={PAD.left + CW + 4}
+              y={m.y + 3}
+              fill="#8B7355"
+              fontSize={8}
+              fontFamily="Inter, system-ui, sans-serif"
+            >
+              {m.emoji} {formatCompact(m.fdv)}
+            </text>
+          </g>
+        ))}
+
+        {/* Y-left axis ticks (pool value) */}
+        {yLeftTicks.map((val) => (
+          <text
+            key={val}
+            x={PAD.left - 6}
+            y={poolToY(val, yLeftMax) + 3}
+            textAnchor="end"
+            fill="#8B7355"
+            fontSize={8}
+            fontFamily="Inter, system-ui, sans-serif"
+          >
+            {formatCompact(val)}
+          </text>
+        ))}
+
+        {/* Y-right axis ticks (FDV) */}
+        {yRightTicks.map((val) => (
+          <text
+            key={val}
+            x={PAD.left + CW + 4}
+            y={fdvToY(val) + 3}
+            fill="#8B7355"
+            fontSize={7}
+            fontFamily="Inter, system-ui, sans-serif"
+            opacity={0.5}
+          >
+            {formatCompact(val)}
+          </text>
+        ))}
+
+        {/* X-axis month labels */}
+        {months.map((m) => (
+          <g key={m.label}>
+            <line
+              x1={timeToX(m.ms, startMs, totalMs)}
+              y1={PAD.top}
+              x2={timeToX(m.ms, startMs, totalMs)}
+              y2={PAD.top + CH}
+              stroke="#D4C5B0"
+              strokeWidth={0.3}
+            />
+            <text
+              x={timeToX(m.ms, startMs, totalMs)}
+              y={PAD.top + CH + 14}
+              textAnchor="middle"
+              fill="#8B7355"
+              fontSize={9}
+              fontFamily="Inter, system-ui, sans-serif"
+            >
+              {m.label}
+            </text>
+          </g>
+        ))}
+
+        {/* Axis labels */}
+        <text
+          x={12}
+          y={PAD.top + CH / 2}
+          textAnchor="middle"
+          fill="#8B7355"
+          fontSize={9}
+          fontFamily="Inter, system-ui, sans-serif"
+          transform={`rotate(-90, 12, ${PAD.top + CH / 2})`}
+        >
+          Pool Value (USD)
+        </text>
+        <text
+          x={SVG_W - 8}
+          y={PAD.top + CH / 2}
+          textAnchor="middle"
+          fill="#8B7355"
+          fontSize={9}
+          fontFamily="Inter, system-ui, sans-serif"
+          transform={`rotate(90, ${SVG_W - 8}, ${PAD.top + CH / 2})`}
+        >
+          FDV (USD)
+        </text>
+
+        {/* 1. Pool value area fill */}
+        {poolAreaPath && (
+          <path d={poolAreaPath} fill="url(#pool-area-grad)" />
+        )}
+
+        {/* 2. Pool value step line */}
+        {poolStepPath && (
+          <path
+            d={poolStepPath}
+            fill="none"
+            stroke="#8B4513"
+            strokeWidth={2}
+            opacity={0.6}
+          />
+        )}
+
+        {/* 3. Linear FDV projection (dashed) */}
+        <path
+          d={projectionPath}
+          fill="none"
+          stroke="#8B7355"
+          strokeWidth={1.5}
+          strokeDasharray="6,4"
+          opacity={0.5}
+        />
+
+        {/* 4. Actual FDV line (solid) */}
+        {actualFdvPath && (
+          <path
+            d={actualFdvPath}
+            fill="none"
+            stroke="#2C1810"
+            strokeWidth={2}
+          />
+        )}
+
+        {/* Heartbeat dot on current FDV position */}
+        {currentFdv > 0 && (
+          <g>
+            {/* Pulse ring */}
+            <circle cx={nowX} cy={dotY} r={6} fill="none" stroke="#8B4513" strokeWidth={1.5} opacity={0.4}>
+              <animate attributeName="r" values="6;12;6" dur="1.5s" repeatCount="indefinite" />
+              <animate attributeName="opacity" values="0.4;0;0.4" dur="1.5s" repeatCount="indefinite" />
+            </circle>
+            {/* Solid dot */}
+            <circle cx={nowX} cy={dotY} r={4} fill="#8B4513">
+              <animate attributeName="r" values="4;5.6;4" dur="1.5s" repeatCount="indefinite" />
+              <animate attributeName="opacity" values="1;0.7;1" dur="1.5s" repeatCount="indefinite" />
+            </circle>
+          </g>
+        )}
+
+        {/* Chart border */}
+        <rect
+          x={PAD.left}
+          y={PAD.top}
+          width={CW}
+          height={CH}
+          fill="none"
+          stroke="#D4C5B0"
+          strokeWidth={0.5}
+        />
+      </svg>
+
+      {/* Legend */}
+      <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 mt-2 text-[10px]">
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-4 h-0.5 bg-[#2C1810]" /> Actual FDV
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-4 h-0.5 border-t border-dashed border-[#8B7355]" /> Linear projection
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-4 h-0.5 bg-[#8B4513] opacity-60" /> Pool value
+        </span>
       </div>
     </div>
   );
 }
 
+/* ─── Main component ─── */
+
 export function CampaignHero() {
   const { data, isLoading } = useAirdropStatus();
+  const countdown = useCountdown(data?.campaignEnd ?? "2027-01-01");
 
   if (isLoading || !data) {
     return (
@@ -69,33 +471,57 @@ export function CampaignHero() {
     );
   }
 
+  const pad2 = (n: number) => String(n).padStart(2, "0");
+
   return (
-    <div className="border-border rounded border p-5 space-y-4">
-      {/* Title + Tagline */}
-      <div className="text-center">
+    <div className="border-border rounded border p-5 space-y-5">
+      {/* Title + Explanation */}
+      <div className="text-center space-y-2">
         <h2 className="text-foreground text-xl font-bold leading-tight">
           PLOT Big or Nothing Airdrop
         </h2>
-        <p className="text-accent text-sm font-medium mt-1">
-          {data.poolAmount.toLocaleString()} PLOT locked. Earn or burn.
+        <p className="text-muted text-xs leading-relaxed max-w-lg mx-auto">
+          {data.poolAmount.toLocaleString()} PLOT (5% of max supply) locked in a time-locked contract.
+          If PLOT FDV reaches milestone targets within 6 months, the pool is distributed to point holders.
+          If not, it&apos;s burned forever.
         </p>
+
+        {/* Lock-up proof */}
+        {data.lockerId ? (
+          <a
+            href={`https://mint.club/locker/${data.lockerId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent text-xs hover:underline inline-flex items-center gap-1"
+          >
+            <span>&#x1F512;</span> View lock-up proof on Mint Club
+          </a>
+        ) : (
+          <span className="text-muted text-xs inline-flex items-center gap-1">
+            <span>&#x1F512;</span> Lock-up proof: pending
+          </span>
+        )}
       </div>
 
-      {/* Countdown */}
+      {/* Live Countdown */}
       {data.timeRemainingDays > 0 && (
-        <div>
-          <CountdownDisplay days={data.timeRemainingDays} />
-          <div className="mt-2">
-            <div className="bg-surface border-border h-1.5 rounded border overflow-hidden">
-              <div
-                className="bg-accent h-full transition-all"
-                style={{ width: `${data.timeElapsedPercent}%` }}
-              />
+        <div className="flex items-center gap-2 justify-center">
+          {[
+            { val: countdown.d, label: "days" },
+            { val: countdown.h, label: "hrs" },
+            { val: countdown.m, label: "min" },
+            { val: countdown.s, label: "sec" },
+          ].map((unit, i) => (
+            <div key={unit.label} className="flex items-center gap-2">
+              {i > 0 && <span className="text-muted text-lg font-mono">:</span>}
+              <div className="text-center">
+                <div className="text-foreground text-2xl font-bold font-mono tabular-nums">
+                  {i === 0 ? unit.val : pad2(unit.val)}
+                </div>
+                <div className="text-muted text-[9px] uppercase tracking-wider">{unit.label}</div>
+              </div>
             </div>
-            <div className="text-muted text-[10px] mt-0.5 text-right">
-              {data.timeElapsedPercent}% elapsed
-            </div>
-          </div>
+          ))}
         </div>
       )}
 
@@ -117,19 +543,24 @@ export function CampaignHero() {
         </div>
       </div>
 
-      {/* Lockup proof */}
-      {data.lockerId && (
-        <div className="text-center">
-          <a
-            href={`https://mint.club/locker/${data.lockerId}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-accent text-xs hover:underline"
-          >
-            View lockup proof on-chain
-          </a>
+      {/* 6-Month Timeline Chart */}
+      <TimelineChart
+        campaignStart={data.campaignStart}
+        campaignEnd={data.campaignEnd}
+        currentFdv={data.currentFdv}
+        poolAmount={data.poolAmount}
+      />
+
+      {/* Current position summary */}
+      <div className="text-center space-y-0.5">
+        <div className="text-foreground text-xs font-medium">
+          Current FDV: {data.currentFdv > 0 ? formatUsdValue(data.currentFdv) : "\u2014"}
+          <span className="text-muted"> &middot; Zone: {currentZoneLabel(data.currentFdv)}</span>
         </div>
-      )}
+        <div className="text-muted text-[10px]">
+          Pool value: {data.currentFdv > 0 ? formatUsdValue(poolValueAtFdv(data.currentFdv, data.poolAmount)) : "$0"}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/airdrop/CampaignHero.tsx
+++ b/src/components/airdrop/CampaignHero.tsx
@@ -137,7 +137,6 @@ function useCountdown(endDateStr: string) {
 /* ─── Pure chart helpers (outside component to avoid unstable refs) ─── */
 
 const FDV_LOG_MIN = Math.log10(100);
-const FDV_LOG_MAX = Math.log10(200_000_000);
 
 function timeToX(ms: number, startMs: number, totalMs: number): number {
   return PAD.left + ((ms - startMs) / totalMs) * CW;
@@ -147,9 +146,9 @@ function poolToY(usd: number, yLeftMax: number): number {
   return PAD.top + CH * (1 - usd / yLeftMax);
 }
 
-function fdvToY(fdv: number): number {
+function fdvToY(fdv: number, logMax: number): number {
   if (fdv <= 0) return PAD.top + CH;
-  const t = (Math.log10(Math.max(fdv, 100)) - FDV_LOG_MIN) / (FDV_LOG_MAX - FDV_LOG_MIN);
+  const t = (Math.log10(Math.max(fdv, 100)) - FDV_LOG_MIN) / (logMax - FDV_LOG_MIN);
   return PAD.top + CH * (1 - t);
 }
 
@@ -184,6 +183,7 @@ function TimelineChart({
   const nowX = timeToX(Math.min(nowMs, endMs), startMs, totalMs);
 
   const diamondFdv = tiers[tiers.length - 1].fdv;
+  const fdvLogMax = Math.log10(diamondFdv * 2); // 2x headroom above diamond
   const diamondPoolUsd = poolAmount * (diamondFdv / MAX_SUPPLY);
   const yLeftMax = diamondPoolUsd * 1.1;
 
@@ -242,29 +242,28 @@ function TimelineChart({
       const dpMs = new Date(dp.date + "T00:00:00Z").getTime();
       if (dpMs < startMs || dpMs > endMs) continue;
       const x = timeToX(dpMs, startMs, totalMs);
-      const y = fdvToY(dp.fdv);
+      const y = fdvToY(dp.fdv, fdvLogMax);
       parts.push(`${parts.length === 0 ? "M" : "L"} ${x.toFixed(1)} ${y.toFixed(1)}`);
     }
     if (parts.length > 0 && currentFdv > 0) {
-      parts.push(`L ${nowX.toFixed(1)} ${fdvToY(currentFdv).toFixed(1)}`);
+      parts.push(`L ${nowX.toFixed(1)} ${fdvToY(currentFdv, fdvLogMax).toFixed(1)}`);
     }
     return parts.join(" ");
-  }, [dailyPrices, startMs, endMs, totalMs, currentFdv, nowX]);
+  }, [dailyPrices, startMs, endMs, totalMs, currentFdv, nowX, fdvLogMax]);
 
-  // Linear projection: current FDV → Diamond at campaign end
   // Linear projection: from current position (nowX) → Diamond at campaign end
   const projectionPath = useMemo(() => {
     const toX = PAD.left + CW;
-    const fromY = fdvToY(currentFdv > 0 ? currentFdv : 100);
-    const toY = fdvToY(diamondFdv);
+    const fromY = fdvToY(currentFdv > 0 ? currentFdv : 100, fdvLogMax);
+    const toY = fdvToY(diamondFdv, fdvLogMax);
     return `M ${nowX} ${fromY} L ${toX} ${toY}`;
-  }, [currentFdv, nowX, diamondFdv]);
+  }, [currentFdv, nowX, diamondFdv, fdvLogMax]);
 
-  const dotY = fdvToY(currentFdv > 0 ? currentFdv : 100);
+  const dotY = fdvToY(currentFdv > 0 ? currentFdv : 100, fdvLogMax);
 
   const milestoneLines = tiers.map((t) => ({
     ...t,
-    y: fdvToY(t.fdv),
+    y: fdvToY(t.fdv, fdvLogMax),
   }));
 
   const yLeftTicks = [0, diamondPoolUsd * 0.25, diamondPoolUsd * 0.5, diamondPoolUsd];

--- a/src/components/airdrop/CampaignHero.tsx
+++ b/src/components/airdrop/CampaignHero.tsx
@@ -240,13 +240,13 @@ function TimelineChart({
   }, [dailyPrices, startMs, endMs, totalMs, currentFdv, nowX]);
 
   // Linear projection: current FDV → Diamond at campaign end
+  // Linear projection: from current position (nowX) → Diamond at campaign end
   const projectionPath = useMemo(() => {
-    const fromX = PAD.left;
     const toX = PAD.left + CW;
     const fromY = fdvToY(currentFdv > 0 ? currentFdv : 100);
     const toY = fdvToY(DIAMOND_FDV);
-    return `M ${fromX} ${fromY} L ${toX} ${toY}`;
-  }, [currentFdv]);
+    return `M ${nowX} ${fromY} L ${toX} ${toY}`;
+  }, [currentFdv, nowX]);
 
   const dotY = fdvToY(currentFdv > 0 ? currentFdv : 100);
 
@@ -256,7 +256,7 @@ function TimelineChart({
   }));
 
   const yLeftTicks = [0, diamondPoolUsd * 0.25, diamondPoolUsd * 0.5, diamondPoolUsd];
-  const yRightTicks = [1_000, 100_000, 1_000_000, 10_000_000, 100_000_000];
+  // Right-axis ticks omitted — milestone emoji labels already show FDV values
 
   return (
     <div className="w-full overflow-x-auto -mx-1 px-1">
@@ -309,21 +309,6 @@ function TimelineChart({
             fill="#8B7355"
             fontSize={8}
             fontFamily="Inter, system-ui, sans-serif"
-          >
-            {formatCompact(val)}
-          </text>
-        ))}
-
-        {/* Y-right axis ticks (FDV) */}
-        {yRightTicks.map((val) => (
-          <text
-            key={val}
-            x={PAD.left + CW + 4}
-            y={fdvToY(val) + 3}
-            fill="#8B7355"
-            fontSize={7}
-            fontFamily="Inter, system-ui, sans-serif"
-            opacity={0.5}
           >
             {formatCompact(val)}
           </text>

--- a/src/components/airdrop/CampaignHero.tsx
+++ b/src/components/airdrop/CampaignHero.tsx
@@ -34,12 +34,22 @@ interface DailyPrice {
 
 const MAX_SUPPLY = 1_000_000;
 
-const TIERS = [
-  { key: "bronze", emoji: "\uD83E\uDD49", label: "Bronze", fdv: 1_000_000, pct: 10 },
-  { key: "silver", emoji: "\uD83E\uDD48", label: "Silver", fdv: 10_000_000, pct: 30 },
-  { key: "gold", emoji: "\uD83E\uDD47", label: "Gold", fdv: 50_000_000, pct: 50 },
-  { key: "diamond", emoji: "\uD83D\uDC8E", label: "Diamond", fdv: 100_000_000, pct: 100 },
-] as const;
+const TIER_META = [
+  { key: "bronze" as const, emoji: "\uD83E\uDD49", label: "Bronze" },
+  { key: "silver" as const, emoji: "\uD83E\uDD48", label: "Silver" },
+  { key: "gold" as const, emoji: "\uD83E\uDD47", label: "Gold" },
+  { key: "diamond" as const, emoji: "\uD83D\uDC8E", label: "Diamond" },
+];
+
+type Tier = { key: string; emoji: string; label: string; fdv: number; pct: number };
+
+/** Build tier array from API milestones so test/prod config is respected */
+function buildTiers(milestones: StatusData["milestones"]): Tier[] {
+  return TIER_META.map((m) => {
+    const ms = milestones[m.key];
+    return { ...m, fdv: ms.mcap, pct: ms.pct };
+  });
+}
 
 /* ─── SVG layout ─── */
 
@@ -77,21 +87,20 @@ function useDailyPrices() {
 }
 
 /** Pool value at current FDV: highest reached tier pct * pool * price */
-function poolValueAtFdv(fdv: number, poolAmount: number): number {
+function poolValueAtFdv(fdv: number, poolAmount: number, tiers: Tier[]): number {
   const price = fdv / MAX_SUPPLY;
-  if (fdv >= 100_000_000) return poolAmount * 1.0 * price;
-  if (fdv >= 50_000_000) return poolAmount * 0.5 * price;
-  if (fdv >= 10_000_000) return poolAmount * 0.3 * price;
-  if (fdv >= 1_000_000) return poolAmount * 0.1 * price;
+  // Walk tiers in reverse to find highest reached
+  for (let i = tiers.length - 1; i >= 0; i--) {
+    if (fdv >= tiers[i].fdv) return poolAmount * (tiers[i].pct / 100) * price;
+  }
   return 0;
 }
 
-function currentZoneLabel(fdv: number): string {
-  if (fdv >= 100_000_000) return "Diamond";
-  if (fdv >= 50_000_000) return "Gold";
-  if (fdv >= 10_000_000) return "Silver";
-  if (fdv >= 1_000_000) return "Bronze";
-  return "Pre-Bronze";
+function currentZoneLabel(fdv: number, tiers: Tier[]): string {
+  for (let i = tiers.length - 1; i >= 0; i--) {
+    if (fdv >= tiers[i].fdv) return tiers[i].label;
+  }
+  return "Pre-" + tiers[0].label;
 }
 
 function formatCompact(val: number): string {
@@ -127,7 +136,6 @@ function useCountdown(endDateStr: string) {
 
 /* ─── Pure chart helpers (outside component to avoid unstable refs) ─── */
 
-const DIAMOND_FDV = 100_000_000;
 const FDV_LOG_MIN = Math.log10(100);
 const FDV_LOG_MAX = Math.log10(200_000_000);
 
@@ -152,11 +160,13 @@ function TimelineChart({
   campaignEnd,
   currentFdv,
   poolAmount,
+  tiers,
 }: {
   campaignStart: string;
   campaignEnd: string;
   currentFdv: number;
   poolAmount: number;
+  tiers: Tier[];
 }) {
   const { data: dailyPrices } = useDailyPrices();
   const [nowMs, setNowMs] = useState(() => Date.now());
@@ -173,7 +183,8 @@ function TimelineChart({
 
   const nowX = timeToX(Math.min(nowMs, endMs), startMs, totalMs);
 
-  const diamondPoolUsd = poolAmount * (DIAMOND_FDV / MAX_SUPPLY);
+  const diamondFdv = tiers[tiers.length - 1].fdv;
+  const diamondPoolUsd = poolAmount * (diamondFdv / MAX_SUPPLY);
   const yLeftMax = diamondPoolUsd * 1.1;
 
   // Month labels for x-axis
@@ -199,7 +210,7 @@ function TimelineChart({
       const dpMs = new Date(dp.date + "T00:00:00Z").getTime();
       if (dpMs < startMs || dpMs > endMs) continue;
       const x = timeToX(dpMs, startMs, totalMs);
-      const pv = poolValueAtFdv(dp.fdv, poolAmount);
+      const pv = poolValueAtFdv(dp.fdv, poolAmount, tiers);
       if (pv !== lastPoolVal && parts.length > 0) {
         parts.push(`L ${x.toFixed(1)} ${poolToY(lastPoolVal, yLeftMax).toFixed(1)}`);
       }
@@ -210,14 +221,15 @@ function TimelineChart({
       parts.push(`L ${nowX.toFixed(1)} ${poolToY(lastPoolVal, yLeftMax).toFixed(1)}`);
     }
     return parts.join(" ");
-  }, [dailyPrices, startMs, endMs, totalMs, poolAmount, nowX, yLeftMax]);
+  }, [dailyPrices, startMs, endMs, totalMs, poolAmount, nowX, yLeftMax, tiers]);
 
   // Pool value area fill
   const poolAreaPath = useMemo(() => {
     if (!poolStepPath) return "";
     const baseline = poolToY(0, yLeftMax);
+    // Clamp area fill start to campaign start (daily prices may predate campaign)
     const firstX = dailyPrices?.length
-      ? timeToX(new Date(dailyPrices[0].date + "T00:00:00Z").getTime(), startMs, totalMs)
+      ? timeToX(Math.max(new Date(dailyPrices[0].date + "T00:00:00Z").getTime(), startMs), startMs, totalMs)
       : PAD.left;
     return `M ${firstX.toFixed(1)} ${baseline.toFixed(1)} ${poolStepPath.replace(/^M/, "L")} L ${nowX.toFixed(1)} ${baseline.toFixed(1)} Z`;
   }, [poolStepPath, dailyPrices, startMs, totalMs, nowX, yLeftMax]);
@@ -244,13 +256,13 @@ function TimelineChart({
   const projectionPath = useMemo(() => {
     const toX = PAD.left + CW;
     const fromY = fdvToY(currentFdv > 0 ? currentFdv : 100);
-    const toY = fdvToY(DIAMOND_FDV);
+    const toY = fdvToY(diamondFdv);
     return `M ${nowX} ${fromY} L ${toX} ${toY}`;
-  }, [currentFdv, nowX]);
+  }, [currentFdv, nowX, diamondFdv]);
 
   const dotY = fdvToY(currentFdv > 0 ? currentFdv : 100);
 
-  const milestoneLines = TIERS.map((t) => ({
+  const milestoneLines = tiers.map((t) => ({
     ...t,
     y: fdvToY(t.fdv),
   }));
@@ -448,6 +460,11 @@ export function CampaignHero() {
   const { data, isLoading } = useAirdropStatus();
   const countdown = useCountdown(data?.campaignEnd ?? "2027-01-01");
 
+  const tiers = useMemo(
+    () => (data ? buildTiers(data.milestones) : []),
+    [data],
+  );
+
   if (isLoading || !data) {
     return (
       <div className="border-border rounded border p-4">
@@ -534,16 +551,17 @@ export function CampaignHero() {
         campaignEnd={data.campaignEnd}
         currentFdv={data.currentFdv}
         poolAmount={data.poolAmount}
+        tiers={tiers}
       />
 
       {/* Current position summary */}
       <div className="text-center space-y-0.5">
         <div className="text-foreground text-xs font-medium">
           Current FDV: {data.currentFdv > 0 ? formatUsdValue(data.currentFdv) : "\u2014"}
-          <span className="text-muted"> &middot; Zone: {currentZoneLabel(data.currentFdv)}</span>
+          <span className="text-muted"> &middot; Zone: {currentZoneLabel(data.currentFdv, tiers)}</span>
         </div>
         <div className="text-muted text-[10px]">
-          Pool value: {data.currentFdv > 0 ? formatUsdValue(poolValueAtFdv(data.currentFdv, data.poolAmount)) : "$0"}
+          Pool value: {data.currentFdv > 0 ? formatUsdValue(poolValueAtFdv(data.currentFdv, data.poolAmount, tiers)) : "$0"}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Combined hero and chart into one cohesive `CampaignHero` section with live d:h:m:s countdown, expanded campaign explanation, lock-up proof link, and a 6-month SVG timeline chart
- Chart renders 3 lines: actual FDV (solid), linear projection to Diamond (dashed), and pool value step line (filled area), with milestone markers and heartbeat-animated current position dot
- Added `/api/airdrop/daily-prices` endpoint serving historical FDV data from `pl_daily_prices` for the timeline chart; removed standalone `MilestoneTrack` from sidebar

Fixes #936

## Test plan
- [ ] Verify hero section renders with title, expanded explanation, countdown, stats row
- [ ] Confirm countdown updates live every second (d:h:m:s format)
- [ ] Check lock-up proof link shows "pending" when no LOCKER_ID, clickable link when set
- [ ] Verify chart renders 6-month x-axis with M1–M7 labels
- [ ] Confirm 3 chart lines: actual FDV (solid dark), linear projection (dashed), pool value (brown filled)
- [ ] Check 4 milestone markers (🥉🥈🥇💎) with horizontal dashed lines
- [ ] Verify heartbeat-animated dot pulses at current FDV position
- [ ] Confirm current FDV, zone label, and pool value display below chart
- [ ] Test pool value calculation: $0 below Bronze, correct % at each tier
- [ ] Verify `/api/airdrop/daily-prices` returns date + fdv array
- [ ] Check MilestoneTrack no longer appears in sidebar
- [ ] Test responsive on mobile (min-width 320px chart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)