### PR TITLE
Move participant count from hero to Leaderboard (#1036)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/airdrop/CampaignHero.tsx
+++ b/src/components/airdrop/CampaignHero.tsx
@@ -306,13 +306,6 @@ export function CampaignHero() {
       {/* ── MCap progress chart ── */}
       <MCapChart currentFdv={data.currentFdv} />
 
-      {/* ── Participant count ── */}
-      <div className="text-center text-muted text-xs">
-        {data.totalParticipants > 0
-          ? `${data.totalParticipants} participants earning`
-          : "Be the first to participate"}
-      </div>
-
       {/* ── MCap explanation footnote ── */}
       <div className="text-center text-muted text-[10px]">
         MCap = PLOT price × 1M max supply

--- a/src/components/airdrop/Leaderboard.tsx
+++ b/src/components/airdrop/Leaderboard.tsx
@@ -57,7 +57,10 @@ export function Leaderboard() {
 
   return (
     <div className="border-border rounded border p-4">
-      <h3 className="text-foreground text-sm font-bold mb-3">Leaderboard</h3>
+      <h3 className="text-foreground text-sm font-bold">Leaderboard</h3>
+      <div className="text-muted text-xs mb-3">
+        {data.entries.length} {data.entries.length === 1 ? "participant" : "participants"}
+      </div>
 
       <div className="overflow-x-auto">
         <table className="w-full text-xs">


### PR DESCRIPTION
## Summary
- Removes participant count ("X participants earning") from CampaignHero
- Adds participant count as subtitle below Leaderboard section title, format: "X participants"
- Count derived from leaderboard entries length

Closes #1036

## Test plan
- [ ] Participant count no longer appears in hero section
- [ ] Participant count appears below Leaderboard title
- [ ] Correct singular/plural ("1 participant" vs "3 participants")
- [ ] No layout breakage in hero or leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)