### PR TITLE
[#978] Remove active-first sort from MCap

### DIFF
--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -331,13 +331,8 @@ export async function getMcapStorylines(
     return { ...sl, mcap };
   });
 
-  // Active-first, then by MCap descending
-  withMcap.sort((a, b) => {
-    const aActive = getStoryStatus(a) === "active" ? 0 : 1;
-    const bActive = getStoryStatus(b) === "active" ? 0 : 1;
-    if (aActive !== bActive) return aActive - bActive;
-    return b.mcap - a.mcap;
-  });
+  // Pure MCap descending — no active-first bias (per #978)
+  withMcap.sort((a, b) => b.mcap - a.mcap);
 
   return withMcap.slice(offset, offset + limit);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary
- Removes active-first sorting from `getMcapStorylines()` — now pure MCap descending
- Trending sort keeps active-first (correct per spec)
- Recent sort was already pure chronological (no change needed)

Fixes #978

## Test plan
- [ ] MCap sort: stories ordered by market cap regardless of active status
- [ ] Trending sort: active stories still appear first
- [ ] Recent sort: unchanged, pure chronological

🤖 Generated with [Claude Code](https://claude.com/claude-code)