### PR TITLE
[#1057] Fix airdrop chart diamond label clipping + MCap caption float

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/airdrop/CampaignHero.tsx
+++ b/src/components/airdrop/CampaignHero.tsx
@@ -65,9 +65,15 @@ function makeMcapToX(milestones: StatusData["milestones"]) {
 }
 
 function formatMcap(n: number): string {
-  if (n >= 1_000_000) return `$${n / 1_000_000}M`;
-  if (n >= 1_000) return `$${n / 1_000}K`;
-  return `$${n}`;
+  if (n >= 1_000_000) {
+    const m = n / 1_000_000;
+    return Number.isInteger(m) ? `$${m}M` : `$${m.toFixed(2)}M`;
+  }
+  if (n >= 1_000) {
+    const k = n / 1_000;
+    return Number.isInteger(k) ? `$${k}K` : `$${k.toFixed(2)}K`;
+  }
+  return `$${n.toFixed(0)}`;
 }
 
 const TIER_NAMES: Record<string, string> = {
@@ -138,7 +144,7 @@ function MCapChart({
   // SVG geometry — short horizontal band, room for top labels on desktop
   const svgW = 600;
   const svgH = 110;
-  const pad = { top: 50, right: 16, bottom: 14, left: 16 };
+  const pad = { top: 50, right: 50, bottom: 14, left: 24 };
   const chartW = svgW - pad.left - pad.right;
   const barY = pad.top + (svgH - pad.top - pad.bottom) / 2;
 


### PR DESCRIPTION
Fixes #1057

## Summary

Two visible bugs from #1056:

1. **Diamond milestone labels clipped:** \`unlocks 100%\` rendered as \`unlocks 1\`, \`(≈ #250)\` rendered as \`(≈ #2\`, because text-anchor=\"middle\" centered at x=584 (= pad.left + 1.0×chartW) extends ~35px past the SVG \`viewBox\`'s right edge. Fixed by widening \`pad.right\` from 16 to 50 (and \`pad.left\` 16 → 24 for symmetry, so \`\$0\` endpoint label has room).

2. **Current MCap caption showed raw float:** \`\$33.523555869999996K\`. Fixed by adding \`.toFixed(2)\` rounding inside \`formatMcap\` for non-integer K/M values, while keeping integer milestone values (\$1M, \$10M, etc.) clean as \`\$1M\` not \`\$1.00M\`.

## Files

- `src/components/airdrop/CampaignHero.tsx` — `formatMcap` rounding + `pad` adjustment in `MCapChart`
- `package.json` — 1.7.0 → 1.7.1

## Verification

- `npm run typecheck` passes
- `formatMcap(1_000_000)` → `\$1M` (integer untouched)
- `formatMcap(33_523.555)` → `\$33.52K`
- `formatMcap(50)` → `\$50`
- Diamond label at new x = 24 + 526 = 550, "unlocks 100%" centered = spans ≈515–585, fits inside viewBox (0–600)

## Test plan

- [ ] All four milestone labels visible in full on desktop including \`\$100M / unlocks 100% / (≈ #250)\`
- [ ] Current MCap caption shows \`\$33.52K\`-style rounded number
- [ ] No layout regression on bronze/silver/gold labels