### PR TITLE
[#1053] Update test-mode milestones to current prod values

### DIFF
--- a/lib/airdrop/config.ts
+++ b/lib/airdrop/config.ts
@@ -57,10 +57,10 @@ const TEST_CONFIG: AirdropConfig = {
   CAMPAIGN_END: new Date("2026-05-11"),       // start + 7 days
   POOL_AMOUNT: 10,                            // 10 PLOT
   MILESTONES: {
-    BRONZE: { mcap: 7_000, pct: 10 },
-    SILVER: { mcap: 10_000, pct: 30 },
-    GOLD: { mcap: 35_000, pct: 50 },
-    DIAMOND: { mcap: 50_000, pct: 100 },
+    BRONZE: { mcap: 1_000_000, pct: 10 },
+    SILVER: { mcap: 10_000_000, pct: 30 },
+    GOLD: { mcap: 50_000_000, pct: 50 },
+    DIAMOND: { mcap: 100_000_000, pct: 100 },
   },
   LOCKER_TX: "0xb4549d21a3a026d215f38d9bf50779fe337254944ae746d008b3b13cd684adce",
   POINTS,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Fixes #1053

## Summary

`TEST_CONFIG.MILESTONES` in `lib/airdrop/config.ts` were stale (\$7K/\$10K/\$35K/\$50K) and were rendering on https://plotlink.xyz/airdrop because the Vercel deployment runs with `NEXT_PUBLIC_AIRDROP_MODE=test`. Updated to match the canonical \$1M/\$10M/\$50M/\$100M values that already exist in `PROD_CONFIG` and the "How does this work?" modal copy.

`CAMPAIGN_START` / `CAMPAIGN_END` / `POOL_AMOUNT` in `TEST_CONFIG` are intentionally unchanged — the user only flagged the milestone values as stale.

## Files

- `lib/airdrop/config.ts` — `TEST_CONFIG.MILESTONES` only (4 lines)
- `package.json` — version 1.6.2 → 1.6.3 (3rd digit, bug fix)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (no new warnings on `config.ts`)
- [ ] After deploy, https://plotlink.xyz/airdrop shows milestone labels \$1M / \$10M / \$50M / \$100M with the correct unlock %s (10 / 30 / 50 / 100)
- [ ] Heartbeat dot at current FDV (~\$31K) renders in the pre-bronze band (Y between 75% and 100% of chart height)
- [ ] Countdown still ticks against the test campaign end date (5/11)

## Coordination note

Only `lib/airdrop/config.ts` references the old `7_000` / `35_000` literals (verified via grep) — no other files needed touching.