### PR TITLE
Simplify points & activity with progressive disclosure (#1012)

### DIFF
--- a/src/components/airdrop/StreakCard.tsx
+++ b/src/components/airdrop/StreakCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useRef, useEffect } from "react";
 import { useAccount, useSignMessage } from "wagmi";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -36,8 +36,7 @@ function getWeekDays(
   lastCheckin: string | null,
 ): DayStatus[] {
   const now = new Date();
-  // Get Monday of the current week (UTC)
-  const todayDow = now.getUTCDay(); // 0=Sun, 1=Mon, ...
+  const todayDow = now.getUTCDay();
   const mondayOffset = todayDow === 0 ? -6 : 1 - todayDow;
   const monday = new Date(now);
   monday.setUTCDate(monday.getUTCDate() + mondayOffset);
@@ -46,7 +45,6 @@ function getWeekDays(
   const todayStr = now.toISOString().slice(0, 10);
   const lastCheckinStr = lastCheckin ? new Date(lastCheckin).toISOString().slice(0, 10) : null;
 
-  // Build set of checked-in dates this week by walking back from lastCheckin
   const checkedDates = new Set<string>();
   if (lastCheckinStr && currentStreak > 0) {
     const lastDate = new Date(lastCheckinStr + "T00:00:00Z");
@@ -54,9 +52,8 @@ function getWeekDays(
       const d = new Date(lastDate);
       d.setUTCDate(d.getUTCDate() - i);
       const ds = d.toISOString().slice(0, 10);
-      // Only include dates in this week
       if (d >= monday) checkedDates.add(ds);
-      else break; // no need to go further back
+      else break;
     }
   }
 
@@ -77,6 +74,57 @@ function getWeekDays(
     }
   }
   return result;
+}
+
+/* ─── Tiers tooltip ─── */
+
+function TiersTooltip({ currentStreak }: { currentStreak: number }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("click", handleClick, true);
+    return () => document.removeEventListener("click", handleClick, true);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="text-muted hover:text-foreground text-[10px] cursor-pointer"
+      >
+        tiers &#9432;
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full mt-1 z-10 bg-surface border-border border rounded p-2.5 shadow-sm min-w-[180px]">
+          <div className="space-y-0.5">
+            {BOOST_TIERS.map((tier) => {
+              const unlocked = currentStreak >= tier.days;
+              return (
+                <div
+                  key={tier.days}
+                  className={`flex items-center justify-between text-[11px] ${
+                    unlocked ? "text-foreground" : "text-muted opacity-60"
+                  }`}
+                >
+                  <span>{tier.days}+ days → +{tier.boost}%</span>
+                  <span>{unlocked ? "✓" : "🔒"}</span>
+                </div>
+              );
+            })}
+          </div>
+          <div className="border-border border-t mt-1.5 pt-1.5">
+            <p className="text-muted text-[9px]">Miss a day → drop one tier</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }
 
 /* ─── Component ─── */
