### PR TITLE
[#1017] Hide CMC rank references in test mode

### DIFF
--- a/lib/airdrop/config.ts
+++ b/lib/airdrop/config.ts
@@ -86,5 +86,7 @@ const PROD_CONFIG: AirdropConfig = {
 
 const mode = process.env.NEXT_PUBLIC_AIRDROP_MODE ?? "prod";
 
+export const AIRDROP_TEST_MODE = mode === "test";
+
 export const AIRDROP_CONFIG: AirdropConfig =
-  mode === "test" ? TEST_CONFIG : PROD_CONFIG;
+  AIRDROP_TEST_MODE ? TEST_CONFIG : PROD_CONFIG;

--- a/src/components/airdrop/CampaignHero.tsx
+++ b/src/components/airdrop/CampaignHero.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { formatUsdValue } from "../../../lib/usd-price";
+import { AIRDROP_TEST_MODE } from "../../../lib/airdrop/config";
 
 /* ─── Types ─── */
 
@@ -101,7 +102,7 @@ function buildMilestoneRows(
       unlockPlot,
       poolUsd: unlockPlot * price,
       burnPct: 100 - ms.pct,
-      cmcRank: CMC_RANKS[i] ?? null,
+      cmcRank: AIRDROP_TEST_MODE ? null : (CMC_RANKS[i] ?? null),
       isFull: ms.pct === 100,
     };
   });


### PR DESCRIPTION
Fixes #1017

## Summary
- Export `AIRDROP_TEST_MODE` from `lib/airdrop/config.ts` for client-side test/prod detection
- In `CampaignHero.tsx`, conditionally null out `cmcRank` when in test mode so "≈ CMC #X" labels don't render alongside tiny test FDV values ($7K–$50K)
- Prod mode unchanged — CMC ranks (#1900/#950/#400/#250) display normally

## Test plan
- [ ] Set `NEXT_PUBLIC_AIRDROP_MODE=test` → verify milestone rows show no CMC rank text
- [ ] Set `NEXT_PUBLIC_AIRDROP_MODE=prod` (or unset) → verify CMC ranks display next to each FDV milestone
- [ ] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)