### PR TITLE
[#1040] Fix participant count using total from API

### DIFF
--- a/src/app/api/airdrop/leaderboard/route.ts
+++ b/src/app/api/airdrop/leaderboard/route.ts
@@ -20,7 +20,7 @@ export async function GET(req: NextRequest) {
     .select("address, points");
 
   if (!allPoints || allPoints.length === 0) {
-    return NextResponse.json({ entries: [], userRank: null });
+    return NextResponse.json({ entries: [], userRank: null, totalParticipants: 0 });
   }
 
   // Sum points by address
@@ -63,7 +63,7 @@ export async function GET(req: NextRequest) {
     userRank = idx >= 0 ? idx + 1 : null;
   }
 
-  return NextResponse.json({ entries, userRank }, {
+  return NextResponse.json({ entries, userRank, totalParticipants: pointsByAddress.size }, {
     headers: { "Cache-Control": "public, s-maxage=30, stale-while-revalidate=15" },
   });
 }

--- a/src/components/airdrop/Leaderboard.tsx
+++ b/src/components/airdrop/Leaderboard.tsx
@@ -14,6 +14,7 @@ interface LeaderboardEntry {
 interface LeaderboardData {
   entries: LeaderboardEntry[];
   userRank: number | null;
+  totalParticipants: number;
 }
 
 function truncateAddress(addr: string) {
@@ -59,7 +60,7 @@ export function Leaderboard() {
     <div className="border-border rounded border p-4">
       <h3 className="text-foreground text-sm font-bold">Leaderboard</h3>
       <div className="text-muted text-xs mb-3">
-        {data.entries.length} {data.entries.length === 1 ? "participant" : "participants"}
+        {data.totalParticipants} {data.totalParticipants === 1 ? "participant" : "participants"}
       </div>
 
       <div className="overflow-x-auto">


### PR DESCRIPTION
## Summary
- Add `totalParticipants` (from `pointsByAddress.size`) to leaderboard API response
- Update Leaderboard component to display `data.totalParticipants` instead of `data.entries.length`
- Fixes participant count being capped at 50 (the top-N slice limit)

Fixes #1040

## Test plan
- [ ] Verify `/api/airdrop/leaderboard` response includes `totalParticipants` field
- [ ] Verify leaderboard UI shows correct total when >50 participants exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)