### PR TITLE
[#964] Add IPFS response size limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/api/cron/backfill/route.ts
+++ b/src/app/api/cron/backfill/route.ts
@@ -13,6 +13,7 @@ import type { Database } from "../../../../../lib/supabase";
 
 const IPFS_GATEWAY = "https://ipfs.filebase.io/ipfs/";
 const IPFS_TIMEOUT_MS = 10_000;
+const IPFS_MAX_BYTES = 1_000_000;
 
 /**
  * How many blocks to scan per cron run (~5 min on Base = ~150 blocks at 2s/block).
@@ -36,7 +37,11 @@ async function fetchIPFSContent(cid: string): Promise<string | null> {
       signal: AbortSignal.timeout(IPFS_TIMEOUT_MS),
     });
     if (!res.ok) return null;
-    return await res.text();
+    const cl = res.headers.get("content-length");
+    if (cl && parseInt(cl) > IPFS_MAX_BYTES) return null;
+    const text = await res.text();
+    if (text.length > IPFS_MAX_BYTES) return null;
+    return text;
   } catch {
     return null;
   }

--- a/src/app/api/cron/backfill/route.ts
+++ b/src/app/api/cron/backfill/route.ts
@@ -40,7 +40,7 @@ async function fetchIPFSContent(cid: string): Promise<string | null> {
     const cl = res.headers.get("content-length");
     if (cl && parseInt(cl) > IPFS_MAX_BYTES) return null;
     const text = await res.text();
-    if (text.length > IPFS_MAX_BYTES) return null;
+    if (new TextEncoder().encode(text).byteLength > IPFS_MAX_BYTES) return null;
     return text;
   } catch {
     return null;

--- a/src/app/api/index/plot/route.ts
+++ b/src/app/api/index/plot/route.ts
@@ -14,6 +14,7 @@ import type { Database } from "../../../../../lib/supabase";
 
 const IPFS_GATEWAY = "https://ipfs.filebase.io/ipfs/";
 const IPFS_TIMEOUT_MS = 10_000;
+const IPFS_MAX_BYTES = 1_000_000;
 
 /** PlotChained event topic0 (keccak256 of the event signature) */
 const PLOT_CHAINED_TOPIC = encodeEventTopics({
@@ -93,7 +94,10 @@ export async function POST(req: Request) {
       signal: AbortSignal.timeout(IPFS_TIMEOUT_MS),
     });
     if (!ipfsRes.ok) throw new Error(`IPFS status ${ipfsRes.status}`);
+    const cl = ipfsRes.headers.get("content-length");
+    if (cl && parseInt(cl) > IPFS_MAX_BYTES) throw new Error("IPFS content too large");
     const ipfsContent = await ipfsRes.text();
+    if (ipfsContent.length > IPFS_MAX_BYTES) throw new Error("IPFS content too large");
     // Verify IPFS content hash matches on-chain hash
     if (hashContent(ipfsContent) === contentHash) {
       content = ipfsContent;

--- a/src/app/api/index/plot/route.ts
+++ b/src/app/api/index/plot/route.ts
@@ -97,7 +97,7 @@ export async function POST(req: Request) {
     const cl = ipfsRes.headers.get("content-length");
     if (cl && parseInt(cl) > IPFS_MAX_BYTES) throw new Error("IPFS content too large");
     const ipfsContent = await ipfsRes.text();
-    if (ipfsContent.length > IPFS_MAX_BYTES) throw new Error("IPFS content too large");
+    if (new TextEncoder().encode(ipfsContent).byteLength > IPFS_MAX_BYTES) throw new Error("IPFS content too large");
     // Verify IPFS content hash matches on-chain hash
     if (hashContent(ipfsContent) === contentHash) {
       content = ipfsContent;

--- a/src/app/api/index/storyline/route.ts
+++ b/src/app/api/index/storyline/route.ts
@@ -125,7 +125,7 @@ export async function POST(req: Request) {
     const cl = ipfsRes.headers.get("content-length");
     if (cl && parseInt(cl) > IPFS_MAX_BYTES) throw new Error("IPFS content too large");
     const ipfsContent = await ipfsRes.text();
-    if (ipfsContent.length > IPFS_MAX_BYTES) throw new Error("IPFS content too large");
+    if (new TextEncoder().encode(ipfsContent).byteLength > IPFS_MAX_BYTES) throw new Error("IPFS content too large");
     // Verify IPFS content hash matches on-chain hash
     if (hashContent(ipfsContent) === openingHash) {
       genesisContent = ipfsContent;

--- a/src/app/api/index/storyline/route.ts
+++ b/src/app/api/index/storyline/route.ts
@@ -17,6 +17,7 @@ import { awardWritePoints } from "../../../../../lib/airdrop/award";
 
 const IPFS_GATEWAY = "https://ipfs.filebase.io/ipfs/";
 const IPFS_TIMEOUT_MS = 10_000;
+const IPFS_MAX_BYTES = 1_000_000;
 
 /** StorylineCreated event topic0 */
 const STORYLINE_CREATED_TOPIC = encodeEventTopics({
@@ -121,7 +122,10 @@ export async function POST(req: Request) {
       signal: AbortSignal.timeout(IPFS_TIMEOUT_MS),
     });
     if (!ipfsRes.ok) throw new Error(`IPFS status ${ipfsRes.status}`);
+    const cl = ipfsRes.headers.get("content-length");
+    if (cl && parseInt(cl) > IPFS_MAX_BYTES) throw new Error("IPFS content too large");
     const ipfsContent = await ipfsRes.text();
+    if (ipfsContent.length > IPFS_MAX_BYTES) throw new Error("IPFS content too large");
     // Verify IPFS content hash matches on-chain hash
     if (hashContent(ipfsContent) === openingHash) {
       genesisContent = ipfsContent;


### PR DESCRIPTION
## Summary
- Adds 1MB size limit on IPFS responses in storyline, plot indexers and backfill cron
- Checks both `Content-Length` header (fast reject) and actual body length (defense in depth)
- Oversized responses throw/return null — fallback content handling takes over
- Normal story content (~10K chars) is well under the 1MB limit

Fixes #964

## Test plan
- [ ] Normal story publishing unaffected (content well under 1MB)
- [ ] IPFS responses > 1MB are rejected before full body read (Content-Length check)
- [ ] IPFS responses > 1MB without Content-Length header are caught after read
- [ ] Backfill cron also rejects oversized IPFS content
- [ ] Fallback content still works when IPFS fetch fails due to size

🤖 Generated with [Claude Code](https://claude.com/claude-code)