@@ -122,106 +170,57 @@ export function StreakCard({ streak, address }: { streak: StreakData; address: s
     [streak.currentStreak, streak.checkedInToday, streak.lastCheckin],
   );
 
-  // Current tier index for highlight
-  const currentTierIdx = useMemo(() => {
-    for (let i = BOOST_TIERS.length - 1; i >= 0; i--) {
-      if (streak.currentStreak >= BOOST_TIERS[i].days) return i;
-    }
-    return -1;
-  }, [streak.currentStreak]);
-
   return (
-    <div className="border-border rounded border px-3 py-3 space-y-3">
-      {/* Header: streak count + boost tier */}
-      <div className="text-center">
-        <div className="text-foreground text-lg font-bold">
-          &#x26A1; {streak.currentStreak} Day{streak.currentStreak !== 1 ? "s" : ""} Streak
+    <div className="border-border rounded border px-3 py-2.5 space-y-2.5">
+      {/* Compact header: streak + boost + check-in button */}
+      <div className="flex items-center justify-between">
+        <div className="text-foreground text-sm font-bold">
+          &#x26A1; {streak.currentStreak} Day{streak.currentStreak !== 1 ? "s" : ""}
           {streak.boostPercent > 0 && (
-            <span className="text-accent"> &middot; +{streak.boostPercent}% Boost</span>
+            <span className="text-accent font-medium"> · +{streak.boostPercent}%</span>
           )}
         </div>
-        {streak.boostPercent === 0 && streak.nextTier && (
-          <div className="text-muted text-xs">
-            Next: {streak.nextTier.days} days &rarr; +{streak.nextTier.boost * 100}%
-          </div>
-        )}
-      </div>
-
-      {/* Weekly calendar */}
-      <div className="border-border rounded border px-2 py-2">
-        <div className="grid grid-cols-7 gap-1 text-center">
-          {DAY_LABELS.map((label) => (
-            <div key={label} className="text-muted text-[8px] uppercase tracking-wider">
-              {label}
-            </div>
-          ))}
-          {weekDays.map((status, i) => (
-            <div key={i} className="flex justify-center">
-              <DayDot status={status} />
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {/* Check In button */}
-      <div className="text-center">
         <button
           type="button"
           onClick={handleCheckIn}
           disabled={streak.checkedInToday || checking}
-          className="bg-accent text-white rounded px-4 py-1.5 text-xs font-medium disabled:opacity-50 cursor-pointer"
+          className="bg-accent text-white rounded px-3 py-1 text-xs font-medium disabled:opacity-50 cursor-pointer"
         >
           {streak.checkedInToday
-            ? "Checked in today \u2713"
+            ? "✓ Done"
             : checking
-              ? "Signing..."
+              ? "..."
               : "Check In"}
         </button>
       </div>
 
-      {error && <div className="text-error text-xs text-center">{error}</div>}
-
-      {/* Boost tiers table */}
-      <div className="border-border rounded border px-2 py-2">
-        <div className="text-muted text-[10px] font-medium uppercase tracking-wider mb-1.5">
-          Boost Tiers
-        </div>
-        <div className="space-y-0.5">
-          {BOOST_TIERS.map((tier, i) => {
-            const unlocked = streak.currentStreak >= tier.days;
-            const isCurrent = i === currentTierIdx;
-            return (
-              <div
-                key={tier.days}
-                className={`grid grid-cols-[1fr_auto_auto] items-center text-xs px-2 py-0.5 rounded gap-x-3 ${
-                  isCurrent
-                    ? "bg-accent/10 text-foreground font-medium"
-                    : unlocked
-                      ? "text-foreground"
-                      : "text-muted opacity-60"
-                }`}
-              >
-                <span>{tier.days}+ days</span>
-                <span>+{tier.boost}%</span>
-                <span className="w-14 text-right text-[10px]">
-                  {isCurrent ? (
-                    <span className="text-accent font-medium">&larr; active</span>
-                  ) : unlocked ? (
-                    <span>&check;</span>
-                  ) : (
-                    <span>&#x1F512;</span>
-                  )}
-                </span>
-              </div>
-            );
-          })}
-        </div>
-        <div className="border-border border-t mt-1.5 pt-1.5">
-          <p className="text-muted text-[9px]">
-            Miss a day &rarr; drop one tier
-          </p>
-        </div>
+      {/* Weekly calendar */}
+      <div className="grid grid-cols-7 gap-1 text-center">
+        {DAY_LABELS.map((label) => (
+          <div key={label} className="text-muted text-[8px] uppercase tracking-wider">
+            {label}
+          </div>
+        ))}
+        {weekDays.map((status, i) => (
+          <div key={i} className="flex justify-center">
+            <DayDot status={status} />
+          </div>
+        ))}
       </div>
+
+      {/* Next tier + tiers tooltip */}
+      <div className="flex items-center justify-between">
+        {streak.nextTier ? (
+          <div className="text-muted text-[10px]">
+            Next: {streak.nextTier.days} days → +{streak.nextTier.boost * 100}%
+          </div>
+        ) : (
+          <div className="text-accent text-[10px] font-medium">Max boost reached!</div>
+        )}
+        <TiersTooltip currentStreak={streak.currentStreak} />
+      </div>
+
+      {error && <div className="text-error text-xs text-center">{error}</div>}
     </div>
   );
 }

--- a/src/components/airdrop/UserPoints.tsx
+++ b/src/components/airdrop/UserPoints.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo, useRef, useEffect } from "react";
 import { useAccount, useSignMessage } from "wagmi";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { StreakCard } from "./StreakCard";
@@ -31,6 +31,13 @@ interface PointsData {
 
 interface StatusData {
   latestPriceUsd: number | null;
+  milestones: {
+    bronze: { mcap: number; pct: number; reached: boolean };
+    silver: { mcap: number; pct: number; reached: boolean };
+    gold: { mcap: number; pct: number; reached: boolean };
+    diamond: { mcap: number; pct: number; reached: boolean };
+  };
+  currentFdv: number;
 }
 
 const ACTIONS: { key: keyof PointsData["breakdown"]; label: string }[] = [
@@ -39,6 +46,8 @@ const ACTIONS: { key: keyof PointsData["breakdown"]; label: string }[] = [
   { key: "write", label: "Writing" },
   { key: "rate", label: "Rating" },
 ];
+
+const TIER_KEYS = ["bronze", "silver", "gold", "diamond"] as const;
 
 function useAirdropPoints(address: string | undefined) {
   return useQuery<PointsData>({
@@ -52,6 +61,46 @@ function useAirdropPoints(address: string | undefined) {
     staleTime: 60_000,
     refetchInterval: 60_000,
   });
+}
+
+function formatCompact(val: number): string {
+  if (val >= 1_000_000) return `$${(val / 1_000_000).toFixed(0)}M`;
+  if (val >= 1_000) return `$${(val / 1_000).toFixed(0)}K`;
+  return `$${val.toFixed(0)}`;
+}
+
+/* ─── Tooltip component ─── */
+
+function InfoTooltip({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("click", handleClick, true);
+    return () => document.removeEventListener("click", handleClick, true);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="text-muted hover:text-foreground text-[11px] ml-1 cursor-pointer"
+        aria-label="Show details"
+      >
+        &#9432;
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full mt-1 z-10 bg-surface border-border border rounded p-2.5 shadow-sm min-w-[240px] text-xs">
+          {children}
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function UserPoints() {
@@ -71,8 +120,8 @@ export function UserPoints() {
 function UserPointsInner({ address }: { address: string }) {
   const { data, isLoading } = useAirdropPoints(address);
   const { profile: farcasterProfile } = useConnectedIdentity();
+  const [breakdownOpen, setBreakdownOpen] = useState(false);
 
-  // Fetch latest price for USD estimates
   const { data: statusData } = useQuery<StatusData>({
     queryKey: ["airdrop-status"],
     queryFn: async () => {
@@ -82,6 +131,21 @@ function UserPointsInner({ address }: { address: string }) {
     },
     staleTime: 60_000,
   });
+
+  const currentEstimate = useMemo(() => {
+    if (!data || !statusData) return null;
+    const currentFdv = statusData.currentFdv;
+    const price = statusData.latestPriceUsd;
+    let key: (typeof TIER_KEYS)[number] = "bronze";
+    for (let i = TIER_KEYS.length - 1; i >= 0; i--) {
+      if (currentFdv >= statusData.milestones[TIER_KEYS[i]].mcap) {
+        key = TIER_KEYS[i];
+        break;
+      }
+    }
+    const amount = data.estimatedAirdrop[key];
+    return { amount, usd: price && amount > 0 ? amount * price : null };
+  }, [data, statusData]);
 
   if (isLoading || !data) {
     return (
@@ -103,58 +167,77 @@ function UserPointsInner({ address }: { address: string }) {
             <div className="text-foreground text-xl font-bold">{data.totalPoints.toLocaleString()}</div>
           </div>
           <div className="text-right">
-            <div className="text-muted text-[10px]">Your share</div>
+            <div className="text-muted text-[10px]">Share</div>
             <div className="text-foreground text-sm font-medium">{data.sharePercent.toFixed(2)}%</div>
           </div>
         </div>
 
-        {/* Estimated airdrop */}
-        <div className="text-muted text-[10px] mt-2 space-y-0.5">
-          {([
-            { key: "bronze", label: "\uD83E\uDD49 Bronze" },
-            { key: "silver", label: "\uD83E\uDD48 Silver" },
-            { key: "gold", label: "\uD83E\uDD47 Gold" },
-            { key: "diamond", label: "\uD83D\uDC8E Diamond" },
-          ] as const).map(({ key, label }) => {
-            const amount = data.estimatedAirdrop[key];
-            const usdVal = price && amount > 0 ? formatUsdValue(amount * price) : null;
-            return (
-              <div key={key}>
-                Est. if {label}:{" "}
-                <span className="text-foreground font-medium">
-                  {amount.toLocaleString()} PLOT
-                </span>
-                {usdVal && <span className="text-muted"> ({usdVal})</span>}
+        {/* Single estimated airdrop line + tooltip */}
+        {currentEstimate && (
+          <div className="mt-2 text-xs">
+            <span className="text-muted">Est. airdrop: </span>
+            <span className="text-foreground font-medium">
+              {currentEstimate.amount.toLocaleString()} PLOT
+            </span>
+            {currentEstimate.usd && (
+              <span className="text-muted"> (~{formatUsdValue(currentEstimate.usd)})</span>
+            )}
+            <InfoTooltip>
+              <div className="space-y-1">
+                {TIER_KEYS.map((key) => {
+                  const amount = data.estimatedAirdrop[key];
+                  const fdv = statusData?.milestones[key].mcap ?? 0;
+                  const usdVal = price && amount > 0 ? formatUsdValue(amount * price) : null;
+                  return (
+                    <div key={key} className="text-muted">
+                      At {formatCompact(fdv)} FDV →{" "}
+                      <span className="text-foreground font-medium">
+                        {amount.toLocaleString()} PLOT
+                      </span>
+                      {usdVal && <span> (~{usdVal})</span>}
+                    </div>
+                  );
+                })}
               </div>
-            );
-          })}
-        </div>
+            </InfoTooltip>
+            <div className="text-muted text-[10px] mt-0.5">(based on current FDV)</div>
+          </div>
+        )}
       </div>
 
       {/* Streak card */}
       <StreakCard streak={data.streak} address={address} />
 
-      {/* Point breakdown */}
-      <div className="border-border rounded border px-3 py-3">
-        <div className="text-muted text-xs mb-2">Breakdown</div>
-        <div className="space-y-1">
-          {ACTIONS.map(({ key, label }) => {
-            const pts = data.breakdown[key];
-            const pct = data.totalPoints > 0 ? Math.round((pts / data.totalPoints) * 100) : 0;
-            return (
-              <div key={key} className="flex items-center justify-between text-xs">
-                <span className="text-foreground">{label}</span>
-                <span className="text-foreground font-medium">
-                  {pts.toLocaleString()} PL
-                  <span className="text-muted ml-1">({pct}%)</span>
-                  {data.streak.boostPercent > 0 && pts > 0 && (
-                    <span className="text-accent ml-1">+{data.streak.boostPercent}%</span>
-                  )}
-                </span>
-              </div>
-            );
-          })}
-        </div>
+      {/* Point breakdown — collapsed by default */}
+      <div className="border-border rounded border px-3 py-2.5">
+        <button
+          type="button"
+          onClick={() => setBreakdownOpen(!breakdownOpen)}
+          className="w-full flex items-center justify-between text-muted text-xs cursor-pointer"
+        >
+          <span>Breakdown</span>
+          <span className="text-[10px]">{breakdownOpen ? "▾" : "▸"}</span>
+        </button>
+        {breakdownOpen && (
+          <div className="space-y-1 mt-2">
+            {ACTIONS.map(({ key, label }) => {
+              const pts = data.breakdown[key];
+              const pct = data.totalPoints > 0 ? Math.round((pts / data.totalPoints) * 100) : 0;
+              return (
+                <div key={key} className="flex items-center justify-between text-xs">
+                  <span className="text-foreground">{label}</span>
+                  <span className="text-foreground font-medium">
+                    {pts.toLocaleString()} PL
+                    <span className="text-muted ml-1">({pct}%)</span>
+                    {data.streak.boostPercent > 0 && pts > 0 && (
+                      <span className="text-accent ml-1">+{data.streak.boostPercent}%</span>
+                    )}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
       </div>
 
       {/* Referral section */}
@@ -232,7 +315,6 @@ function ReferralSection({
     }
   };
 
-  // Generate referral code via Farcaster username
   const handleUseFarcaster = async () => {
     setError("");
     setSubmitting(true);
@@ -261,80 +343,74 @@ function ReferralSection({
   };
 
   return (
-    <div className="border-border rounded border px-3 py-3 space-y-2">
-      <div className="text-muted text-xs">Referral</div>
-
-      {/* Referred by */}
-      {referral.referredBy ? (
-        <div className="text-xs">
-          <span className="text-muted">Referred by: </span>
-          <span className="text-foreground font-mono">{referral.referredBy}</span>
-        </div>
-      ) : (
-        <div>
-          <div className="text-muted text-[10px] mb-1">Who referred you?</div>
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={referrerCode}
-              onChange={(e) => setReferrerCode(e.target.value)}
-              placeholder="Enter referral code"
-              className="bg-surface border-border text-foreground placeholder:text-muted flex-1 rounded border px-2 py-1 text-xs font-mono focus:border-accent focus:outline-none"
-            />
-            <button
-              type="button"
-              onClick={handleSetReferrer}
-              disabled={!referrerCode.trim() || submitting}
-              className="bg-accent text-bg rounded px-3 py-1 text-xs font-medium disabled:opacity-50 cursor-pointer"
-            >
-              {submitting ? "..." : "Set"}
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/* Your referral link */}
+    <div className="border-border rounded border px-3 py-2.5 space-y-2">
+      {/* Referral link + actions */}
       {referralLink ? (
         <div>
-          <div className="text-muted text-[10px] mb-1">Your referral link</div>
-          <div className="bg-surface border-border rounded border px-2 py-1.5 text-xs font-mono text-foreground break-all">
-            {referralLink}
-          </div>
-          <div className="flex gap-2 mt-1">
+          <div className="flex items-center gap-2 text-xs">
+            <span className="text-muted">&#x1F517;</span>
+            <span className="text-foreground font-mono text-[11px] truncate flex-1">
+              {referralLink}
+            </span>
             <button
               type="button"
               onClick={handleCopy}
-              className="text-accent text-xs hover:underline cursor-pointer"
+              className="text-accent text-xs hover:underline cursor-pointer shrink-0"
             >
               {copied ? "Copied!" : "Copy"}
             </button>
             <button
               type="button"
               onClick={handleShare}
-              className="text-accent text-xs hover:underline cursor-pointer"
+              className="text-accent text-xs hover:underline cursor-pointer shrink-0"
             >
-              Share on X
+              &#x1D54F;
             </button>
           </div>
+          <div className="text-[10px] text-muted mt-1">
+            {referral.referredUsersCount} referred
+            {referral.referredBy && (
+              <span>
+                {" · "}Referred by: <span className="text-foreground font-mono">{referral.referredBy}</span>
+              </span>
+            )}
+          </div>
         </div>
-      ) : hasFarcaster ? (
-        <div>
+      ) : (
+        <div className="space-y-2">
+          {hasFarcaster && (
+            <button
+              type="button"
+              onClick={handleUseFarcaster}
+              disabled={submitting}
+              className="text-accent text-xs hover:underline cursor-pointer disabled:opacity-50"
+            >
+              Use Farcaster username as referral code
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Referred by input (only if not yet set) */}
+      {!referral.referredBy && (
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={referrerCode}
+            onChange={(e) => setReferrerCode(e.target.value)}
+            placeholder="Who referred you?"
+            className="bg-surface border-border text-foreground placeholder:text-muted flex-1 rounded border px-2 py-1 text-xs font-mono focus:border-accent focus:outline-none"
+          />
           <button
             type="button"
-            onClick={handleUseFarcaster}
-            disabled={submitting}
-            className="text-accent text-xs hover:underline cursor-pointer disabled:opacity-50"
+            onClick={handleSetReferrer}
+            disabled={!referrerCode.trim() || submitting}
+            className="bg-accent text-bg rounded px-3 py-1 text-xs font-medium disabled:opacity-50 cursor-pointer"
           >
-            Use Farcaster username as referral code
+            {submitting ? "..." : "Set"}
           </button>
         </div>
-      ) : null}
-
-      {/* Referred users count */}
-      <div className="text-xs">
-        <span className="text-muted">Referred users: </span>
-        <span className="text-foreground font-medium">{referral.referredUsersCount}</span>
-      </div>
+      )}
 
       {error && <div className="text-error text-xs">{error}</div>}
     </div>

--- a/src/components/airdrop/UserPoints.tsx
+++ b/src/components/airdrop/UserPoints.tsx
@@ -47,6 +47,7 @@ const ACTIONS: { key: keyof PointsData["breakdown"]; label: string }[] = [
   { key: "rate", label: "Rating" },
 ];
 
+const MAX_SUPPLY = 1_000_000;
 const TIER_KEYS = ["bronze", "silver", "gold", "diamond"] as const;
 
 function useAirdropPoints(address: string | undefined) {
@@ -155,8 +156,6 @@ function UserPointsInner({ address }: { address: string }) {
     );
   }
 
-  const price = statusData?.latestPriceUsd ?? null;
-
   return (
     <div className="space-y-3">
       {/* Points summary */}
@@ -187,14 +186,15 @@ function UserPointsInner({ address }: { address: string }) {
                 {TIER_KEYS.map((key) => {
                   const amount = data.estimatedAirdrop[key];
                   const fdv = statusData?.milestones[key].mcap ?? 0;
-                  const usdVal = price && amount > 0 ? formatUsdValue(amount * price) : null;
+                  const scenarioPrice = fdv / MAX_SUPPLY;
+                  const scenarioUsd = amount > 0 ? formatUsdValue(amount * scenarioPrice) : null;
                   return (
                     <div key={key} className="text-muted">
                       At {formatCompact(fdv)} FDV →{" "}
                       <span className="text-foreground font-medium">
                         {amount.toLocaleString()} PLOT
                       </span>
-                      {usdVal && <span> (~{usdVal})</span>}
+                      {scenarioUsd && <span> (~{scenarioUsd})</span>}
                     </div>
                   );
                 })}


### PR DESCRIPTION
## Summary
- **Estimated airdrop**: single number based on current FDV milestone, with ⓘ tooltip showing all 4 FDV scenarios (no tier names — uses "$1M/$10M/$50M/$100M")
- **Breakdown**: collapsed by default, click "Breakdown ▸" to expand
- **Streak card**: compact single-row header (⚡ 14 Days · +10% [Check In]), calendar preserved, boost tiers hidden behind "tiers ⓘ" tooltip
- **Referral**: compact inline layout with link + copy + share on one line, referred-by inline

Closes #1012

## Test plan
- [ ] Points summary shows single estimate with "(based on current FDV)" note
- [ ] ⓘ tooltip on estimate shows 4 FDV scenarios with correct amounts
- [ ] Breakdown collapsed by default, expands/collapses on click
- [ ] Streak header shows streak count + boost + check-in button in one row
- [ ] "tiers ⓘ" tooltip shows all 5 boost tiers with lock/unlock status
- [ ] Check-in button works (wallet signature flow)
- [ ] Referral link, copy, and share-on-X work
- [ ] No tier names (Bronze/Silver/Gold/Diamond) visible anywhere
- [ ] Responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)