### PR TITLE
Redesign airdrop page: dark theme (#1070)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/airdrop/page.tsx
+++ b/src/app/airdrop/page.tsx
@@ -20,7 +20,7 @@ export default function AirdropPage() {
       <CampaignHero />
 
       {/* 2-column grid below hero */}
-      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]">
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1fr_340px]">
         {/* Left column: user-specific */}
         <div className="min-w-0 space-y-6">
           {campaignEnded ? <ClaimPanel /> : <UserPoints />}

--- a/src/components/airdrop/CampaignHero.tsx
+++ b/src/components/airdrop/CampaignHero.tsx
@@ -189,98 +189,118 @@ function MCapChart({
 
   return (
     <div className="space-y-2">
-      <svg
-        viewBox={`0 0 ${svgW} ${svgH}`}
-        className="w-full font-mono"
-        preserveAspectRatio="xMidYMid meet"
-        role="img"
-        aria-label={`MCap area chart: current ${formatMcap(currentFdv)} of ${formatMcap(yMax)}`}
-      >
-        <defs>
-          <linearGradient id="mcap-area-fill" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stopColor="var(--accent)" stopOpacity="0.32" />
-            <stop offset="100%" stopColor="var(--accent)" stopOpacity="0.02" />
-          </linearGradient>
-        </defs>
+      <div className="bg-surface-raised rounded-[var(--card-radius)] border border-border p-3">
+        <svg
+          viewBox={`0 0 ${svgW} ${svgH}`}
+          className="w-full font-mono"
+          preserveAspectRatio="xMidYMid meet"
+          role="img"
+          aria-label={`MCap area chart: current ${formatMcap(currentFdv)} of ${formatMcap(yMax)}`}
+        >
+          <defs>
+            <linearGradient id="mcap-area-fill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--dist)" stopOpacity="0.28" />
+              <stop offset="100%" stopColor="var(--dist)" stopOpacity="0.02" />
+            </linearGradient>
+          </defs>
 
-        {/* Y-axis tick gridlines */}
-        {yTicks.map((tick) => {
-          const y = toY(tick);
-          return (
-            <line key={`grid-${tick}`} x1={pad.left} y1={y} x2={pad.left + chartW} y2={y} stroke="var(--accent)" strokeWidth={0.5} opacity={0.1} />
-          );
-        })}
-
-        {/* Vertical band dividers (full chart height, 3 inner + 2 edges) */}
-        {[0, 0.25, 0.5, 0.75, 1].map((frac) => {
-          const x = toX(frac);
-          const isEdge = frac === 0 || frac === 1;
-          return (
-            <line key={`band-${frac}`} x1={x} y1={pad.top} x2={x} y2={pad.top + chartH} stroke="var(--accent)" strokeWidth={isEdge ? 0.75 : 0.5} opacity={isEdge ? 0.5 : 0.35} />
-          );
-        })}
-
-        {/* Y-axis tick labels (left) */}
-        {yTicks.map((tick) => {
-          const y = toY(tick);
-          return (
-            <text key={`ytick-${tick}`} x={pad.left - 6} y={y + 3} textAnchor="end" fill="var(--color-muted)" fontSize={9}>
-              {formatMcap(tick)}
-            </text>
-          );
-        })}
-
-        {/* Area fill below curve */}
-        <path d={areaPath} fill="url(#mcap-area-fill)" />
-
-        {/* Curve line */}
-        <path d={linePath} fill="none" stroke="var(--accent)" strokeWidth={2} />
-
-        {/* Milestone label blocks — inside chart, anchored to LEFT of each vertical line */}
-        <g className="hidden sm:block">
-          {milestoneEntries.map((ms) => {
-            const lineX = toX(ms.pos);
-            const labelX = lineX - 6;
-            const top = pad.top + 14;
+          {/* Y-axis tick gridlines */}
+          {yTicks.map((tick) => {
+            const y = toY(tick);
             return (
-              <g key={`label-${ms.key}`}>
-                <text x={labelX} y={top} textAnchor="end" fill="var(--accent)" fontSize={10} fontWeight="bold" style={{ letterSpacing: "0.18em" }}>
-                  MILESTONE {ms.milestoneNum}
-                </text>
-                <text x={labelX} y={top + 16} textAnchor="end" fill="var(--accent)" fontSize={13} fontWeight="bold">
-                  {ms.label}
-                </text>
-                <text x={labelX} y={top + 30} textAnchor="end" fill="var(--accent)" fontSize={10} opacity={0.85}>
-                  unlocks {ms.pct}%
-                </text>
-                {ms.cmcRank && (
-                  <text x={labelX} y={top + 43} textAnchor="end" fill="var(--accent)" fontSize={9} opacity={0.55}>
-                    CMC {ms.cmcRank}
-                  </text>
-                )}
-              </g>
+              <line key={`grid-${tick}`} x1={pad.left} y1={y} x2={pad.left + chartW} y2={y} stroke="var(--border)" strokeWidth={0.5} />
             );
           })}
-        </g>
 
-        {/* Heartbeat dot at current MCap */}
-        <circle cx={dotX} cy={dotY} r={6} fill="var(--accent)" opacity={0.75}>
-          <animate attributeName="r" values="6;12;6" dur="1.5s" repeatCount="indefinite" />
-          <animate attributeName="opacity" values="0.75;0;0.75" dur="1.5s" repeatCount="indefinite" />
-        </circle>
-        <circle cx={dotX} cy={dotY} r={4} fill="var(--accent)" />
+          {/* Milestone column backgrounds — reached=dist, unreached=burn(faded) */}
+          {milestoneEntries.map((ms, idx) => {
+            const x0 = toX(idx === 0 ? 0 : milestoneEntries[idx - 1].pos);
+            const x1 = toX(ms.pos);
+            return (
+              <rect
+                key={`col-${ms.key}`}
+                x={x0}
+                y={pad.top}
+                width={x1 - x0}
+                height={chartH}
+                fill={ms.reached ? "var(--dist)" : "var(--burn)"}
+                opacity={ms.reached ? 0.08 : 0.04}
+              />
+            );
+          })}
 
-        {/* Current MCap caption right above the dot */}
-        <text x={dotX} y={dotY - 12} textAnchor="middle" fill="var(--accent)" fontSize={10} fontWeight="bold">
-          {formatMcap(currentFdv)}
-        </text>
-      </svg>
+          {/* Vertical band dividers */}
+          {[0, 0.25, 0.5, 0.75, 1].map((frac) => {
+            const x = toX(frac);
+            const isEdge = frac === 0 || frac === 1;
+            return (
+              <line key={`band-${frac}`} x1={x} y1={pad.top} x2={x} y2={pad.top + chartH} stroke="var(--border)" strokeWidth={isEdge ? 0.75 : 0.5} />
+            );
+          })}
+
+          {/* Y-axis tick labels (left) */}
+          {yTicks.map((tick) => {
+            const y = toY(tick);
+            return (
+              <text key={`ytick-${tick}`} x={pad.left - 6} y={y + 3} textAnchor="end" fill="var(--muted)" fontSize={9}>
+                {formatMcap(tick)}
+              </text>
+            );
+          })}
+
+          {/* Area fill below curve */}
+          <path d={areaPath} fill="url(#mcap-area-fill)" />
+
+          {/* Curve line */}
+          <path d={linePath} fill="none" stroke="var(--dist)" strokeWidth={2} />
+
+          {/* Milestone label blocks — inside chart, anchored to LEFT of each vertical line */}
+          <g className="hidden sm:block">
+            {milestoneEntries.map((ms) => {
+              const lineX = toX(ms.pos);
+              const labelX = lineX - 6;
+              const top = pad.top + 14;
+              const color = ms.reached ? "var(--dist)" : "var(--accent)";
+              return (
+                <g key={`label-${ms.key}`}>
+                  <text x={labelX} y={top} textAnchor="end" fill={color} fontSize={10} fontWeight="bold" style={{ letterSpacing: "0.18em" }}>
+                    MILESTONE {ms.milestoneNum}
+                  </text>
+                  <text x={labelX} y={top + 16} textAnchor="end" fill={color} fontSize={13} fontWeight="bold">
+                    {ms.label}
+                  </text>
+                  <text x={labelX} y={top + 30} textAnchor="end" fill={color} fontSize={10} opacity={0.85}>
+                    unlocks {ms.pct}%
+                  </text>
+                  {ms.cmcRank && (
+                    <text x={labelX} y={top + 43} textAnchor="end" fill={color} fontSize={9} opacity={0.55}>
+                      CMC {ms.cmcRank}
+                    </text>
+                  )}
+                </g>
+              );
+            })}
+          </g>
+
+          {/* Heartbeat dot at current MCap */}
+          <circle cx={dotX} cy={dotY} r={6} fill="var(--accent)" opacity={0.75}>
+            <animate attributeName="r" values="6;12;6" dur="1.5s" repeatCount="indefinite" />
+            <animate attributeName="opacity" values="0.75;0;0.75" dur="1.5s" repeatCount="indefinite" />
+          </circle>
+          <circle cx={dotX} cy={dotY} r={4} fill="var(--accent)" />
+
+          {/* Current MCap caption right above the dot */}
+          <text x={dotX} y={dotY - 12} textAnchor="middle" fill="var(--accent)" fontSize={10} fontWeight="bold">
+            {formatMcap(currentFdv)}
+          </text>
+        </svg>
+      </div>
 
       {/* Mobile milestone legend — Mn / value / pct in 4 columns */}
       <div className="grid grid-cols-4 gap-1 sm:hidden font-mono">
         {milestoneEntries.map((ms) => (
           <div key={ms.key} className="text-center">
-            <div className="text-[10px] font-bold text-foreground uppercase tracking-wider">
+            <div className={`text-[10px] font-bold uppercase tracking-wider ${ms.reached ? "text-[var(--dist)]" : "text-foreground"}`}>
               M{ms.milestoneNum}
             </div>
             <div className="text-[10px] text-muted">{ms.label}</div>

--- a/src/components/airdrop/CampaignHero.tsx
+++ b/src/components/airdrop/CampaignHero.tsx
@@ -303,7 +303,7 @@ export function CampaignHero() {
 
   if (isLoading || !data) {
     return (
-      <div className="border-border rounded border p-4">
+      <div className="bg-surface rounded-[var(--card-radius)] border border-border p-4">
         <div className="text-muted text-sm">Loading campaign status...</div>
       </div>
     );
@@ -312,10 +312,10 @@ export function CampaignHero() {
   const pad2 = (n: number) => String(n).padStart(2, "0");
 
   return (
-    <div className="border-border rounded border p-5 space-y-6">
+    <div className="bg-surface rounded-[var(--card-radius)] border border-border p-5 space-y-6">
       {/* ── Bold headline ── */}
       <div className="text-center space-y-2">
-        <h2 className="text-foreground text-xl sm:text-2xl font-bold leading-tight tracking-tight">
+        <h2 className="font-heading text-foreground text-3xl sm:text-[48px] font-bold leading-[1.1] tracking-tight">
           PLOT BIG AIRDROP
         </h2>
         <p className="text-muted text-sm sm:text-base leading-relaxed max-w-md mx-auto">
@@ -359,7 +359,7 @@ export function CampaignHero() {
           ].map((unit, i) => (
             <div key={unit.label} className="flex items-center gap-2">
               {i > 0 && <span className="text-muted text-lg font-mono">:</span>}
-              <div className="text-center">
+              <div className="bg-surface-raised rounded-[var(--card-radius)] border border-border px-3 py-2 text-center min-w-[56px]">
                 <div className="text-foreground text-2xl font-bold font-mono tabular-nums">
                   {i === 0 ? unit.val : pad2(unit.val)}
                 </div>
@@ -384,11 +384,11 @@ export function CampaignHero() {
       {/* ── How It Works modal ── */}
       {showModal && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
           onClick={closeModal}
         >
           <div
-            className="bg-background border-border rounded border p-5 w-full max-w-lg max-h-[85vh] overflow-y-auto space-y-5 relative"
+            className="bg-surface border-border rounded-[var(--card-radius)] border p-5 w-full max-w-lg max-h-[85vh] overflow-y-auto space-y-5 relative"
             onClick={(e) => e.stopPropagation()}
           >
             <button

--- a/src/components/airdrop/ClaimPanel.tsx
+++ b/src/components/airdrop/ClaimPanel.tsx
@@ -54,7 +54,7 @@ function CampaignResults() {
   if (!data || !data.finalized) return null;
 
   return (
-    <div className="border-border rounded border p-4 space-y-2">
+    <div className="bg-surface border-border rounded-[var(--card-radius)] border p-4 space-y-2">
       <div className="flex items-center gap-2">
         <span className="bg-accent text-bg rounded px-2 py-0.5 text-[10px] font-bold">CAMPAIGN COMPLETE</span>
       </div>
@@ -107,7 +107,7 @@ export function ClaimPanel() {
     <>
       <CampaignResults />
       {!isConnected || !address ? (
-        <div className="border-border rounded border p-4 text-center">
+        <div className="bg-surface border-border rounded-[var(--card-radius)] border p-4 text-center">
           <p className="text-muted text-sm">Connect your wallet to check your claim.</p>
         </div>
       ) : (
@@ -163,7 +163,7 @@ function ClaimPanelInner({ address }: { address: string }) {
 
   if (isLoading || !proofData) {
     return (
-      <div className="border-border rounded border p-4">
+      <div className="bg-surface border-border rounded-[var(--card-radius)] border p-4">
         <div className="text-muted text-sm">Checking claim eligibility...</div>
       </div>
     );
@@ -172,7 +172,7 @@ function ClaimPanelInner({ address }: { address: string }) {
   // Not eligible
   if (!proofData.eligible || !proofData.amount || !proofData.proof) {
     return (
-      <div className="border-border rounded border p-4 text-center">
+      <div className="bg-surface border-border rounded-[var(--card-radius)] border p-4 text-center">
         <div className="text-foreground text-sm font-bold mb-1">Campaign Complete</div>
         <p className="text-muted text-xs">You did not earn any PLOT in this campaign.</p>
       </div>
@@ -201,7 +201,7 @@ function ClaimPanelInner({ address }: { address: string }) {
   };
 
   return (
-    <div className="border-border rounded border p-4">
+    <div className="bg-surface border-border rounded-[var(--card-radius)] border p-4">
       <div className="text-foreground text-sm font-bold mb-3">Claim Your PLOT</div>
 
       <div className="text-center space-y-2">

--- a/src/components/airdrop/Leaderboard.tsx
+++ b/src/components/airdrop/Leaderboard.tsx
@@ -44,7 +44,7 @@ export function Leaderboard() {
 
   if (isLoading || !data) {
     return (
-      <div className="border-border rounded border p-4">
+      <div className="bg-surface border-border rounded-[var(--card-radius)] border p-4">
         <div className="text-muted text-sm">Loading leaderboard...</div>
       </div>
     );
@@ -52,7 +52,7 @@ export function Leaderboard() {
 
   if (data.entries.length === 0 && data.totalParticipants === 0) {
     return (
-      <div className="border-border rounded border p-4">
+      <div className="bg-surface border-border rounded-[var(--card-radius)] border p-4">
         <h3 className="text-foreground text-sm font-bold mb-2">Leaderboard</h3>
         <div className="text-muted text-xs">No participants yet.</div>
       </div>
@@ -63,7 +63,7 @@ export function Leaderboard() {
   const onCurrentPage = userAddr && data.entries.some((e) => e.address.toLowerCase() === userAddr);
 
   return (
-    <div className="border-border rounded border p-4">
+    <div className="bg-surface border-border rounded-[var(--card-radius)] border p-4">
       <h3 className="text-foreground text-sm font-bold">Leaderboard</h3>
       <div className="text-muted text-xs mb-3">
         {data.totalParticipants} {data.totalParticipants === 1 ? "participant" : "participants"}

--- a/src/components/airdrop/StreakCard.tsx
+++ b/src/components/airdrop/StreakCard.tsx
@@ -184,7 +184,7 @@ export function StreakCard({ streak, address }: { streak: StreakData; address: s
           type="button"
           onClick={handleCheckIn}
           disabled={streak.checkedInToday || checking}
-          className="bg-accent text-bg rounded-[var(--card-radius)] px-3 py-1 text-xs font-medium disabled:opacity-50 cursor-pointer"
+          className="bg-accent text-white rounded-[var(--card-radius)] px-3 py-1 text-xs font-medium disabled:opacity-50 cursor-pointer"
         >
           {streak.checkedInToday
             ? "✓ Done"

--- a/src/components/airdrop/StreakCard.tsx
+++ b/src/components/airdrop/StreakCard.tsx
@@ -171,7 +171,7 @@ export function StreakCard({ streak, address }: { streak: StreakData; address: s
   );
 
   return (
-    <div className="border-border rounded border px-3 py-2.5 space-y-2.5">
+    <div className="bg-surface border-border rounded-[var(--card-radius)] border px-3 py-2.5 space-y-2.5">
       {/* Compact header: streak + boost + check-in button */}
       <div className="flex items-center justify-between">
         <div className="text-foreground text-sm font-bold">
@@ -184,7 +184,7 @@ export function StreakCard({ streak, address }: { streak: StreakData; address: s
           type="button"
           onClick={handleCheckIn}
           disabled={streak.checkedInToday || checking}
-          className="bg-accent text-white rounded px-3 py-1 text-xs font-medium disabled:opacity-50 cursor-pointer"
+          className="bg-accent text-bg rounded-[var(--card-radius)] px-3 py-1 text-xs font-medium disabled:opacity-50 cursor-pointer"
         >
           {streak.checkedInToday
             ? "✓ Done"

--- a/src/components/airdrop/UserPoints.tsx
+++ b/src/components/airdrop/UserPoints.tsx
@@ -109,7 +109,7 @@ export function UserPoints() {
 
   if (!isConnected || !address) {
     return (
-      <div className="border-border rounded border p-4 text-center">
+      <div className="bg-surface border-border rounded-[var(--card-radius)] border p-4 text-center">
         <p className="text-muted text-sm">Connect your wallet to view your points.</p>
       </div>
     );
@@ -150,7 +150,7 @@ function UserPointsInner({ address }: { address: string }) {
 
   if (isLoading || !data) {
     return (
-      <div className="border-border rounded border p-4">
+      <div className="bg-surface border-border rounded-[var(--card-radius)] border p-4">
         <div className="text-muted text-sm">Loading your points...</div>
       </div>
     );
@@ -159,7 +159,7 @@ function UserPointsInner({ address }: { address: string }) {
   return (
     <div className="space-y-3">
       {/* Points summary */}
-      <div className="border-border rounded border p-4">
+      <div className="bg-surface border-border rounded-[var(--card-radius)] border p-4">
         <div className="flex items-baseline justify-between">
           <div>
             <span className="text-muted text-xs">Your PL Points</span>
@@ -209,7 +209,7 @@ function UserPointsInner({ address }: { address: string }) {
       <StreakCard streak={data.streak} address={address} />
 
       {/* Point breakdown — collapsed by default */}
-      <div className="border-border rounded border px-3 py-2.5">
+      <div className="bg-surface border-border rounded-[var(--card-radius)] border px-3 py-2.5">
         <button
           type="button"
           onClick={() => setBreakdownOpen(!breakdownOpen)}
@@ -343,7 +343,7 @@ function ReferralSection({
   };
 
   return (
-    <div className="border-border rounded border px-3 py-2.5 space-y-2">
+    <div className="bg-surface border-border rounded-[var(--card-radius)] border px-3 py-2.5 space-y-2">
       {/* Referral link + actions */}
       {referralLink ? (
         <div>

--- a/src/components/airdrop/WeeklySnapshots.tsx
+++ b/src/components/airdrop/WeeklySnapshots.tsx
@@ -39,7 +39,7 @@ export function WeeklySnapshots() {
 
   if (isLoading || !data) {
     return (
-      <div className="border-border rounded border p-4">
+      <div className="bg-surface border-border rounded-[var(--card-radius)] border p-4">
         <div className="text-muted text-sm">Loading snapshots...</div>
       </div>
     );
@@ -47,7 +47,7 @@ export function WeeklySnapshots() {
 
   if (data.snapshots.length === 0) {
     return (
-      <div className="border-border rounded border p-4">
+      <div className="bg-surface border-border rounded-[var(--card-radius)] border p-4">
         <h3 className="text-foreground text-sm font-bold mb-2">Weekly Recaps</h3>
         <div className="text-muted text-xs">
           No weekly snapshots yet — check back after the first week!
@@ -57,7 +57,7 @@ export function WeeklySnapshots() {
   }
 
   return (
-    <div className="border-border rounded border p-4">
+    <div className="bg-surface border-border rounded-[var(--card-radius)] border p-4">
       <h3 className="text-foreground text-sm font-bold mb-3">Weekly Recaps</h3>
 
       <div className="space-y-2">
@@ -72,7 +72,7 @@ export function WeeklySnapshots() {
           return (
             <div
               key={snap.weekNumber}
-              className="border-border rounded border px-3 py-2"
+              className="bg-surface border-border rounded-[var(--card-radius)] border px-3 py-2"
             >
               <div className="text-foreground text-xs font-bold mb-1">
                 Week {snap.weekNumber} Recap{" "}


### PR DESCRIPTION
## Summary
- **CampaignHero**: Large Newsreader serif "PLOT BIG AIRDROP" title (48px), `bg-surface` card with `card-radius`, countdown digits in `surface-raised` cards, modal with `backdrop-blur-sm` and `bg-surface`
- **All 7 airdrop widgets**: Updated from `border-border rounded border` to `bg-surface border-border rounded-[var(--card-radius)] border` for consistent dark surface cards
- **StreakCard**: Fixed `text-white` → `text-bg` on check-in button
- **Layout**: Sidebar width 320px → 340px per spec
- **All existing functionality preserved**: Points, streaks, check-in, leaderboard pagination, weekly snapshots, claim panel, countdown, milestone chart, referrals, "How It Works" modal
- Version bump to 1.14.0

Closes #1070

## Test plan
- [ ] Typecheck passes ✅
- [ ] Lint passes ✅
- [ ] All 41 unit tests pass ✅
- [ ] Hero displays large serif title with countdown in dark cards
- [ ] All widgets render with dark surface backgrounds
- [ ] Milestone chart SVG renders correctly
- [ ] Streak check-in button functional
- [ ] Leaderboard pagination works
- [ ] "How It Works" modal opens with dark surface styling
- [ ] Responsive: sidebar stacks on mobile (≤1024px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)