### PR TITLE
Change lock-up proof link to basescan tx (#1003)

### DIFF
--- a/lib/airdrop/config.ts
+++ b/lib/airdrop/config.ts
@@ -20,7 +20,7 @@ export interface AirdropConfig {
     readonly GOLD: Milestone;
     readonly DIAMOND: Milestone;
   };
-  readonly LOCKER_ID: string | null;
+  readonly LOCKER_TX: string | null;
   readonly POINTS: {
     readonly BUY_PER_PLOT: number;
     readonly REFERRAL_PCT: number;
@@ -62,7 +62,7 @@ const TEST_CONFIG: AirdropConfig = {
     GOLD: { mcap: 35_000, pct: 50 },
     DIAMOND: { mcap: 50_000, pct: 100 },
   },
-  LOCKER_ID: "3882",
+  LOCKER_TX: "0xb4549d21a3a026d215f38d9bf50779fe337254944ae746d008b3b13cd684adce",
   POINTS,
   STREAK_BOOSTS,
   STREAK_MIN_GAP_MINUTES,
@@ -78,7 +78,7 @@ const PROD_CONFIG: AirdropConfig = {
     GOLD: { mcap: 50_000_000, pct: 50 },
     DIAMOND: { mcap: 100_000_000, pct: 100 },
   },
-  LOCKER_ID: null,
+  LOCKER_TX: null,
   POINTS,
   STREAK_BOOSTS,
   STREAK_MIN_GAP_MINUTES,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/api/airdrop/status/route.ts
+++ b/src/app/api/airdrop/status/route.ts
@@ -86,7 +86,7 @@ export async function GET() {
     milestones,
     totalPointsEarned,
     totalParticipants,
-    lockerId: AIRDROP_CONFIG.LOCKER_ID,
+    lockerTx: AIRDROP_CONFIG.LOCKER_TX,
   }, {
     headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=30" },
   });

--- a/src/components/airdrop/CampaignHero.tsx
+++ b/src/components/airdrop/CampaignHero.tsx
@@ -22,7 +22,7 @@ interface StatusData {
   };
   totalPointsEarned: number;
   totalParticipants: number;
-  lockerId: string | null;
+  lockerTx: string | null;
 }
 
 interface DailyPrice {
@@ -634,14 +634,14 @@ export function CampaignHero() {
         </p>
 
         {/* Lock-up proof */}
-        {data.lockerId ? (
+        {data.lockerTx ? (
           <a
-            href={`https://mint.club/locker/${data.lockerId}`}
+            href={`https://basescan.org/tx/${data.lockerTx}`}
             target="_blank"
             rel="noopener noreferrer"
             className="text-accent text-xs hover:underline inline-flex items-center gap-1"
           >
-            <span>&#x1F512;</span> View lock-up proof on Mint Club
+            <span>&#x1F512;</span> View lock-up proof on Basescan
           </a>
         ) : (
           <span className="text-muted text-xs inline-flex items-center gap-1">


### PR DESCRIPTION
## Summary
- Replace `LOCKER_ID` with `LOCKER_TX` in the airdrop config so the lock-up proof can link to the actual basescan transaction instead of a Mint Club URL that has no destination page.
- Update `CampaignHero` to render `https://basescan.org/tx/{lockerTx}` with the label "View lock-up proof on Basescan".
- Test config now points to the existing test lock-up tx; prod stays `null` until the prod lock-up is executed.
- Bumps version to 1.2.1 (3rd-digit bump per CLAUDE.md for bug fixes).

Closes #1003.

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (no new errors)
- [ ] In test mode (`NEXT_PUBLIC_AIRDROP_MODE=test`), `/airdrop` page shows "View lock-up proof on Basescan" linking to `https://basescan.org/tx/0xb4549...4adce`
- [ ] In prod mode, the link is hidden and "Lock-up proof: pending" is shown instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)