### PR TITLE
Redesign story detail page: dark theme (#1067)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/story/[storylineId]/[plotIndex]/page.tsx
+++ b/src/app/story/[storylineId]/[plotIndex]/page.tsx
@@ -122,7 +122,7 @@ export default async function PlotDetailPage({ params }: { params: Params }) {
       {/* Chapter header with inline reading mode */}
       <header className="border-border mb-8 border-b pb-4">
         <div className="flex items-center gap-3">
-          <h1 className="text-accent flex-1 text-xl font-bold tracking-tight">
+          <h1 className="font-heading text-foreground flex-1 text-xl font-medium tracking-tight sm:text-2xl">
             {chapterTitle}
           </h1>
           <ReadingModeWrapper
@@ -168,7 +168,7 @@ export default async function PlotDetailPage({ params }: { params: Params }) {
         {prevIndex !== null ? (
           <Link
             href={`/story/${sid}/${prevIndex}`}
-            className="border-border text-muted hover:text-foreground rounded border px-4 py-2 text-xs transition-colors"
+            className="bg-surface border-border text-muted hover:text-foreground hover:border-accent/30 rounded-[var(--card-radius)] border px-4 py-2 text-xs transition-colors"
           >
             &larr; Previous
           </Link>
@@ -184,7 +184,7 @@ export default async function PlotDetailPage({ params }: { params: Params }) {
         {nextIndex !== null ? (
           <Link
             href={`/story/${sid}/${nextIndex}`}
-            className="border-border text-muted hover:text-foreground rounded border px-4 py-2 text-xs transition-colors"
+            className="bg-surface border-border text-muted hover:text-foreground hover:border-accent/30 rounded-[var(--card-radius)] border px-4 py-2 text-xs transition-colors"
           >
             Next &rarr;
           </Link>

--- a/src/app/story/[storylineId]/og/route.tsx
+++ b/src/app/story/[storylineId]/og/route.tsx
@@ -82,6 +82,17 @@ export async function GET(
     }
   }
 
+  type FallbackVariant = "A" | "B" | "C" | "D";
+  const variants: FallbackVariant[] = ["A", "B", "C", "D"];
+  const variant = variants[((id * 2654435761) >>> 0) % 4];
+
+  const FALLBACK_BG: Record<FallbackVariant, string> = {
+    A: "radial-gradient(ellipse at 30% 20%, #3a2e24, #261f19)",
+    B: "repeating-linear-gradient(135deg, #2a2420 0px, #2a2420 8px, #332c26 8px, #332c26 16px)",
+    C: "conic-gradient(from 180deg at 50% 50%, #2e3540, #2a2420, #2e3540)",
+    D: "#302820",
+  };
+
   const fonts = fontData
     ? [{ name: "Newsreader", data: fontData, weight: 500 as const }]
     : [];
@@ -100,14 +111,14 @@ export async function GET(
           fontFamily: fontData ? "Newsreader" : "Georgia, serif",
         }}
       >
-        {/* Dark card */}
+        {/* Cover card with deterministic fallback pattern */}
         <div
           style={{
             width: "380px",
             height: "520px",
             display: "flex",
             flexDirection: "column",
-            backgroundColor: "#2a2420",
+            background: FALLBACK_BG[variant],
             borderRadius: "12px",
             border: "1px solid #3a332c",
             position: "relative",

--- a/src/app/story/[storylineId]/og/route.tsx
+++ b/src/app/story/[storylineId]/og/route.tsx
@@ -13,7 +13,7 @@ export const runtime = "nodejs";
 async function loadFont(): Promise<ArrayBuffer | null> {
   try {
     const res = await fetch(
-      "https://fonts.googleapis.com/css2?family=Lora:wght@700&display=swap",
+      "https://fonts.googleapis.com/css2?family=Newsreader:wght@500&display=swap",
     );
     const css = await res.text();
     const match =
@@ -83,7 +83,7 @@ export async function GET(
   }
 
   const fonts = fontData
-    ? [{ name: "Lora", data: fontData, weight: 700 as const }]
+    ? [{ name: "Newsreader", data: fontData, weight: 500 as const }]
     : [];
 
   return new ImageResponse(
@@ -96,59 +96,52 @@ export async function GET(
           flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
-          backgroundColor: "#DDD3C2",
-          fontFamily: fontData ? "Lora" : "Georgia, serif",
+          backgroundColor: "#1f1a15",
+          fontFamily: fontData ? "Newsreader" : "Georgia, serif",
         }}
       >
-        {/* Centered moleskine card */}
+        {/* Dark card */}
         <div
           style={{
-            width: "360px",
-            height: "540px",
+            width: "380px",
+            height: "520px",
             display: "flex",
             flexDirection: "column",
-            backgroundColor: "#F5EFE6",
-            borderRadius: "5px 15px 15px 5px",
-            border: "1px solid #D4C5B0",
-            boxShadow:
-              "4px 6px 20px rgba(44, 24, 16, 0.18), 1px 1px 4px rgba(44, 24, 16, 0.08)",
+            backgroundColor: "#2a2420",
+            borderRadius: "12px",
+            border: "1px solid #3a332c",
             position: "relative",
             overflow: "hidden",
           }}
         >
-          {/* Elastic band */}
+          {/* Accent strip at top */}
           <div
             style={{
-              position: "absolute",
-              top: "-1px",
-              bottom: "-1px",
-              right: "28px",
-              width: "8px",
-              borderRadius: "2px",
-              background: "rgba(139, 69, 19, 0.18)",
               display: "flex",
+              height: "3px",
+              background: "linear-gradient(90deg, #b05c3a, #b05c3a80, transparent)",
             }}
           />
 
-          {/* Top-left: genre tag */}
+          {/* Top: genre tag */}
           <div
             style={{
               display: "flex",
-              padding: "24px 28px 0",
+              padding: "28px 28px 0",
             }}
           >
             {sl.genre ? (
               <div
                 style={{
                   display: "flex",
-                  fontSize: "13px",
-                  color: "#8B4513",
-                  backgroundColor: "rgba(139, 69, 19, 0.08)",
-                  borderRadius: "3px",
+                  fontSize: "12px",
+                  color: "#b05c3a",
+                  backgroundColor: "rgba(176, 92, 58, 0.12)",
+                  borderRadius: "4px",
                   padding: "4px 12px",
                   textTransform: "uppercase",
-                  letterSpacing: "0.1em",
-                  fontWeight: 700,
+                  letterSpacing: "0.12em",
+                  fontWeight: 500,
                 }}
               >
                 {sl.genre}
@@ -166,60 +159,78 @@ export async function GET(
               justifyContent: "center",
               alignItems: "center",
               flex: 1,
-              padding: "0 36px",
+              padding: "0 32px",
               textAlign: "center",
             }}
           >
             <div
               style={{
-                fontSize: titleDisplay.length > 30 ? "32px" : "38px",
-                fontWeight: 700,
-                color: "#8B4513",
-                lineHeight: 1.25,
+                width: "40px",
+                height: "1px",
+                background: "rgba(176, 92, 58, 0.4)",
+                marginBottom: "20px",
+                display: "flex",
+              }}
+            />
+            <div
+              style={{
+                fontSize: titleDisplay.length > 30 ? "30px" : "36px",
+                fontWeight: 500,
+                color: "#ede4d6",
+                lineHeight: 1.3,
                 display: "flex",
                 textAlign: "center",
                 justifyContent: "center",
-                maxWidth: "380px",
+                maxWidth: "340px",
               }}
             >
               {titleDisplay}
             </div>
+            <div
+              style={{
+                width: "40px",
+                height: "1px",
+                background: "rgba(176, 92, 58, 0.4)",
+                marginTop: "20px",
+                display: "flex",
+              }}
+            />
           </div>
 
-          {/* Bottom: plot count + TVL */}
+          {/* Bottom: stats */}
           <div
             style={{
               display: "flex",
               flexDirection: "column",
               gap: "6px",
-              padding: "0 28px 24px",
-              fontSize: "15px",
-              color: "#6B5B47",
+              padding: "0 28px 28px",
+              fontSize: "14px",
+              color: "#8a7e70",
             }}
           >
             <div style={{ display: "flex" }}>{plotLabel}</div>
             {tvlDisplay && (
-              <div style={{ display: "flex", fontWeight: 700, color: "#8B4513" }}>
+              <div style={{ display: "flex", fontWeight: 500, color: "#b05c3a" }}>
                 {tvlDisplay}
               </div>
             )}
           </div>
         </div>
 
-        {/* Below moleskine: author + branding */}
+        {/* Below card: author + branding */}
         <div
           style={{
             display: "flex",
             justifyContent: "space-between",
             alignItems: "center",
-            width: "360px",
-            marginTop: "16px",
-            fontSize: "16px",
-            color: "#8B7355",
+            width: "380px",
+            marginTop: "20px",
+            fontSize: "15px",
+            color: "#8a7e70",
           }}
         >
           <div style={{ display: "flex" }}>by {authorName}</div>
-          <div style={{ display: "flex", color: "#A89880" }}>plotlink.xyz</div>
+          <div style={{ display: "flex", color: "#5a5248" }}>plotlink.xyz</div>
         </div>
       </div>
     ),

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -90,7 +90,7 @@ export async function generateMetadata({
         type: "launch_miniapp",
         url: storyUrl,
         name: "PlotLink",
-        splashBackgroundColor: "#E8DFD0",
+        splashBackgroundColor: "#1f1a15",
       },
     },
   });
@@ -159,9 +159,17 @@ export default async function StoryPage({ params }: { params: Params }) {
     : null;
 
   return (
-    <div className="mx-auto max-w-5xl px-6 py-10 pb-24 lg:pb-10">
+    <div className="mx-auto max-w-5xl px-4 py-8 pb-24 lg:pb-10">
       <ViewTracker storylineId={id} />
-      <StoryHeader storyline={storyline} priceInfo={priceInfo} />
+
+      {/* Breadcrumb */}
+      <nav className="text-muted mb-6 text-xs">
+        <Link href="/" className="hover:text-accent transition-colors">Stories</Link>
+        <span className="mx-2">›</span>
+        <span className="text-foreground">{sl.title}</span>
+      </nav>
+
+      <StoryHeader storyline={storyline} priceInfo={priceInfo} storylineId={id} />
 
       <div className="mt-8 grid grid-cols-1 gap-10 lg:grid-cols-[1fr_320px]">
         {/* Story content — genesis + table of contents */}
@@ -252,31 +260,50 @@ export default async function StoryPage({ params }: { params: Params }) {
   );
 }
 
+type FallbackVariant = "A" | "B" | "C" | "D";
+
+function hashToVariant(id: number): FallbackVariant {
+  const variants: FallbackVariant[] = ["A", "B", "C", "D"];
+  return variants[((id * 2654435761) >>> 0) % 4];
+}
+
+const FALLBACK_STYLES: Record<FallbackVariant, React.CSSProperties> = {
+  A: { background: "radial-gradient(ellipse at 30% 20%, oklch(28% 0.04 40), oklch(16% 0.02 50))" },
+  B: { background: "repeating-linear-gradient(135deg, oklch(18% 0.018 50) 0px, oklch(18% 0.018 50) 8px, oklch(22% 0.02 45) 8px, oklch(22% 0.02 45) 16px)" },
+  C: { background: "conic-gradient(from 180deg at 50% 50%, oklch(20% 0.03 220), oklch(18% 0.02 50), oklch(20% 0.03 220))" },
+  D: { background: "oklch(20% 0.025 50)" },
+};
+
 function StoryHeader({
   storyline,
   priceInfo,
+  storylineId,
+  coverUrl,
 }: {
   storyline: Storyline;
   priceInfo: TokenPriceInfo | null;
+  storylineId: number;
+  coverUrl?: string;
 }) {
   const createdDate = storyline.block_timestamp
     ? new Date(storyline.block_timestamp).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
     : null;
+  const variant = hashToVariant(storylineId);
 
   const statsGrid = priceInfo ? (
     <div className="grid grid-cols-2 sm:grid-cols-3 gap-1.5">
-      <div className="border-border rounded border px-2 py-1.5 text-center min-w-0">
+      <div className="bg-surface rounded-[var(--card-radius)] border border-border px-2 py-1.5 text-center min-w-0">
         <MarketCapBox
           tokenAddress={storyline.token_address}
           totalSupply={parseFloat(priceInfo.totalSupply)}
           pricePerToken={parseFloat(priceInfo.pricePerToken)}
         />
       </div>
-      <div className="border-border rounded border px-2 py-1.5 text-center min-w-0">
+      <div className="bg-surface rounded-[var(--card-radius)] border border-border px-2 py-1.5 text-center min-w-0">
         <div className="text-foreground text-sm font-bold">{formatSupply(priceInfo.totalSupply)}</div>
         <div className="text-muted text-[9px]">Supply Minted</div>
       </div>
-      <div className="border-border rounded border px-2 py-1.5 text-center min-w-0">
+      <div className="bg-surface rounded-[var(--card-radius)] border border-border px-2 py-1.5 text-center min-w-0">
         {storyline.sunset ? (
           <>
             <div className="text-foreground text-sm font-bold">{storyline.plot_count}</div>
@@ -301,14 +328,14 @@ function StoryHeader({
           </>
         )}
       </div>
-      <div className="border-border rounded border px-2 py-1.5 text-center min-w-0">
+      <div className="bg-surface rounded-[var(--card-radius)] border border-border px-2 py-1.5 text-center min-w-0">
         <TokenPriceBox pricePerToken={parseFloat(priceInfo.pricePerToken)} />
       </div>
-      <div className="border-border rounded border px-2 py-1.5 text-center min-w-0">
+      <div className="bg-surface rounded-[var(--card-radius)] border border-border px-2 py-1.5 text-center min-w-0">
         <div className="text-foreground text-sm font-bold">{storyline.plot_count}</div>
         <div className="text-muted text-[9px]">{storyline.plot_count === 1 ? "Plot" : "Plots"}</div>
       </div>
-      <div className="border-border rounded border px-2 py-1.5 text-center min-w-0">
+      <div className="bg-surface rounded-[var(--card-radius)] border border-border px-2 py-1.5 text-center min-w-0">
         <div className="text-foreground text-sm font-bold">{createdDate ?? "—"}</div>
         <div className="text-muted text-[9px]">Created</div>
       </div>
@@ -320,37 +347,30 @@ function StoryHeader({
   );
 
   return (
-    <header
-      className="pb-6 grid gap-x-4 sm:gap-x-6 grid-cols-[130px_1fr] sm:grid-cols-[160px_1fr]"
-    >
-      {/* Moleskine book cover */}
-      <div className="sm:row-span-2">
+    <header className="pb-6 grid gap-x-6 grid-cols-1 sm:grid-cols-[200px_1fr] lg:grid-cols-[280px_1fr]">
+      {/* Cover frame */}
+      <div className="hidden sm:block sm:row-span-2">
         <div
-          className="relative flex flex-col overflow-hidden border border-[var(--border)]"
-          style={{
-            aspectRatio: "2/3",
-            borderRadius: "5px 12px 12px 5px",
-            backgroundColor: "#F5EFE6",
-            boxShadow: "2px 4px 8px rgba(44, 24, 16, 0.08)",
-          }}
+          className="relative w-full overflow-hidden rounded-[var(--card-radius)] border border-border"
+          style={{ aspectRatio: "2/3" }}
         >
-          <div
-            className="pointer-events-none absolute inset-y-[-1px] right-[16px] z-20 w-[5px] rounded-[2px]"
-            style={{ background: "rgba(139, 69, 19, 0.15)" }}
-          />
-          <div className="relative z-10 px-2.5 pt-2.5">
-            <span className="rounded-sm bg-[var(--accent)]/10 px-1.5 py-0.5 text-[8px] font-semibold uppercase tracking-widest text-[var(--accent)]">
+          {coverUrl ? (
+            <img src={coverUrl} alt={storyline.title} loading="lazy" className="absolute inset-0 h-full w-full object-cover" />
+          ) : (
+            <div className="absolute inset-0" style={FALLBACK_STYLES[variant]}>
+              <div className="flex h-full flex-col items-center justify-center px-4 text-center">
+                <div className="mb-3 h-px w-8 bg-accent/40" />
+                <h2 className="font-heading text-lg font-medium leading-tight tracking-tight text-foreground lg:text-xl">
+                  {storyline.title}
+                </h2>
+                <div className="mt-3 h-px w-8 bg-accent/40" />
+              </div>
+            </div>
+          )}
+          <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent" />
+          <div className="absolute bottom-0 left-0 right-0 p-3">
+            <span className="rounded-sm bg-black/50 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-white backdrop-blur-sm">
               {storyline.genre || "Uncategorized"}
-            </span>
-          </div>
-          <div className="relative z-10 flex flex-1 items-center justify-center px-3 text-center">
-            <span className="font-heading text-sm sm:text-base font-bold leading-tight text-[var(--accent)]">
-              {storyline.title}
-            </span>
-          </div>
-          <div className="relative z-10 px-2.5 pb-2.5">
-            <span className="text-[8px] text-[var(--text-muted)]">
-              {storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"}
             </span>
           </div>
         </div>
@@ -358,14 +378,14 @@ function StoryHeader({
 
       {/* Info column */}
       <div className="min-w-0">
-        <h1 className="font-body text-xl sm:text-2xl font-bold tracking-tight text-accent">
+        <h1 className="font-heading text-xl sm:text-2xl lg:text-3xl font-medium tracking-tight text-foreground">
           {storyline.title}
         </h1>
         <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted">
           <RatingSummary storylineId={storyline.storyline_id} separator />
           <ViewCount storylineId={storyline.storyline_id} initialCount={storyline.view_count} />
         </div>
-        <div className="mt-2 space-y-1 text-xs">
+        <div className="mt-3 space-y-1 text-xs">
           <div className="flex items-center gap-1.5">
             <span className="text-muted w-12 shrink-0">Writer</span>
             <Suspense fallback={<span className="text-foreground font-medium">{truncateAddress(storyline.writer_address)}</span>}>
@@ -386,7 +406,7 @@ function StoryHeader({
       </div>
 
       {/* Stats + CTA */}
-      <div className="col-span-2 sm:col-span-1 sm:col-start-2">
+      <div className="col-span-1 sm:col-start-2">
         {statsGrid && <div className="mt-4 sm:mt-6">{statsGrid}</div>}
         <div className="[&_a]:w-full [&_div]:w-full sm:[&_a]:w-auto sm:[&_div]:w-auto">{ctaButton}</div>
       </div>

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -348,10 +348,10 @@ function StoryHeader({
 
   return (
     <header className="pb-6 grid gap-x-6 grid-cols-1 sm:grid-cols-[200px_1fr] lg:grid-cols-[280px_1fr]">
-      {/* Cover frame */}
-      <div className="hidden sm:block sm:row-span-2">
+      {/* Cover frame — stacks on mobile, side column on sm+ */}
+      <div className="sm:row-span-2">
         <div
-          className="relative w-full overflow-hidden rounded-[var(--card-radius)] border border-border"
+          className="relative mx-auto w-48 overflow-hidden rounded-[var(--card-radius)] border border-border sm:mx-0 sm:w-full"
           style={{ aspectRatio: "2/3" }}
         >
           {coverUrl ? (

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -109,7 +109,7 @@ export function ReadingMode({
   }, []);
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col" style={{ background: "var(--paper-bg, #F5F0E8)" }}>
+    <div className="fixed inset-0 z-50 flex flex-col" style={{ background: "var(--bg)" }}>
       {/* Top bar */}
       <div className="flex items-center justify-between px-4 py-3 sm:px-6" style={{ borderBottom: "1px solid var(--border)" }}>
         <div className="min-w-0 flex-1">
@@ -228,7 +228,7 @@ export function ReadingMode({
         >
           <div
             className="border-border w-full max-w-md rounded-t-lg border sm:rounded-lg"
-            style={{ background: "var(--paper-bg, #F5F0E8)" }}
+            style={{ background: "var(--bg)" }}
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">

--- a/src/components/StoryContent.tsx
+++ b/src/components/StoryContent.tsx
@@ -5,10 +5,6 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
 
-/**
- * Sanitization schema — fiction-focused Markdown only.
- * No images, tables, or code blocks.
- */
 const sanitizeSchema = {
   ...defaultSchema,
   tagNames: [
@@ -30,13 +26,9 @@ const sanitizeSchema = {
   attributes: {},
 };
 
-/**
- * Renders story content as Markdown with fiction-focused styling.
- * Plain text stories render correctly (plain text is valid Markdown).
- */
 export function StoryContent({ content }: { content: string }) {
   return (
-    <div className="ruled-paper story-markdown">
+    <div className="story-markdown font-prose text-foreground leading-7">
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkBreaks]}
         rehypePlugins={[[rehypeSanitize, sanitizeSchema]]}
@@ -47,9 +39,6 @@ export function StoryContent({ content }: { content: string }) {
   );
 }
 
-/**
- * Write/Preview toggle for story editing forms.
- */
 export function WritePreviewToggle({
   activeTab,
   onTabChange,
@@ -58,7 +47,7 @@ export function WritePreviewToggle({
   onTabChange: (tab: "write" | "preview") => void;
 }) {
   return (
-    <div className="mb-2 flex gap-1 border-b border-[var(--border)] pb-1">
+    <div className="mb-2 flex gap-1 border-b border-border pb-1">
       <button
         type="button"
         onClick={() => onTabChange("write")}
@@ -85,19 +74,16 @@ export function WritePreviewToggle({
   );
 }
 
-/**
- * Preview pane that matches story page rendering.
- */
 export function ContentPreview({ content }: { content: string }) {
   if (!content.trim()) {
     return (
-      <div className="ruled-paper text-muted min-h-[336px] text-sm italic">
+      <div className="text-muted min-h-[336px] text-sm italic p-6">
         Nothing to preview
       </div>
     );
   }
   return (
-    <div className="min-h-[336px]">
+    <div className="min-h-[336px] p-6">
       <StoryContent content={content} />
     </div>
   );


### PR DESCRIPTION
## Summary
- **StoryHeader**: Replace Moleskine notebook cover with 280px cover-image-ready frame using deterministic fallback gradient patterns (A/B/C/D), dark surface stat cards
- **StoryContent + ReadingMode**: Swap ruled-paper/paper-bg classes for dark serif typography (`font-prose text-foreground leading-7`)
- **OG image**: Dark card design with Newsreader font, accent color strip, matching the new palette
- **Navigation**: Added breadcrumb nav to story detail page
- Version bump to 1.12.0

Closes #1067

## Test plan
- [ ] Typecheck passes (`npm run typecheck` ✅)
- [ ] Lint passes (`npm run lint` ✅)
- [ ] All 41 unit tests pass (`npm run test` ✅)
- [ ] Story detail page renders with dark palette and cover frame
- [ ] OG image generates with dark card design
- [ ] Reading mode uses dark background
- [ ] Plot detail page breadcrumb + nav works
- [ ] Table of Contents hover states use surface tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)