### PR TITLE
Milestone cards: prod values, icons, CMC rank (#1027)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/airdrop/CampaignHero.tsx
+++ b/src/components/airdrop/CampaignHero.tsx
@@ -24,6 +24,13 @@ interface StatusData {
   lockerTx: string | null;
 }
 
+const MILESTONE_CARDS = [
+  { mcap: 1_000_000, label: "$1M", cmcRank: "#1900", pct: 10, key: "bronze" as const },
+  { mcap: 10_000_000, label: "$10M", cmcRank: "#950", pct: 30, key: "silver" as const },
+  { mcap: 50_000_000, label: "$50M", cmcRank: "#400", pct: 50, key: "gold" as const },
+  { mcap: 100_000_000, label: "$100M", cmcRank: "#250", pct: 100, key: "diamond" as const },
+];
+
 /* ─── Helpers ─── */
 
 function useAirdropStatus() {
@@ -125,6 +132,39 @@ export function CampaignHero() {
           ))}
         </div>
       )}
+
+      {/* ── Milestone cards ── */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        {MILESTONE_CARDS.map((ms) => {
+          const reached = data.currentFdv >= ms.mcap;
+          return (
+            <div
+              key={ms.key}
+              className={`rounded border px-3 py-3 space-y-1.5 ${
+                reached ? "border-accent" : "border-border opacity-60"
+              }`}
+            >
+              <div className="text-sm">
+                {reached ? (
+                  <span className="text-accent">&#x2705;</span>
+                ) : (
+                  <span className="text-muted">&#x25CB;</span>
+                )}
+              </div>
+              <div className={`text-sm font-bold text-center ${reached ? "text-accent" : "text-foreground"}`}>
+                {ms.label}
+              </div>
+              <div className="text-muted text-[10px] text-center">
+                ≈ CMC {ms.cmcRank}
+              </div>
+              <div className="text-muted text-[10px] text-center">unlocks</div>
+              <div className={`text-xs font-bold text-center ${reached ? "text-accent" : "text-foreground"}`}>
+                {ms.pct}%
+              </div>
+            </div>
+          );
+        })}
+      </div>
 
       {/* ── Participant count ── */}
       <div className="text-center text-muted text-xs">


### PR DESCRIPTION
## Summary
- Adds 4-column milestone card grid below headline/countdown showing $1M / $10M / $50M / $100M (hardcoded prod values)
- Each card displays: status icon (green checkmark if reached, pending circle if not), MCap target, approximate CMC rank, and unlock percentage
- Responsive layout: 2×2 on mobile, 4-col on desktop
- Milestone reached status determined by comparing `currentFdv` against prod MCap thresholds

Closes #1027

## Test plan
- [ ] Cards show $1M / $10M / $50M / $100M with correct unlock percentages (10/30/50/100%)
- [ ] CMC ranks display correctly (#1900/#950/#400/#250)
- [ ] Checkmark icon shows for reached milestones, pending circle for unreached
- [ ] Cards placed below headline/countdown, above participant count
- [ ] Responsive: 4-col desktop, 2×2 mobile
- [ ] No layout breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)