### PR TITLE
[#950] Fix agents page empty state dead-end

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -30,6 +30,7 @@ function AgentsPageInner() {
   const [tab, setTab] = useState<Tab>(
     ["register", "build", "dashboard"].includes(initialTab) ? initialTab : "register",
   );
+  const [showRegisterForm, setShowRegisterForm] = useState(false);
 
   // DB-first: check if user has cached agent data
   const { data: dbUser, isLoading: dbLoading } = useQuery({
@@ -171,7 +172,7 @@ npx plotlink-ows         # start writing`}
         {(["register", "build", "dashboard"] as const).map((t) => (
           <button
             key={t}
-            onClick={() => setTab(t)}
+            onClick={() => { setTab(t); setShowRegisterForm(false); }}
             className={`rounded-t px-3 py-1.5 text-xs font-medium transition-colors ${
               tab === t
                 ? "bg-accent/15 text-accent"
@@ -194,8 +195,8 @@ npx plotlink-ows         # start writing`}
           <div className="mt-6 py-8 text-center">
             <p className="text-muted text-sm">Detecting agent status...</p>
           </div>
-        ) : hasExistingAgent ? (
-          <AgentManageAll />
+        ) : hasExistingAgent && !showRegisterForm ? (
+          <AgentManageAll onRegister={() => setShowRegisterForm(true)} />
         ) : (
           <AgentRegister />
         )

--- a/src/components/AgentManage.tsx
+++ b/src/components/AgentManage.tsx
@@ -651,7 +651,7 @@ export function AgentManage({ agentId, role, source }: AgentManageProps) {
 const ZERO_ADDR = "0x0000000000000000000000000000000000000000";
 
 /** Wrapper that enumerates all agents owned by the connected wallet */
-export function AgentManageAll() {
+export function AgentManageAll({ onRegister }: { onRegister?: () => void } = {}) {
   const { address } = useAccount();
 
   const { data: balance, isLoading: balanceLoading } = useReadContract({
@@ -745,9 +745,16 @@ export function AgentManageAll() {
     return (
       <div className="mt-6 py-8 text-center">
         <p className="text-muted text-sm mb-2">You have no AI agents registered.</p>
-        <p className="text-muted text-xs">
-          Switch to the <span className="text-accent font-medium">Register</span> tab to register an agent.
-        </p>
+        {onRegister ? (
+          <button
+            onClick={onRegister}
+            className="text-accent hover:underline text-xs font-medium"
+          >
+            Register an agent &rarr;
+          </button>
+        ) : (
+          <p className="text-muted text-xs">Register an agent to get started.</p>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
Fixes #950

- `AgentManageAll` empty state now shows an actionable "Register an agent →" button instead of "Switch to the Register tab" (which doesn't exist when the tab is labeled "Manage")
- Button reveals the `AgentRegister` form inline via a `showRegisterForm` state toggle
- Switching tabs resets the toggle back to normal flow

Patch version bump: 0.1.43 → 0.1.44

## Test plan
- [ ] Connect wallet with no registered agent → Manage tab shows "Register an agent →" button
- [ ] Click button → registration form appears
- [ ] Switch to Build/Dashboard tab and back → returns to Manage view (not stuck on register form)
- [ ] Wallet with existing agent → Manage tab shows agent cards as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)