### PR TITLE
Add innovation banner — conditional airdrop explainer (#1013)

### DIFF
--- a/src/app/airdrop/page.tsx
+++ b/src/app/airdrop/page.tsx
@@ -4,6 +4,7 @@ import { UserPoints } from "../../components/airdrop/UserPoints";
 import { ClaimPanel } from "../../components/airdrop/ClaimPanel";
 import { Leaderboard } from "../../components/airdrop/Leaderboard";
 import { WeeklySnapshots } from "../../components/airdrop/WeeklySnapshots";
+import { InnovationBanner } from "../../components/airdrop/InnovationBanner";
 import { AIRDROP_CONFIG } from "../../../lib/airdrop/config";
 
 export const metadata: Metadata = {
@@ -18,6 +19,11 @@ export default function AirdropPage() {
     <main className="mx-auto max-w-5xl px-6 py-8 pb-24 lg:pb-8">
       {/* Hero spans full width */}
       <CampaignHero />
+
+      {/* Innovation banner — between hero and user sections */}
+      <div className="mt-6">
+        <InnovationBanner />
+      </div>
 
       {/* 2-column grid below hero */}
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]">

--- a/src/components/airdrop/InnovationBanner.tsx
+++ b/src/components/airdrop/InnovationBanner.tsx
@@ -1,0 +1,60 @@
+const COLUMNS = [
+  {
+    title: "TYPICAL AIRDROP",
+    rows: ["Fixed amount", "Dumps on listing", "No skin in game"],
+    highlighted: false,
+  },
+  {
+    title: "TYPICAL STAKING",
+    rows: ["Fixed APY", "Inflates supply", "No risk reward"],
+    highlighted: false,
+  },
+  {
+    title: "THIS AIRDROP",
+    rows: ["Pool grows with market", "Burned if no growth", "Everyone wins together"],
+    highlighted: true,
+  },
+] as const;
+
+export function InnovationBanner() {
+  return (
+    <div className="border-border rounded border p-5 space-y-4">
+      <div className="text-muted text-[10px] font-bold uppercase tracking-widest text-center font-mono">
+        ── How is this different? ──
+      </div>
+
+      {/* Three-column comparison */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {COLUMNS.map((col) => (
+          <div
+            key={col.title}
+            className={`rounded border px-4 py-3 space-y-2 ${
+              col.highlighted
+                ? "border-accent text-foreground"
+                : "border-border text-muted opacity-50"
+            }`}
+          >
+            <div className="text-[10px] font-bold uppercase tracking-wider font-mono text-center">
+              {col.title}
+            </div>
+            <div className="space-y-1.5">
+              {col.rows.map((row) => (
+                <div key={row} className="text-xs text-center font-mono">
+                  {row}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Summary */}
+      <p className="text-muted text-xs leading-relaxed max-w-xl mx-auto text-center font-mono">
+        The pool isn&apos;t pre-valued — it&apos;s valued <span className="text-foreground font-medium">by the market</span>.
+        At $100M FDV, 50,000 PLOT = $5M distributed.
+        At $0 growth, 50,000 PLOT = burned forever.
+        Everyone — team, holders, earners — wins only if PLOT grows.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `InnovationBanner.tsx` component with three-column comparison: Typical Airdrop vs Typical Staking vs This Airdrop
- First two columns dimmed (opacity-50, muted border), third column accent-highlighted
- Summary paragraph below: "The pool isn't pre-valued — it's valued by the market"
- Placed between CampaignHero and the user/leaderboard grid in `airdrop/page.tsx`
- Monospace font throughout, responsive (3-col desktop, stacked mobile)

Closes #1013

## Test plan
- [ ] Three columns render with correct content
- [ ] First two columns visually dimmed, third has accent border
- [ ] Summary paragraph readable and properly styled
- [ ] Responsive: 3-col on desktop (sm+), stacked on mobile
- [ ] Monospace font consistent with site aesthetic
- [ ] Banner positioned between hero and user sections
- [ ] No layout regressions on other airdrop page sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)