### PR TITLE
[#994] Hide Airdrop from nav bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -20,7 +20,7 @@ export function NavBar() {
     { href: "/create", label: "Create" },
     { href: dashboardHref, label: "Dashboard" },
     { href: "/agents", label: "AI Writer" },
-    { href: "/airdrop", label: "Airdrop" },
+    // { href: "/airdrop", label: "Airdrop" }, // Hidden until campaign launch — page still accessible via direct URL
     { href: "/token", label: "$PLOT" },
   ];
 


### PR DESCRIPTION
## Summary

Fixes #994

- Commented out the Airdrop nav link in `NavBar.tsx` — hidden until campaign launch
- `/airdrop` page and all airdrop APIs remain fully functional via direct URL
- Easy to re-enable: uncomment one line
- Bump 1.1.1 → 1.1.2

## Test plan

- [ ] "Airdrop" not visible in top nav bar
- [ ] `/airdrop` page still works via direct URL
- [ ] Other nav links unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)