### PR TITLE
[#987] Move Terms/Privacy consent into wallet connect modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -90,7 +90,20 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <WagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>
-        <RainbowKitProvider theme={plotlinkTheme} modalSize="compact">
+        <RainbowKitProvider
+          theme={plotlinkTheme}
+          modalSize="compact"
+          appInfo={{
+            appName: "PlotLink",
+            disclaimer: ({ Text, Link }) => (
+              <Text>
+                By connecting, you agree to our{" "}
+                <Link href="/terms">Terms</Link> and{" "}
+                <Link href="/privacy">Privacy Policy</Link>.
+              </Text>
+            ),
+          }}
+        >
           <Suspense fallback={null}>
             <ReferralCapture />
           </Suspense>

--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -116,14 +116,6 @@ export function ConnectWallet({ onNavigate, compact }: ConnectWalletProps = {}) 
             >
               {compact ? "Connect" : "connect wallet"}
             </button>
-            {!compact && (
-              <p className="text-muted text-[9px] mt-1.5 text-center leading-relaxed">
-                By connecting, you agree to our{" "}
-                <Link href="/terms" className="text-accent hover:underline">Terms</Link>
-                {" "}and{" "}
-                <Link href="/privacy" className="text-accent hover:underline">Privacy Policy</Link>.
-              </p>
-            )}
           </div>
         );
       }}


### PR DESCRIPTION
## Summary

Fixes #987

- Added `appInfo.disclaimer` to `RainbowKitProvider` in `providers.tsx` — consent text with Terms and Privacy links now appears inside the connect modal
- Removed inline consent text from `ConnectWallet.tsx` (was below the connect button)
- Bump 1.1.0 → 1.1.1

## Test plan

- [ ] Open connect modal — consent text appears below wallet options
- [ ] Terms and Privacy links work inside the modal
- [ ] No consent text below the connect button on the page
- [ ] Compact mode connect button unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)