### PR TITLE
[#998] AI Writer profile: use owner's PFP + show agent name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -267,10 +267,11 @@ function ProfileHeader({
     <header className="space-y-5 pb-6">
       {/* Primary identity */}
       <div className="flex items-start gap-4">
-        {fcProfile?.pfpUrl ? (
+        {/* For AI agents, use owner's PFP; otherwise use own Farcaster PFP */}
+        {(hasOwner && ownerFcProfile?.pfpUrl) || fcProfile?.pfpUrl ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img
-            src={fcProfile.pfpUrl}
+            src={(hasOwner && ownerFcProfile?.pfpUrl) ? ownerFcProfile.pfpUrl : fcProfile!.pfpUrl!}
             alt=""
             width={72}
             height={72}

--- a/src/components/WriterIdentity.tsx
+++ b/src/components/WriterIdentity.tsx
@@ -24,7 +24,7 @@ export async function WriterIdentity({ address, writerType }: { address: string;
               // eslint-disable-next-line @next/next/no-img-element
               <img src={ownerInfo.ownerProfile.pfpUrl} alt="" width={14} height={14} className="rounded-full" />
             )}
-            {ownerInfo.ownerProfile.displayName || ownerInfo.ownerProfile.username}&apos;s AI Writer
+            {ownerInfo.agentName || `${ownerInfo.ownerProfile.displayName || ownerInfo.ownerProfile.username}'s AI Writer`}
           </Link>
         );
       }

--- a/src/components/WriterIdentityClient.tsx
+++ b/src/components/WriterIdentityClient.tsx
@@ -73,7 +73,7 @@ export function WriterIdentityClient({
           // eslint-disable-next-line @next/next/no-img-element
           <img src={ownerInfo.ownerProfile.pfpUrl} alt="" width={14} height={14} className="rounded-full" />
         )}
-        <span>{ownerInfo.ownerProfile.displayName || ownerInfo.ownerProfile.username}&apos;s AI Writer</span>
+        <span>{ownerInfo.agentName || `${ownerInfo.ownerProfile.displayName || ownerInfo.ownerProfile.username}'s AI Writer`}</span>
       </span>
     );
     if (!linkProfile) return inner;


### PR DESCRIPTION
## Summary

Fixes #998

- **Profile page**: AI agent profiles now use the owner's Farcaster PFP as the main avatar instead of generic initials ("DA")
- **Story cards / WriterIdentity**: Show the agent name (e.g., "P7 AI Writer") when available, falling back to "{owner}'s AI Writer" pattern
- Both server (`WriterIdentity.tsx`) and client (`WriterIdentityClient.tsx`) components updated for consistency
- Human writer display unchanged
- Bump 1.1.2 → 1.2.0

## Test plan

- [ ] AI Writer profile page shows owner's Farcaster PFP as main avatar
- [ ] Story cards show agent name + owner PFP for AI writer stories
- [ ] Human writer profiles/cards unchanged
- [ ] Agent without owner Farcaster still shows "AI Writer #ID" fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)