### PR TITLE
Apply dark design system to all remaining pages (#1071)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -129,7 +129,7 @@ function AgentsPageInner() {
     <div className="mx-auto max-w-2xl px-6 py-12">
       {/* Hero section — OWS Writer */}
       <div className="mb-10">
-        <h1 className="font-body text-2xl sm:text-3xl font-bold tracking-tight text-foreground">
+        <h1 className="font-heading text-2xl sm:text-3xl font-medium tracking-tight text-foreground">
           Your AI Writes.{" "}
           <span className="text-accent">You Earn.</span>
         </h1>

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -295,26 +295,26 @@ function CreatePage() {
 
   return (
     <div className="mx-auto max-w-2xl px-6 py-12">
-      <h1 className="font-body text-2xl font-bold tracking-tight text-accent">Create</h1>
+      <h1 className="font-heading text-2xl font-medium tracking-tight text-foreground">Create</h1>
 
-      {/* Tab bar */}
-      <div className="mt-6 flex gap-2">
+      {/* Tab bar — pill style */}
+      <div className="mt-6 flex gap-1.5">
         <button
           onClick={() => setTab("new")}
-          className={`rounded border px-3 py-1 text-xs font-medium transition-colors ${
+          className={`rounded-full px-4 py-1.5 text-xs font-medium transition-colors ${
             tab === "new"
-              ? "border-accent text-accent"
-              : "border-border text-muted hover:text-foreground"
+              ? "bg-accent text-white"
+              : "bg-surface border border-border text-muted hover:text-foreground"
           }`}
         >
           New
         </button>
         <button
           onClick={() => setTab("chain")}
-          className={`rounded border px-3 py-1 text-xs font-medium transition-colors ${
+          className={`rounded-full px-4 py-1.5 text-xs font-medium transition-colors ${
             tab === "chain"
-              ? "border-accent text-accent"
-              : "border-border text-muted hover:text-foreground"
+              ? "bg-accent text-white"
+              : "bg-surface border border-border text-muted hover:text-foreground"
           }`}
         >
           Add Plot
@@ -432,7 +432,7 @@ function CreatePage() {
                   disabled={newBusy}
                   rows={12}
                   placeholder="Write the genesis plot (500–10,000 characters)"
-                  className="ruled-paper border-border text-foreground placeholder:text-muted w-full resize-y rounded border focus:border-accent focus:outline-none disabled:opacity-50"
+                  className="bg-surface border-border text-foreground placeholder:text-muted font-prose w-full resize-y rounded border focus:border-accent focus:outline-none disabled:opacity-50"
                 />
               ) : (
                 <ContentPreview content={newContent} />
@@ -580,7 +580,7 @@ function CreatePage() {
                   disabled={chainBusy || noStoryline}
                   rows={12}
                   placeholder={noStoryline ? "Select a storyline above to chain a plot" : "Write the next plot (500–10,000 characters)"}
-                  className="ruled-paper border-border text-foreground placeholder:text-muted w-full resize-y rounded border focus:border-accent focus:outline-none disabled:opacity-50"
+                  className="bg-surface border-border text-foreground placeholder:text-muted font-prose w-full resize-y rounded border focus:border-accent focus:outline-none disabled:opacity-50"
                 />
               ) : (
                 <ContentPreview content={chainContent} />

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,7 +1,7 @@
 export default function PrivacyPage() {
   return (
     <div className="mx-auto max-w-2xl px-6 py-12">
-      <article className="prose prose-sm max-w-none">
+      <article className="prose prose-sm max-w-none font-prose">
         <h1>Privacy Policy</h1>
         <p className="text-muted"><strong>PlotLink &mdash; plotlink.xyz</strong><br />Last updated: April 24, 2026</p>
 

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,7 +1,7 @@
 export default function TermsPage() {
   return (
     <div className="mx-auto max-w-2xl px-6 py-12">
-      <article className="prose prose-sm max-w-none">
+      <article className="prose prose-sm max-w-none font-prose">
         <h1>Terms of Service</h1>
         <p className="text-muted"><strong>PlotLink &mdash; plotlink.xyz</strong><br />Last updated: April 24, 2026</p>
 

--- a/src/components/AgentBuild.tsx
+++ b/src/components/AgentBuild.tsx
@@ -157,19 +157,19 @@ export PLOTLINK_FILEBASE_BUCKET=...`}</CodeBlock>
         <h3 className="text-foreground text-sm font-bold mb-3">API Endpoints</h3>
         <p className="text-muted text-xs mb-3">For advanced integrations, call the indexer endpoints directly after on-chain transactions.</p>
         <div className="space-y-3">
-          <div className="border-border rounded border p-3">
+          <div className="bg-surface border-border rounded-[var(--card-radius)] border p-3">
             <p className="text-foreground text-xs font-semibold">POST /api/index/storyline</p>
             <p className="text-muted text-xs mt-1">Index a new storyline after on-chain creation. Body: <code className="text-foreground">{"{ txHash }"}</code></p>
           </div>
-          <div className="border-border rounded border p-3">
+          <div className="bg-surface border-border rounded-[var(--card-radius)] border p-3">
             <p className="text-foreground text-xs font-semibold">POST /api/index/plot</p>
             <p className="text-muted text-xs mt-1">Index a new plot after on-chain chaining. Body: <code className="text-foreground">{"{ txHash }"}</code></p>
           </div>
-          <div className="border-border rounded border p-3">
+          <div className="bg-surface border-border rounded-[var(--card-radius)] border p-3">
             <p className="text-foreground text-xs font-semibold">POST /api/index/trade</p>
             <p className="text-muted text-xs mt-1">Index a trade for price history. Body: <code className="text-foreground">{"{ txHash, tokenAddress }"}</code></p>
           </div>
-          <div className="border-border rounded border p-3">
+          <div className="bg-surface border-border rounded-[var(--card-radius)] border p-3">
             <p className="text-foreground text-xs font-semibold">POST /api/index/donation</p>
             <p className="text-muted text-xs mt-1">Index a donation. Body: <code className="text-foreground">{"{ txHash }"}</code></p>
           </div>
@@ -180,15 +180,15 @@ export PLOTLINK_FILEBASE_BUCKET=...`}</CodeBlock>
       <section>
         <h3 className="text-foreground text-sm font-bold mb-3">Contract Addresses</h3>
         <div className="space-y-2">
-          <div className="border-border rounded border p-3">
+          <div className="bg-surface border-border rounded-[var(--card-radius)] border p-3">
             <p className="text-muted text-xs">StoryFactory</p>
             <code className="text-foreground font-mono text-xs break-all">{STORY_FACTORY}</code>
           </div>
-          <div className="border-border rounded border p-3">
+          <div className="bg-surface border-border rounded-[var(--card-radius)] border p-3">
             <p className="text-muted text-xs">MCV2_Bond (bonding curve)</p>
             <code className="text-foreground font-mono text-xs break-all">{MCV2_BOND}</code>
           </div>
-          <div className="border-border rounded border p-3">
+          <div className="bg-surface border-border rounded-[var(--card-radius)] border p-3">
             <p className="text-muted text-xs">ERC-8004 Agent Registry</p>
             <code className="text-foreground font-mono text-xs break-all">{ERC8004_REGISTRY}</code>
           </div>

--- a/src/components/AgentDashboard.tsx
+++ b/src/components/AgentDashboard.tsx
@@ -250,7 +250,7 @@ export function AgentDashboard() {
           const storylines = hasActivity ? (allStorylines?.[writerAddr.toLowerCase()] || []) : [];
 
           return (
-            <div key={agent.agentId.toString()} className="border-border rounded border p-4">
+            <div key={agent.agentId.toString()} className="bg-surface border-border rounded-[var(--card-radius)] border p-4">
               <div className="flex items-center justify-between mb-3">
                 <div className="flex items-center gap-2">
                   <p className="text-foreground text-sm font-medium">{agent.name}</p>

--- a/src/components/AgentManage.tsx
+++ b/src/components/AgentManage.tsx
@@ -437,7 +437,7 @@ export function AgentManage({ agentId, role, source }: AgentManageProps) {
       )}
 
       {/* Wallet Info */}
-      <div className="border-border rounded border divide-y divide-[var(--border)]">
+      <div className="bg-surface border-border rounded-[var(--card-radius)] border divide-y divide-[var(--border)]">
         <div className="px-4 py-3">
           <p className="text-muted text-xs mb-1">Owner Wallet</p>
           <p className="text-foreground text-xs font-mono break-all">
@@ -478,7 +478,7 @@ export function AgentManage({ agentId, role, source }: AgentManageProps) {
             </div>
           ) : source === "ows" ? (
             /* OWS agents: paste-based flow (signature generated on local OWS app) */
-            <div className="border-border rounded border p-4 space-y-4">
+            <div className="bg-surface border-border rounded-[var(--card-radius)] border p-4 space-y-4">
               <div>
                 <label className="text-foreground mb-2 block text-sm">New OWS Wallet Address</label>
                 <input type="text" value={newWalletAddr} onChange={(e) => setNewWalletAddr(e.target.value)} placeholder="0x..."
@@ -534,7 +534,7 @@ export function AgentManage({ agentId, role, source }: AgentManageProps) {
             </div>
           ) : (
             /* Direct agents: browser-based sign flow (existing) */
-            <div className="border-border rounded border p-4 space-y-4">
+            <div className="bg-surface border-border rounded-[var(--card-radius)] border p-4 space-y-4">
               {walletStep === "enter" && (
                 <>
                   <div>

--- a/src/components/AgentRegister.tsx
+++ b/src/components/AgentRegister.tsx
@@ -491,7 +491,7 @@ function DirectRegister() {
             {agentId !== undefined && <p className="text-muted mt-1 text-xs">Agent ID: {agentId.toString()}</p>}
           </div>
           {agentId !== undefined && (
-            <details className="border-border rounded border" open={bindStep !== null}>
+            <details className="bg-surface border-border rounded-[var(--card-radius)] border" open={bindStep !== null}>
               <summary className="text-muted cursor-pointer px-4 py-3 text-xs hover:text-foreground transition-colors"
                 onClick={() => { if (!bindStep) setBindStep("enter"); }}>
                 Optional — Want to use a different wallet for your agent?
@@ -597,7 +597,7 @@ export function AgentRegister() {
   return (
     <div className="mt-6 space-y-8">
       {/* Section 1: Link AI Writer */}
-      <div className="border-border rounded border p-5">
+      <div className="bg-surface border-border rounded-[var(--card-radius)] border p-5">
         <h3 className="text-accent mb-1 text-sm font-bold">Link AI Writer (PlotLink OWS App)</h3>
         <p className="text-muted mb-4 text-xs">No coding required — paste the binding code from your OWS app</p>
         <LinkAIWriter />
@@ -611,7 +611,7 @@ export function AgentRegister() {
       </div>
 
       {/* Section 2: Direct Registration */}
-      <div className="border-border rounded border p-5">
+      <div className="bg-surface border-border rounded-[var(--card-radius)] border p-5">
         <h3 className="text-foreground mb-1 text-sm font-bold">Register New AI Agent</h3>
         <p className="text-muted mb-4 text-xs">For developers building custom agent integrations</p>
         <DirectRegister />

--- a/src/components/DonateWidget.tsx
+++ b/src/components/DonateWidget.tsx
@@ -136,7 +136,7 @@ export function DonateWidget({ storylineId, writerAddress }: DonateWidgetProps) 
               if (txState !== "idle") reset();
             }}
             disabled={txState !== "idle" && txState !== "error" && txState !== "done"}
-            className="border-border bg-background text-foreground w-full rounded border px-3 py-2 pr-14 text-sm focus:border-accent focus:outline-none disabled:opacity-50"
+            className="border-border bg-surface text-foreground w-full rounded border px-3 py-2 pr-14 text-sm focus:border-accent focus:outline-none disabled:opacity-50"
           />
           {balance !== undefined && (
             <button

--- a/src/components/RatingWidget.tsx
+++ b/src/components/RatingWidget.tsx
@@ -155,7 +155,7 @@ export function RatingWidget({ storylineId, tokenAddress }: RatingWidgetProps) {
             disabled={submitting}
             maxLength={500}
             rows={2}
-            className="border-border bg-background text-foreground mt-2 w-full resize-none rounded border px-3 py-2 text-sm focus:border-accent focus:outline-none disabled:opacity-50"
+            className="border-border bg-surface text-foreground mt-2 w-full resize-none rounded border px-3 py-2 text-sm focus:border-accent focus:outline-none disabled:opacity-50"
           />
 
           <button

--- a/src/components/ReadingMode.tsx
+++ b/src/components/ReadingMode.tsx
@@ -169,7 +169,7 @@ export function ReadingMode({
                 flipDir === "left" ? "page-flip-out-left" : "page-flip-out-right"
               }`}
               style={{
-                background: "var(--paper-bg, #F5F0E8)",
+                background: "var(--bg)",
                 top: `-${outgoingScroll}px`,
               }}
             >

--- a/src/components/ReferralInput.tsx
+++ b/src/components/ReferralInput.tsx
@@ -43,7 +43,7 @@ export function ReferralInput() {
   // Already has a referrer — show read-only
   if (referrerData) {
     return (
-      <div className="border-border rounded border px-4 py-3">
+      <div className="bg-surface border-border rounded-[var(--card-radius)] border px-4 py-3">
         <div className="text-muted text-xs">Referred by</div>
         <div className="text-foreground text-sm font-mono mt-1">
           {referrerData.displayName}
@@ -84,7 +84,7 @@ export function ReferralInput() {
   };
 
   return (
-    <div className="border-border rounded border px-4 py-3">
+    <div className="bg-surface border-border rounded-[var(--card-radius)] border px-4 py-3">
       <div className="text-muted text-xs mb-2">Who referred you?</div>
       <div className="flex gap-2">
         <input

--- a/src/components/TradingWidget.tsx
+++ b/src/components/TradingWidget.tsx
@@ -450,7 +450,7 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
     <section className="border-border mt-8 rounded border px-4 py-4">
       <h2 className="text-foreground group relative text-sm font-medium">
         Trade to Support
-        <span className="bg-background border-border text-muted pointer-events-none absolute left-0 top-full z-10 mt-1 hidden w-64 rounded border p-2 text-[10px] font-normal leading-snug shadow-md group-hover:block">
+        <span className="bg-surface border-border text-muted pointer-events-none absolute left-0 top-full z-10 mt-1 hidden w-64 rounded border p-2 text-[10px] font-normal leading-snug shadow-md group-hover:block">
           Every trade generates a creator royalty — buying and selling these story tokens directly supports the writer to keep continuing this story.
         </span>
       </h2>
@@ -526,7 +526,7 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
               if (txState !== "idle") reset();
             }}
             disabled={txState !== "idle" && txState !== "error" && txState !== "done"}
-            className={`border-border bg-background text-foreground w-full rounded border px-3 py-2 text-sm focus:border-accent focus:outline-none disabled:opacity-50 ${tab === "sell" || tab === "buy" ? "pr-14" : ""}`}
+            className={`border-border bg-surface text-foreground w-full rounded border px-3 py-2 text-sm focus:border-accent focus:outline-none disabled:opacity-50 ${tab === "sell" || tab === "buy" ? "pr-14" : ""}`}
           />
           {tab === "sell" && balance !== undefined && (
             <button


### PR DESCRIPTION
## Summary
- **Legal pages** (privacy, terms): Added `font-prose` for serif long-form typography
- **Create page**: `font-heading` title, pill-style tabs, `bg-surface` textareas replacing `ruled-paper`, `font-prose` for content areas
- **Agents page**: `font-heading` title
- **Form inputs**: `bg-background` → `bg-surface` in TradingWidget, DonateWidget, RatingWidget
- **ReadingMode**: Last `paper-bg` fallback → `var(--bg)`
- **Agent components** (Build, Manage, Register, Dashboard): All cards updated to `bg-surface` + `card-radius`
- **ReferralInput**: Surface card styling
- **Zero remaining artifacts**: No `font-body`, `ruled-paper`, `bg-background`, `moleskine`, or cream colors left in codebase
- Version bump to 1.15.0

Closes #1071

## Test plan
- [ ] Typecheck passes ✅
- [ ] Lint passes ✅
- [ ] All 41 unit tests pass ✅
- [ ] Create page forms render with dark surface inputs and pill tabs
- [ ] Agents page tabs and cards dark-themed
- [ ] Legal pages display in serif typography
- [ ] Trading/Donate/Rating widgets have dark inputs
- [ ] ReadingMode uses dark background for outgoing pages
- [ ] No cream/light artifacts visible anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)