### PR TITLE
Update airdrop test dates to Apr 27-30

### DIFF
--- a/lib/airdrop/config.ts
+++ b/lib/airdrop/config.ts
@@ -53,8 +53,8 @@ const STREAK_BOOSTS: Record<number, number> = {
 const STREAK_MIN_GAP_MINUTES = 30;
 
 const TEST_CONFIG: AirdropConfig = {
-  CAMPAIGN_START: new Date("2026-06-01"),
-  CAMPAIGN_END: new Date("2026-06-04"),       // start + 3 days
+  CAMPAIGN_START: new Date("2026-04-27"),
+  CAMPAIGN_END: new Date("2026-04-30"),       // start + 3 days
   POOL_AMOUNT: 10,                            // 10 PLOT
   MILESTONES: {
     BRONZE: { mcap: 7_000, pct: 10 },


### PR DESCRIPTION
Set test campaign window to today (Apr 27) through Apr 30 for the 3-day test run.