### PR TITLE
[#953] Add Mint Club fee attribution on /create page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -448,7 +448,7 @@ function CreatePage() {
             <p className="text-muted text-xs">
               All storylines have a 7-day deadline &mdash; the story sunsets if no new plot is added within 7 days.
               {creationFee > BigInt(0) && (
-                <> Creation fee: {formatEther(creationFee)} ETH.</>
+                <> Creation fee: {formatEther(creationFee)} ETH (paid to Mint Club for bonding curve creation, not PlotLink).</>
               )}
             </p>
 


### PR DESCRIPTION
## Summary
Fixes #953

- Creation fee text now reads: "Creation fee: 0.0007 ETH (paid to Mint Club for bonding curve creation, not PlotLink)."
- Clarifies PlotLink doesn't charge this fee

Patch version bump: 0.1.44 → 0.1.45

## Test plan
- [ ] /create page shows updated fee text with Mint Club attribution
- [ ] Text only appears when `creationFee > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)