### PR TITLE
[#966] Airdrop endpoint security: rate limiting + cache headers

### DIFF
--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,39 @@
+import { createServerClient } from "./supabase";
+
+/**
+ * DB-based rate limiter (serverless-safe).
+ * Returns true if the request is allowed, false if rate limited.
+ */
+export async function checkRateLimit(
+  ip: string,
+  endpoint: string,
+  maxRequests = 5,
+  windowMs = 60_000,
+): Promise<boolean> {
+  const supabase = createServerClient();
+  if (!supabase) return true; // fail open if DB unavailable
+
+  const key = `${endpoint}:${ip}`;
+  const windowStart = new Date(Date.now() - windowMs).toISOString();
+
+  // Count recent requests in window
+  const { count } = await supabase
+    .from("rate_limits")
+    .select("id", { count: "exact", head: true })
+    .eq("key", key)
+    .gte("created_at", windowStart);
+
+  if (count !== null && count >= maxRequests) {
+    return false;
+  }
+
+  // Record this request
+  await supabase.from("rate_limits").insert({ key });
+
+  return true;
+}
+
+/** Extract client IP from request headers (Vercel x-forwarded-for). */
+export function getClientIp(req: Request): string {
+  return req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,7 +1,8 @@
 import { createServerClient } from "./supabase";
 
 /**
- * DB-based rate limiter (serverless-safe).
+ * DB-based rate limiter (serverless-safe, atomic).
+ * Uses a Supabase RPC function that counts + inserts in a single transaction.
  * Returns true if the request is allowed, false if rate limited.
  */
 export async function checkRateLimit(
@@ -14,23 +15,15 @@ export async function checkRateLimit(
   if (!supabase) return true; // fail open if DB unavailable
 
   const key = `${endpoint}:${ip}`;
-  const windowStart = new Date(Date.now() - windowMs).toISOString();
 
-  // Count recent requests in window
-  const { count } = await supabase
-    .from("rate_limits")
-    .select("id", { count: "exact", head: true })
-    .eq("key", key)
-    .gte("created_at", windowStart);
+  const { data, error } = await supabase.rpc("check_rate_limit", {
+    p_key: key,
+    p_max_requests: maxRequests,
+    p_window_ms: windowMs,
+  });
 
-  if (count !== null && count >= maxRequests) {
-    return false;
-  }
-
-  // Record this request
-  await supabase.from("rate_limits").insert({ key });
-
-  return true;
+  if (error) return true; // fail open on error
+  return data as boolean;
 }
 
 /** Extract client IP from request headers (Vercel x-forwarded-for). */

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -523,6 +523,24 @@ export interface Database {
         };
         Relationships: [];
       };
+      rate_limits: {
+        Row: {
+          id: number;
+          key: string;
+          created_at: string;
+        };
+        Insert: {
+          id?: never;
+          key: string;
+          created_at?: string;
+        };
+        Update: {
+          id?: never;
+          key?: string;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
       trade_history: {
         Row: {
           id: number;

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -742,6 +742,10 @@ export interface Database {
         Args: { sid: number; caddr: string };
         Returns: void;
       };
+      check_rate_limit: {
+        Args: { p_key: string; p_max_requests: number; p_window_ms: number };
+        Returns: boolean;
+      };
     };
     Enums: {
       [_ in never]: never;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/api/airdrop/checkin/route.ts
+++ b/src/app/api/airdrop/checkin/route.ts
@@ -12,8 +12,14 @@ import { createServerClient } from "../../../../../lib/supabase";
 import { AIRDROP_CONFIG } from "../../../../../lib/airdrop/config";
 import { getStreakBoost, dropOneTier, getNextTier } from "../../../../../lib/airdrop/streak";
 import { verifyWalletOwnership } from "../../../../../lib/airdrop/verify-wallet";
+import { checkRateLimit, getClientIp } from "../../../../../lib/rate-limit";
 
 export async function POST(req: Request) {
+  const ip = getClientIp(req);
+  if (!(await checkRateLimit(ip, "airdrop/checkin"))) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
   const supabase = createServerClient();
   if (!supabase) {
     return NextResponse.json({ error: "Supabase not configured" }, { status: 500 });

--- a/src/app/api/airdrop/leaderboard/route.ts
+++ b/src/app/api/airdrop/leaderboard/route.ts
@@ -63,5 +63,7 @@ export async function GET(req: NextRequest) {
     userRank = idx >= 0 ? idx + 1 : null;
   }
 
-  return NextResponse.json({ entries, userRank });
+  return NextResponse.json({ entries, userRank }, {
+    headers: { "Cache-Control": "public, s-maxage=30, stale-while-revalidate=15" },
+  });
 }

--- a/src/app/api/airdrop/points/route.ts
+++ b/src/app/api/airdrop/points/route.ts
@@ -110,5 +110,7 @@ export async function GET(req: NextRequest) {
       referredUsersCount: referredUsersCount ?? 0,
     },
     estimatedAirdrop,
+  }, {
+    headers: { "Cache-Control": "public, s-maxage=10, stale-while-revalidate=5" },
   });
 }

--- a/src/app/api/airdrop/referral-code/route.ts
+++ b/src/app/api/airdrop/referral-code/route.ts
@@ -10,6 +10,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { nanoid } from "nanoid";
 import { createServerClient } from "../../../../../lib/supabase";
 import { verifyWalletOwnership } from "../../../../../lib/airdrop/verify-wallet";
+import { checkRateLimit, getClientIp } from "../../../../../lib/rate-limit";
 
 export async function GET(req: NextRequest) {
   const supabase = createServerClient();
@@ -36,6 +37,11 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: Request) {
+  const ip = getClientIp(req);
+  if (!(await checkRateLimit(ip, "airdrop/referral-code"))) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
   const supabase = createServerClient();
   if (!supabase) {
     return NextResponse.json({ error: "Supabase not configured" }, { status: 500 });

--- a/src/app/api/airdrop/register-referral/route.ts
+++ b/src/app/api/airdrop/register-referral/route.ts
@@ -12,6 +12,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createServerClient } from "../../../../../lib/supabase";
 import { verifyWalletOwnership } from "../../../../../lib/airdrop/verify-wallet";
+import { checkRateLimit, getClientIp } from "../../../../../lib/rate-limit";
 
 export async function GET(req: NextRequest) {
   const supabase = createServerClient();
@@ -52,6 +53,11 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: Request) {
+  const ip = getClientIp(req);
+  if (!(await checkRateLimit(ip, "airdrop/register-referral"))) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
   const supabase = createServerClient();
   if (!supabase) {
     return NextResponse.json({ error: "Supabase not configured" }, { status: 500 });

--- a/src/app/api/airdrop/snapshots/route.ts
+++ b/src/app/api/airdrop/snapshots/route.ts
@@ -33,5 +33,7 @@ export async function GET() {
       mcapEnd: s.mcap_end,
       totalPlEarned: s.total_pl_earned,
     })),
+  }, {
+    headers: { "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60" },
   });
 }

--- a/src/app/api/airdrop/status/route.ts
+++ b/src/app/api/airdrop/status/route.ts
@@ -87,5 +87,7 @@ export async function GET() {
     totalPointsEarned,
     totalParticipants,
     lockerId: AIRDROP_CONFIG.LOCKER_ID,
+  }, {
+    headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=30" },
   });
 }

