### PR TITLE
[#981] Add Terms of Service and Privacy Policy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,54 +1,139 @@
-# PlotLink — Your Story Is a Token
+<div align="center">
 
-PlotLink is an on-chain storytelling protocol where every storyline becomes a tradable token from day one.
+<img src="public/plotlink-logo.svg" alt="PlotLink" width="80" />
 
-**How it works:** Writers publish storylines that automatically deploy an ERC-20 token on a bonding curve. Each new chapter (plot) drives demand, and every trade generates 5% royalties for the author. Stories are stored permanently on IPFS — the narrative lives on-chain, not on someone's server.
+# PlotLink
 
-## Core Mechanics
+### Every story becomes a token.
 
-- **Write** — Publish a storyline with a genesis plot. A unique token + bonding curve is created instantly.
-- **Trade** — Readers mint tokens to back stories they believe in. Prices rise with demand along a J-curve (up to 1,888x from first to last mint).
-- **Chain** — Authors must publish new plots every 7 days, keeping storylines alive and readers engaged.
-- **Earn** — 5% royalties on every mint and burn, plus direct donations from readers.
+<p>
+  <a href="https://plotlink.xyz"><strong>Website</strong></a> ·
+  <a href="#-how-it-works"><strong>How it Works</strong></a> ·
+  <a href="#-ai-writer"><strong>AI Writer</strong></a> ·
+  <a href="#-airdrop"><strong>Airdrop</strong></a> ·
+  <a href="https://plotlink.xyz/terms"><strong>Terms</strong></a>
+</p>
 
-## What Makes It Different
+<p>
+  <a href="https://plotlink.xyz"><img src="https://img.shields.io/badge/live-plotlink.xyz-8B4513" alt="live" /></a>
+  <img src="https://img.shields.io/badge/chain-Base_(L2)-0052FF" alt="Base" />
+  <img src="https://img.shields.io/badge/storage-IPFS-65C2CB" alt="IPFS" />
+  <a href="https://www.npmjs.com/package/plotlink-ows"><img src="https://img.shields.io/npm/v/plotlink-ows" alt="AI Writer npm" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="AGPL-3.0 License" /></a>
+</p>
 
-- Tokenized storytelling with built-in monetization — no ad revenue, no paywalls, no platform cuts beyond protocol royalties
-- AI agents can write too — ERC-8004 registry support enables autonomous agent storytelling alongside human writers
-- Mobile-first design with Farcaster miniapp integration for social distribution
-- Bonding curves mean early readers who discover great stories are financially rewarded
+</div>
 
-## Tech Stack
+---
 
-- **Framework**: Next.js 16 (App Router), TypeScript
-- **Styling**: Tailwind CSS v4
-- **Database**: Supabase
-- **Storage**: IPFS via Filebase
-- **Chain**: Base (L2), Mint Club V2 bonding curves
-- **Wallet**: Wagmi + RainbowKit
+## What is PlotLink?
 
-## Getting Started
+**PlotLink** is an on-chain storytelling protocol where writers publish serialized fiction and each storyline gets its own token on a bonding curve — no presale, no seed round. Just stories and markets.
+
+New chapters drive minting. Minting generates royalties. Great stories win.
+
+<video src="https://github.com/user-attachments/assets/GWCLV1BZWdw" width="720" controls></video>
+
+[▶ Watch Demo on YouTube](https://www.youtube.com/watch?v=GWCLV1BZWdw)
+
+[🌐 Visit plotlink.xyz](https://plotlink.xyz)
+
+## 📖 How it Works
+
+```
+Write → Publish on-chain → Token created → Readers mint → Writer earns royalties
+  ↑                                                              │
+  └──────────── next chapter (every 7 days) ────────────────────┘
+```
+
+1. **Write** — Publish a storyline with a genesis plot. A unique ERC-20 token + bonding curve is created instantly on Base.
+2. **Mint** — Readers mint Story tokens with PLOT to support stories they believe in. Prices rise with demand along the bonding curve.
+3. **Chain** — Writers publish new chapters (plots) every 7 days, keeping storylines alive and readers engaged.
+4. **Earn** — Writers receive 5% royalties on every mint, plus direct donations from readers.
+
+### Key Features
+
+- **Tokenized storytelling** — every story has its own bonding curve token from day one
+- **Writer royalties** — 5% on every mint, paid automatically by the smart contract
+- **Permanent storage** — stories live on IPFS and are referenced on-chain, not on someone's server
+- **AI Writer tool** — anyone can become a fiction writer with an AI co-writer ([PlotLink OWS](https://github.com/realproject7/plotlink-ows))
+- **Farcaster integration** — social distribution via Farcaster Mini App
+- **ERC-8004 agent support** — AI agents can register and publish stories autonomously
+
+## 🤖 AI Writer
+
+**PlotLink OWS** (Open Writer Station) is a local-first AI writing assistant that pairs you with Claude to brainstorm, draft, and publish tokenized stories.
+
+```bash
+npx plotlink-ows init    # guided setup
+npx plotlink-ows         # start writing
+```
+
+- Chat with your AI co-writer to brainstorm ideas, outline stories, and refine drafts
+- Publish directly on-chain from the local app
+- Your stories, API keys, and wallet stay on your machine
+
+👉 [github.com/realproject7/plotlink-ows](https://github.com/realproject7/plotlink-ows)
+
+## 🎯 Airdrop
+
+**PLOT Big or Nothing Airdrop** — 50,000 PLOT (5% of max supply) locked in a time-locked contract. Earn PL Points through platform activity over 6 months. If PLOT FDV reaches milestone targets, the pool is distributed. If not, it's burned forever.
+
+- **Earn points** by minting Story tokens, referring friends, writing stories, and daily check-ins
+- **Milestone targets** — 🥉 $1M / 🥈 $10M / 🥇 $50M / 💎 $100M FDV
+- **Streak boost** — daily SIWE check-in multiplies all point earnings up to +50%
+
+👉 [plotlink.xyz/airdrop](https://plotlink.xyz/airdrop)
+
+## 🏗️ Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| **Framework** | Next.js 16 (App Router), TypeScript |
+| **Styling** | Tailwind CSS v4 |
+| **Database** | Supabase |
+| **Storage** | IPFS via Filebase |
+| **Chain** | Base (L2) |
+| **Bonding Curve** | Mint Club V2 |
+| **Wallet** | Wagmi + RainbowKit |
+| **Identity** | Farcaster (Neynar), ERC-8004 |
+
+## 📜 Contracts
+
+| Contract | Address |
+|----------|---------|
+| **StoryFactory** | [`0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf`](https://basescan.org/address/0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf) |
+| **PLOT Token** | [`0x4F567DACBF9D15A6acBe4A47FC2Ade0719Fb63C4`](https://basescan.org/address/0x4F567DACBF9D15A6acBe4A47FC2Ade0719Fb63C4) |
+| **ERC-8004 Registry** | [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://basescan.org/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432) |
+| **MCV2 Bond** | [`0xc5a076cad94176c2996B32d8466Be1cE757FAa27`](https://basescan.org/address/0xc5a076cad94176c2996B32d8466Be1cE757FAa27) |
+
+Contract source: [realproject7/plotlink-contracts](https://github.com/realproject7/plotlink-contracts)
+
+## 🛠️ Development
 
 ```bash
 npm install
-npm run dev
-```
-
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-## Commands
-
-```bash
-npm run dev        # Start dev server
+npm run dev        # Start dev server (http://localhost:3000)
 npm run build      # Production build
 npm run lint       # ESLint
 npm run typecheck  # TypeScript type-check
 ```
 
-## Environment Variables
+See [`.env.example`](.env.example) for required environment variables.
 
-See [`.env.example`](.env.example) for all required environment variables.
+## 📄 Legal
 
-## Live
+- [Terms of Service](https://plotlink.xyz/terms)
+- [Privacy Policy](https://plotlink.xyz/privacy)
 
-[plotlink.xyz](https://plotlink.xyz)
+PLOT and Story tokens are utility tokens, not investments or securities. All on-chain transactions are final and irreversible. See the full Terms of Service for details.
+
+## License
+
+[AGPL-3.0](LICENSE) — you may view, fork, and modify the code, but any modified version deployed as a public service must be open-sourced under the same license. Commercial use requires explicit permission.
+
+---
+
+<div align="center">
+  <p>Made by <a href="https://farcaster.xyz/project7">@project7</a></p>
+</div>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 New chapters drive minting. Minting generates royalties. Great stories win.
 
-<video src="https://github.com/user-attachments/assets/GWCLV1BZWdw" width="720" controls></video>
+[![PlotLink Demo](https://img.youtube.com/vi/GWCLV1BZWdw/maxresdefault.jpg)](https://www.youtube.com/watch?v=GWCLV1BZWdw)
 
 [▶ Watch Demo on YouTube](https://www.youtube.com/watch?v=GWCLV1BZWdw)
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,89 @@
+export default function PrivacyPage() {
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-12">
+      <article className="prose prose-sm max-w-none">
+        <h1>Privacy Policy</h1>
+        <p className="text-muted"><strong>PlotLink &mdash; plotlink.xyz</strong><br />Last updated: April 24, 2026</p>
+
+        <h2>1. Overview</h2>
+        <p>PlotLink is an on-chain storytelling protocol. This policy explains what data we collect, what we don&apos;t collect, and how data is handled.</p>
+
+        <h2>2. What We Do NOT Collect</h2>
+        <p>PlotLink does not collect, store, or process:</p>
+        <ul>
+          <li>Email addresses</li>
+          <li>Phone numbers</li>
+          <li>Passwords</li>
+          <li>Names or personal identifiers</li>
+          <li>IP addresses (beyond standard server logs)</li>
+          <li>Location data</li>
+          <li>Cookies for tracking or advertising</li>
+        </ul>
+
+        <h2>3. What We Store</h2>
+
+        <h3>Blockchain Data (Public)</h3>
+        <p>We index publicly available on-chain data including:</p>
+        <ul>
+          <li>Wallet addresses (public by nature of blockchain)</li>
+          <li>Transaction hashes</li>
+          <li>Token balances and activity</li>
+          <li>Published story content (stored on IPFS, referenced on-chain)</li>
+        </ul>
+        <p>This data is already public on the Base blockchain. PlotLink indexes it for display purposes.</p>
+
+        <h3>Farcaster Profile Data</h3>
+        <p>If your wallet is linked to a Farcaster account, we cache your public Farcaster profile (username, display name, profile picture) for display purposes. This data is publicly available via the Farcaster protocol.</p>
+
+        <h3>Airdrop Campaign Data</h3>
+        <p>If you participate in the PLOT airdrop campaign, we store:</p>
+        <ul>
+          <li>Your wallet address and earned points</li>
+          <li>Referral relationships (which wallet referred which)</li>
+          <li>Daily check-in streak data</li>
+          <li>Referral codes</li>
+        </ul>
+
+        <h3>Story Ratings and Comments</h3>
+        <p>If you rate or comment on a story, your wallet address and the rating/comment are stored in our database.</p>
+
+        <h2>4. Local Data (PlotLink OWS)</h2>
+        <p>The PlotLink OWS writing tool runs locally on your computer. All data &mdash; stories, drafts, AI conversations, API keys, wallet keys &mdash; is stored locally in <code>~/.plotlink-ows/</code> on your machine. PlotLink does not have access to this data.</p>
+
+        <h2>5. Third-Party Services</h2>
+        <p>PlotLink uses the following third-party services:</p>
+        <ul>
+          <li><strong>Base Network</strong> &mdash; public blockchain (transactions are permanent and public)</li>
+          <li><strong>IPFS via Filebase</strong> &mdash; decentralized storage (published content is permanent and public)</li>
+          <li><strong>Farcaster / Neynar</strong> &mdash; social identity (public profile data)</li>
+          <li><strong>Mint Club</strong> &mdash; bonding curve protocol (token minting and burning)</li>
+          <li><strong>Vercel</strong> &mdash; hosting (standard server logs)</li>
+        </ul>
+        <p>Each service has its own privacy policy.</p>
+
+        <h2>6. Data Retention</h2>
+        <ul>
+          <li>On-chain data and IPFS content are permanent by design and cannot be deleted</li>
+          <li>Database records (ratings, airdrop points, cached profiles) are retained indefinitely</li>
+          <li>There is no account deletion process because there are no accounts &mdash; only wallet addresses</li>
+        </ul>
+
+        <h2>7. Data Security</h2>
+        <ul>
+          <li>No sensitive credentials are stored server-side</li>
+          <li>Database access is restricted via Supabase Row Level Security</li>
+          <li>All API endpoints use HTTPS</li>
+        </ul>
+
+        <h2>8. Children</h2>
+        <p>PlotLink is not intended for use by anyone under 18 years of age.</p>
+
+        <h2>9. Changes</h2>
+        <p>We may update this policy at any time. Changes take effect immediately upon posting.</p>
+
+        <h2>10. Contact</h2>
+        <p>For privacy-related questions, open an issue at <a href="https://github.com/realproject7/plotlink" target="_blank" rel="noopener noreferrer">github.com/realproject7/plotlink</a>.</p>
+      </article>
+    </div>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,95 @@
+export default function TermsPage() {
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-12">
+      <article className="prose prose-sm max-w-none">
+        <h1>Terms of Service</h1>
+        <p className="text-muted"><strong>PlotLink &mdash; plotlink.xyz</strong><br />Last updated: April 24, 2026</p>
+
+        <h2>1. Overview</h2>
+        <p>PlotLink is an open-source, on-chain storytelling protocol on Base (L2). It allows users to publish stories as on-chain tokens and support writers via bonding curves. PlotLink provides the interface &mdash; all transactions occur on public blockchains and are governed by smart contracts.</p>
+
+        <h2>2. Acceptance</h2>
+        <p>By using PlotLink, you agree to these terms. If you do not agree, do not use the service.</p>
+
+        <h2>3. The Service</h2>
+        <p>PlotLink provides:</p>
+        <ul>
+          <li>A web interface for publishing and reading tokenized stories</li>
+          <li>Bonding curve token creation via Mint Club V2 (third-party protocol)</li>
+          <li>IPFS storage of story content via Filebase (third-party provider)</li>
+          <li>An AI writing assistant tool (PlotLink OWS) for local use</li>
+          <li>An airdrop campaign with conditional token distribution</li>
+        </ul>
+        <p>PlotLink does NOT:</p>
+        <ul>
+          <li>Custody, hold, or control user funds or tokens</li>
+          <li>Provide financial, investment, or legal advice</li>
+          <li>Guarantee any token value, return, or market outcome</li>
+          <li>Control or reverse on-chain transactions</li>
+        </ul>
+
+        <h2>4. Wallet-Based Access</h2>
+        <p>PlotLink uses wallet-based authentication (e.g., MetaMask, Coinbase Wallet). We do not collect email addresses, phone numbers, passwords, or other personal credentials. Your wallet address is your identity on the platform.</p>
+
+        <h2>5. User Content</h2>
+        <p>Stories published through PlotLink are stored on IPFS and referenced on-chain. By publishing, you represent that:</p>
+        <ul>
+          <li>You own or have the right to publish the content</li>
+          <li>The content does not infringe any third-party rights</li>
+          <li>The content does not contain illegal material</li>
+        </ul>
+        <p>Published content is permanent and cannot be deleted from IPFS or the blockchain by PlotLink.</p>
+
+        <h2>6. PLOT Token</h2>
+        <p>PLOT is a <strong>utility token</strong> used within the PlotLink protocol. It serves as the reserve currency for minting and burning Story tokens via Mint Club V2 bonding curves. PLOT is not an investment, security, or financial instrument. PlotLink makes no representations about the value, future price, or return potential of PLOT.</p>
+        <p>PLOT is minted and burned through Mint Club V2&apos;s bonding curve mechanism. PlotLink does not control the supply, price, or liquidity of PLOT.</p>
+
+        <h2>7. Story Tokens</h2>
+        <p>Each story published on PlotLink creates a Story token on a bonding curve. Story tokens are a <strong>mechanism for supporting writers</strong> &mdash; purchasing a Story token is a way to support the creator and participate in the story&apos;s community. Story tokens are not investments, securities, or financial instruments.</p>
+        <ul>
+          <li>Writers receive royalties (5%) on each mint as a reward for creating content</li>
+          <li>Token prices are determined algorithmically by the bonding curve, not by PlotLink</li>
+          <li>Story tokens may have no monetary value</li>
+          <li>Purchasing a Story token does not create any obligation from the writer or PlotLink</li>
+        </ul>
+
+        <h2>8. On-Chain Transactions</h2>
+        <p>All transactions on PlotLink &mdash; including minting, burning, and swapping Story tokens &mdash; are executed on the Base blockchain via smart contracts. By using PlotLink, you acknowledge and agree that:</p>
+        <ul>
+          <li><strong>All on-chain transactions are final and irreversible.</strong> PlotLink cannot cancel, reverse, modify, or refund any transaction once it is submitted to the blockchain.</li>
+          <li><strong>PlotLink is not a party to your transactions.</strong> All mints and burns are executed directly between your wallet and the bonding curve smart contract. PlotLink provides the interface only.</li>
+          <li><strong>You are solely responsible for your transactions.</strong> This includes verifying amounts, addresses, and gas fees before confirming.</li>
+          <li><strong>PlotLink cannot recover lost funds.</strong> If you send tokens to the wrong address, interact with the wrong contract, or lose access to your wallet, PlotLink cannot assist with recovery.</li>
+          <li>Token prices are determined by the bonding curve algorithm &mdash; PlotLink does not set, influence, or guarantee prices</li>
+          <li>You accept all risks associated with minting and burning tokens, including total loss of funds</li>
+          <li>You are responsible for understanding applicable tax obligations in your jurisdiction</li>
+        </ul>
+        <p>PlotLink earns no fees from token minting or burning. Creation fees are paid to Mint Club.</p>
+
+        <h2>9. Airdrop Campaign</h2>
+        <p>The PLOT Big or Nothing Airdrop is a conditional distribution. Participation does not guarantee any token distribution. The airdrop pool may be partially or fully burned based on market conditions. PlotLink makes no guarantees about token value or distribution outcomes. The airdrop is not compensation, income, or a return on investment.</p>
+
+        <h2>10. AI Writing Tool</h2>
+        <p>PlotLink OWS is a local application that runs on your computer. It connects to third-party AI providers (Anthropic, OpenAI, etc.) using your own API keys. PlotLink does not process, store, or have access to your AI conversations or API keys.</p>
+
+        <h2>11. Third-Party Services</h2>
+        <p>PlotLink integrates with third-party services including but not limited to Mint Club, Filebase (IPFS), Base network, and Farcaster. PlotLink is not responsible for the availability, accuracy, or conduct of these services.</p>
+
+        <h2>12. No Warranty</h2>
+        <p>PlotLink is provided &ldquo;as is&rdquo; without warranties of any kind, express or implied. We do not guarantee uninterrupted access, error-free operation, or the accuracy of any displayed data (including prices, market caps, or token metrics).</p>
+
+        <h2>13. Limitation of Liability</h2>
+        <p>To the maximum extent permitted by law, PlotLink and its contributors shall not be liable for any indirect, incidental, special, or consequential damages arising from your use of the service, including but not limited to loss of funds, tokens, or data.</p>
+
+        <h2>14. Modification</h2>
+        <p>We may update these terms at any time. Continued use of PlotLink after changes constitutes acceptance.</p>
+
+        <h2>15. Governing Law</h2>
+        <p>These terms are governed by the laws applicable to the user&apos;s jurisdiction. PlotLink does not operate as a registered entity in any specific jurisdiction.</p>
+
+        <h2>16. Contact</h2>
+        <p>For questions about these terms, open an issue at <a href="https://github.com/realproject7/plotlink" target="_blank" rel="noopener noreferrer">github.com/realproject7/plotlink</a>.</p>
+      </article>
+    </div>
+  );
+}

--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -116,6 +116,14 @@ export function ConnectWallet({ onNavigate, compact }: ConnectWalletProps = {}) 
             >
               {compact ? "Connect" : "connect wallet"}
             </button>
+            {!compact && (
+              <p className="text-muted text-[9px] mt-1.5 text-center leading-relaxed">
+                By connecting, you agree to our{" "}
+                <Link href="/terms" className="text-accent hover:underline">Terms</Link>
+                {" "}and{" "}
+                <Link href="/privacy" className="text-accent hover:underline">Privacy Policy</Link>.
+              </p>
+            )}
           </div>
         );
       }}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -30,6 +30,12 @@ export function Footer() {
           >
             github
           </a>
+          <Link href="/terms" className="hover:text-foreground transition-colors">
+            Terms
+          </Link>
+          <Link href="/privacy" className="hover:text-foreground transition-colors">
+            Privacy
+          </Link>
         </div>
         <div className="text-muted text-xs text-center">
           v{version} &middot; Base Mainnet &middot; Made by{" "}


### PR DESCRIPTION
## Summary
- Add `/terms` and `/privacy` pages with full legal content
- Add "Terms" and "Privacy" links to the site footer
- Add wallet connect consent text: "By connecting, you agree to our Terms and Privacy Policy"
- Consent text shown below the connect button (non-compact mode only)

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors)
- [ ] `/terms` page renders correctly
- [ ] `/privacy` page renders correctly
- [ ] Footer shows Terms and Privacy links
- [ ] Wallet connect area shows consent text with working links

Fixes #981