### PR TITLE
[#1018] Rename FDV → MCap across airdrop UI

### DIFF
--- a/src/components/airdrop/CampaignHero.tsx
+++ b/src/components/airdrop/CampaignHero.tsx
@@ -184,7 +184,7 @@ function BurnBar({
 
       <div className="flex items-center justify-between text-xs">
         <span className="text-muted">
-          Current FDV: {currentFdv > 0 ? formatUsdValue(currentFdv) : "—"}
+          Current MCap: {currentFdv > 0 ? formatUsdValue(currentFdv) : "—"}
         </span>
         <span className="text-foreground font-bold">
           Pool value right now: {poolUsd > 0 ? formatUsdValue(poolUsd) : "$0"}
@@ -300,7 +300,7 @@ export function CampaignHero() {
               >
                 <div>
                   <span className="text-foreground font-bold">
-                    FDV {formatCompact(row.fdv)}
+                    MCap {formatCompact(row.fdv)}
                   </span>
                   {row.cmcRank && (
                     <span className="text-muted text-[10px] ml-1.5">{row.cmcRank}</span>
@@ -336,6 +336,11 @@ export function CampaignHero() {
         {data.totalParticipants > 0
           ? `${data.totalParticipants} participants earning`
           : "Be the first to participate"}
+      </div>
+
+      {/* ── MCap explanation footnote ── */}
+      <div className="text-center text-muted text-[10px]">
+        MCap = PLOT price × 1M max supply
       </div>
     </div>
   );

--- a/src/components/airdrop/UserPoints.tsx
+++ b/src/components/airdrop/UserPoints.tsx
@@ -190,7 +190,7 @@ function UserPointsInner({ address }: { address: string }) {
                   const scenarioUsd = amount > 0 ? formatUsdValue(amount * scenarioPrice) : null;
                   return (
                     <div key={key} className="text-muted">
-                      At {formatCompact(fdv)} FDV →{" "}
+                      At {formatCompact(fdv)} MCap →{" "}
                       <span className="text-foreground font-medium">
                         {amount.toLocaleString()} PLOT
                       </span>
@@ -200,7 +200,7 @@ function UserPointsInner({ address }: { address: string }) {
                 })}
               </div>
             </InfoTooltip>
-            <div className="text-muted text-[10px] mt-0.5">(based on current FDV)</div>
+            <div className="text-muted text-[10px] mt-0.5">(based on current MCap)</div>
           </div>
         )}
       </div>

--- a/src/components/airdrop/WeeklySnapshots.tsx
+++ b/src/components/airdrop/WeeklySnapshots.tsx
@@ -93,7 +93,7 @@ export function WeeklySnapshots() {
                   <span className="text-foreground">{snap.newReferrals}</span>
                 </div>
                 <div className="text-muted">
-                  FDV:{" "}
+                  MCap:{" "}
                   <span className="text-foreground">
                     {formatUsdValue(snap.mcapStart)} → {formatUsdValue(snap.mcapEnd)}
                   </span>{" "}


### PR DESCRIPTION
Fixes #1018

## Summary
- Replaced all user-facing "FDV" labels with "MCap" across 3 airdrop components
- Added footnote in CampaignHero: "MCap = PLOT price × 1M max supply"
- Internal variable names (`currentFdv`, `mcap` in config) left unchanged — display-only change

### Files changed
- `CampaignHero.tsx` — burn bar "Current MCap", milestone rows "MCap $X", footnote
- `UserPoints.tsx` — "At $X MCap →" and "(based on current MCap)"
- `WeeklySnapshots.tsx` — "MCap:" label

## Test plan
- [ ] All airdrop pages show "MCap" instead of "FDV"
- [ ] MCap footnote visible at bottom of CampaignHero
- [ ] No API contract changes — `currentFdv` still used internally
- [ ] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)