--- a/supabase/migrations/00037_rate_limits.sql
+++ b/supabase/migrations/00037_rate_limits.sql
@@ -23,6 +23,9 @@ CREATE TRIGGER trg_purge_rate_limits
 
 -- Atomic rate limit check: counts recent requests, inserts if under limit.
 -- Returns true if allowed, false if rate limited.
+-- Atomic rate limit check: uses advisory lock to serialize per key,
+-- counts recent requests, inserts if under limit.
+-- Returns true if allowed, false if rate limited.
 CREATE OR REPLACE FUNCTION check_rate_limit(
   p_key TEXT,
   p_max_requests INT DEFAULT 5,
@@ -31,12 +34,14 @@ CREATE OR REPLACE FUNCTION check_rate_limit(
 DECLARE
   v_count INT;
   v_window_start TIMESTAMPTZ;
+  v_lock_id BIGINT;
 BEGIN
+  v_lock_id := hashtext(p_key);
+  PERFORM pg_advisory_xact_lock(v_lock_id);
   v_window_start := now() - (p_window_ms || ' milliseconds')::interval;
   SELECT count(*) INTO v_count
     FROM rate_limits
-    WHERE key = p_key AND created_at >= v_window_start
-    FOR UPDATE;
+    WHERE key = p_key AND created_at >= v_window_start;
   IF v_count >= p_max_requests THEN
     RETURN false;
   END IF;

--- a/supabase/migrations/00037_rate_limits.sql
+++ b/supabase/migrations/00037_rate_limits.sql
@@ -1,0 +1,22 @@
+-- Rate limiting table for serverless-safe request throttling.
+-- Stores recent request timestamps per IP+endpoint key.
+CREATE TABLE IF NOT EXISTS rate_limits (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  key TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_rate_limits_key_created ON rate_limits (key, created_at DESC);
+
+-- Auto-purge entries older than 5 minutes
+CREATE OR REPLACE FUNCTION purge_old_rate_limits() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM rate_limits WHERE created_at < now() - interval '5 minutes';
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_purge_rate_limits
+  AFTER INSERT ON rate_limits
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION purge_old_rate_limits();

--- a/supabase/migrations/00037_rate_limits.sql
+++ b/supabase/migrations/00037_rate_limits.sql
@@ -20,3 +20,27 @@ CREATE TRIGGER trg_purge_rate_limits
   AFTER INSERT ON rate_limits
   FOR EACH STATEMENT
   EXECUTE FUNCTION purge_old_rate_limits();
+
+-- Atomic rate limit check: counts recent requests, inserts if under limit.
+-- Returns true if allowed, false if rate limited.
+CREATE OR REPLACE FUNCTION check_rate_limit(
+  p_key TEXT,
+  p_max_requests INT DEFAULT 5,
+  p_window_ms INT DEFAULT 60000
+) RETURNS BOOLEAN AS $$
+DECLARE
+  v_count INT;
+  v_window_start TIMESTAMPTZ;
+BEGIN
+  v_window_start := now() - (p_window_ms || ' milliseconds')::interval;
+  SELECT count(*) INTO v_count
+    FROM rate_limits
+    WHERE key = p_key AND created_at >= v_window_start
+    FOR UPDATE;
+  IF v_count >= p_max_requests THEN
+    RETURN false;
+  END IF;
+  INSERT INTO rate_limits (key) VALUES (p_key);
+  RETURN true;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- **POST rate limiting** (5/min per IP) on checkin, referral-code, register-referral endpoints
  - DB-based via new `rate_limits` table — serverless-safe (no in-memory state)
  - Auto-purge trigger removes entries older than 5 minutes
  - Shared `lib/rate-limit.ts` utility with `checkRateLimit()` and `getClientIp()`
- **GET cache headers** on status (60s), leaderboard (30s), points (10s), snapshots (300s)
  - Uses `s-maxage` + `stale-while-revalidate` for CDN-level caching
- Migration: `00037_rate_limits.sql` creates table with index + purge trigger

Fixes #966

## Test plan
- [ ] POST endpoints return 429 after 5 requests/min from same IP
- [ ] Rate limiting persists across serverless invocations (DB-based)
- [ ] GET endpoints include Cache-Control headers in responses
- [ ] Normal airdrop flows (checkin, referral, points) unaffected
- [ ] Migration runs cleanly on Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)