### PR TITLE
[#965] Add fallback content size limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/api/index/plot/route.ts
+++ b/src/app/api/index/plot/route.ts
@@ -30,7 +30,7 @@ export async function POST(req: Request) {
   const body = await req.json();
   const txHash = body.txHash as Hex | undefined;
   const fallbackContent = body.content as string | undefined;
-  if (fallbackContent && fallbackContent.length > 50_000) {
+  if (fallbackContent && new TextEncoder().encode(fallbackContent).byteLength > 50_000) {
     return error("Fallback content too large", 400);
   }
 

--- a/src/app/api/index/plot/route.ts
+++ b/src/app/api/index/plot/route.ts
@@ -30,6 +30,9 @@ export async function POST(req: Request) {
   const body = await req.json();
   const txHash = body.txHash as Hex | undefined;
   const fallbackContent = body.content as string | undefined;
+  if (fallbackContent && fallbackContent.length > 50_000) {
+    return error("Fallback content too large", 400);
+  }
 
   if (!txHash || !/^0x[0-9a-fA-F]{64}$/.test(txHash)) {
     return error("Missing or invalid txHash");

--- a/src/app/api/index/storyline/route.ts
+++ b/src/app/api/index/storyline/route.ts
@@ -33,7 +33,7 @@ export async function POST(req: Request) {
   const body = await req.json();
   const txHash = body.txHash as Hex | undefined;
   const fallbackContent = body.content as string | undefined;
-  if (fallbackContent && fallbackContent.length > 50_000) {
+  if (fallbackContent && new TextEncoder().encode(fallbackContent).byteLength > 50_000) {
     return error("Fallback content too large", 400);
   }
   const rawGenre = body.genre as string | undefined;

--- a/src/app/api/index/storyline/route.ts
+++ b/src/app/api/index/storyline/route.ts
@@ -33,6 +33,9 @@ export async function POST(req: Request) {
   const body = await req.json();
   const txHash = body.txHash as Hex | undefined;
   const fallbackContent = body.content as string | undefined;
+  if (fallbackContent && fallbackContent.length > 50_000) {
+    return error("Fallback content too large", 400);
+  }
   const rawGenre = body.genre as string | undefined;
   const rawLanguage = body.language as string | undefined;
   const genre = rawGenre && (GENRES as readonly string[]).includes(rawGenre) ? rawGenre : null;


### PR DESCRIPTION
## Summary
- Adds 50KB size limit on `body.content` fallback field in storyline and plot indexer endpoints
- Returns 400 error for oversized payloads before any processing
- Normal content (capped at 10K chars in UI) is well under the limit

Fixes #965

## Test plan
- [ ] Normal story publishing with fallback content unaffected
- [ ] Fallback content > 50KB rejected with 400
- [ ] Storyline and plot endpoints both validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)