### PR TITLE
[#1042] Move heartbeat dot into SVG

### DIFF
--- a/src/components/airdrop/CampaignHero.tsx
+++ b/src/components/airdrop/CampaignHero.tsx
@@ -186,23 +186,31 @@ function MCapChart({ currentFdv }: { currentFdv: number }) {
             strokeWidth={2}
           />
         )}
+
+        {/* Heartbeat dot — inside SVG for pixel-perfect alignment */}
+        {progress > 0 && (
+          <>
+            <circle cx={fillX} cy={svgH / 2} r={8} fill="#00ff88" opacity={0.75}>
+              <animate
+                attributeName="r"
+                values="8;16;8"
+                dur="1.5s"
+                repeatCount="indefinite"
+              />
+              <animate
+                attributeName="opacity"
+                values="0.75;0;0.75"
+                dur="1.5s"
+                repeatCount="indefinite"
+              />
+            </circle>
+            <circle cx={fillX} cy={svgH / 2} r={6} fill="#00ff88" />
+          </>
+        )}
       </svg>
 
-      {/* Heartbeat dot — positioned via CSS over the SVG */}
-      <div className="relative -mt-[52px] pointer-events-none" style={{ height: 0 }}>
-        <div
-          className="absolute top-0 -translate-x-1/2 -translate-y-1/2"
-          style={{ left: `${progress * 100}%`, top: 0 }}
-        >
-          <span className="relative flex h-3 w-3">
-            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent opacity-75" />
-            <span className="relative inline-flex rounded-full h-3 w-3 bg-accent" />
-          </span>
-        </div>
-      </div>
-
       {/* Scale labels */}
-      <div className="flex justify-between text-[10px] text-muted font-mono mt-6">
+      <div className="flex justify-between text-[10px] text-muted font-mono mt-1">
         <span>$0</span>
         <span>$50M</span>
         <span>$100M</span>


### PR DESCRIPTION
## Summary
- Replace fragile HTML overlay (`-mt-[52px]` magic number) with SVG `<circle>` elements inside the chart
- Pulse animation using SVG `<animate>` for radius and opacity
- Dot stays pixel-perfect at all viewport sizes since it shares the SVG coordinate space
- Removed extra `mt-6` spacing that compensated for the old zero-height overlay div

Fixes #1042

## Test plan
- [ ] Verify heartbeat dot renders at the correct position on the MCap progress line
- [ ] Verify pulse animation works (expanding ring effect)
- [ ] Verify alignment holds on mobile and desktop viewports
- [ ] Verify dot hidden when progress is 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)