### PR TITLE
Pivot design system from dark to light theme (#1079)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,19 +1,19 @@
 @import "tailwindcss";
 
 :root {
-  --bg:            oklch(13% 0.02 50);
-  --surface:       oklch(18% 0.018 50);
-  --surface-raised: oklch(21% 0.018 50);
-  --fg:            oklch(92% 0.012 70);
-  --muted:         oklch(55% 0.015 50);
-  --border:        oklch(25% 0.015 50);
-  --accent:        oklch(64% 0.13 28);
-  --accent-dim:    oklch(45% 0.08 28);
-  --accent-bg:     oklch(64% 0.13 28 / 0.1);
-  --danger:        oklch(60% 0.18 25);
-  --success:       oklch(58% 0.14 145);
-  --burn:          oklch(58% 0.20 25);
-  --dist:          oklch(58% 0.16 145);
+  --bg:            oklch(98% 0.005 70);
+  --surface:       oklch(95% 0.008 60);
+  --surface-raised: oklch(91% 0.012 55);
+  --fg:            oklch(20% 0.015 50);
+  --muted:         oklch(48% 0.012 50);
+  --border:        oklch(87% 0.008 55);
+  --accent:        oklch(52% 0.14 28);
+  --accent-dim:    oklch(40% 0.10 28);
+  --accent-bg:     oklch(52% 0.14 28 / 0.08);
+  --danger:        oklch(50% 0.18 25);
+  --success:       oklch(45% 0.14 145);
+  --burn:          oklch(50% 0.20 25);
+  --dist:          oklch(45% 0.16 145);
 
   --font-display: 'Newsreader', 'Iowan Old Style', Georgia, serif;
   --font-body:    -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
@@ -148,7 +148,7 @@ code, pre, .font-mono {
 .story-markdown code {
   font-family: var(--font-mono), monospace;
   font-size: 0.9em;
-  background: oklch(100% 0 0 / 0.06);
+  background: oklch(0% 0 0 / 0.06);
   padding: 0.1em 0.3em;
   border-radius: 2px;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,7 @@ const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
 const appName = "PlotLink";
 const appDescription =
   "Tokenise your story from day 1. Publish plots, drive trading, earn royalties from every trade — powered by the market, not a platform.";
-const themeColor = "#1f1a15";
+const themeColor = "#faf8f5";
 
 export const viewport: Viewport = {
   width: "device-width",

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -1058,7 +1058,7 @@ function StoryRow({
           <div className="absolute inset-0" style={FALLBACK_STYLES[hashToVariant(storyline.storyline_id)]}>
             <div className="flex h-full flex-col items-center justify-center px-4 text-center">
               <div className="mb-2 h-px w-8 bg-accent/40" />
-              <span className="font-heading text-sm sm:text-base font-medium leading-tight tracking-tight text-foreground">
+              <span className="font-heading text-sm sm:text-base font-medium leading-tight tracking-tight text-white">
                 {storyline.title}
               </span>
               <div className="mt-2 h-px w-8 bg-accent/40" />
@@ -1069,7 +1069,7 @@ function StoryRow({
           {/* Status badge */}
           <div className="absolute top-2 right-2">
             {storyline.sunset ? (
-              <span className="rounded-sm bg-black/50 px-1.5 py-0.5 text-[8px] font-semibold text-muted backdrop-blur-sm">complete</span>
+              <span className="rounded-sm bg-black/50 px-1.5 py-0.5 text-[8px] font-semibold text-white/60 backdrop-blur-sm">complete</span>
             ) : isExpired ? (
               <span className="rounded-sm bg-black/50 px-1.5 py-0.5 text-[8px] font-semibold text-danger backdrop-blur-sm">expired</span>
             ) : (
@@ -1656,7 +1656,7 @@ function PortfolioTab({ address, isOwnProfile }: { address: string; isOwnProfile
                 <div className="absolute inset-0" style={FALLBACK_STYLES[hashToVariant(h.storyline.storyline_id)]}>
                   <div className="flex h-full flex-col items-center justify-center px-3 text-center">
                     <div className="mb-2 h-px w-6 bg-accent/40" />
-                    <span className="font-heading text-sm sm:text-base font-medium leading-tight tracking-tight text-foreground">
+                    <span className="font-heading text-sm sm:text-base font-medium leading-tight tracking-tight text-white">
                       {h.storyline.title}
                     </span>
                     <div className="mt-2 h-px w-6 bg-accent/40" />

--- a/src/app/story/[storylineId]/og/route.tsx
+++ b/src/app/story/[storylineId]/og/route.tsx
@@ -107,7 +107,7 @@ export async function GET(
           flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
-          backgroundColor: "#1f1a15",
+          backgroundColor: "#faf8f5",
           fontFamily: fontData ? "Newsreader" : "Georgia, serif",
         }}
       >
@@ -237,11 +237,11 @@ export async function GET(
             width: "380px",
             marginTop: "20px",
             fontSize: "15px",
-            color: "#8a7e70",
+            color: "#6a5e50",
           }}
         >
           <div style={{ display: "flex" }}>by {authorName}</div>
-          <div style={{ display: "flex", color: "#5a5248" }}>plotlink.xyz</div>
+          <div style={{ display: "flex", color: "#4a4038" }}>plotlink.xyz</div>
         </div>
       </div>
     ),

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -90,7 +90,7 @@ export async function generateMetadata({
         type: "launch_miniapp",
         url: storyUrl,
         name: "PlotLink",
-        splashBackgroundColor: "#1f1a15",
+        splashBackgroundColor: "#faf8f5",
       },
     },
   });

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -360,7 +360,7 @@ function StoryHeader({
             <div className="absolute inset-0" style={FALLBACK_STYLES[variant]}>
               <div className="flex h-full flex-col items-center justify-center px-4 text-center">
                 <div className="mb-3 h-px w-8 bg-accent/40" />
-                <h2 className="font-heading text-lg font-medium leading-tight tracking-tight text-foreground lg:text-xl">
+                <h2 className="font-heading text-lg font-medium leading-tight tracking-tight text-white lg:text-xl">
                   {storyline.title}
                 </h2>
                 <div className="mt-3 h-px w-8 bg-accent/40" />

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -60,10 +60,10 @@ export function StoryCard({
           {/* Fallback: centered title treatment */}
           <div className="flex h-full flex-col items-center justify-center px-4 text-center">
             <div className="mb-3 h-px w-8 bg-[var(--accent)]/40" />
-            <h3 className="font-heading text-base font-medium leading-tight tracking-tight text-foreground sm:text-lg">
+            <h3 className="font-heading text-base font-medium leading-tight tracking-tight text-white sm:text-lg">
               {storyline.title}
             </h3>
-            <div className="mt-2 text-[10px] text-muted">
+            <div className="mt-2 text-[10px] text-white/70">
               <WriterIdentityClient address={storyline.writer_address} writerType={storyline.writer_type} />
             </div>
             <div className="mt-3 h-px w-8 bg-[var(--accent)]/40" />
@@ -76,7 +76,7 @@ export function StoryCard({
 
       {/* Top-left badges */}
       <div className="absolute top-0 left-0 z-10 flex flex-wrap gap-1 p-2">
-        <span className="rounded-sm bg-black/50 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-foreground backdrop-blur-sm">
+        <span className="rounded-sm bg-black/50 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-white backdrop-blur-sm">
           {displayGenre || "Uncategorized"}
         </span>
         {storyline.writer_type === 1 && (


### PR DESCRIPTION
## Summary
- Flip all OKLCH color tokens in `globals.css` from dark palette to light: warm white backgrounds (`98%` lightness), off-white surfaces (`95%`), dark brown text (`20%`)
- Adjust accent/semantic colors (danger, success, burn, dist) darker for proper contrast on light backgrounds
- Update hardcoded `#1f1a15` theme/splash colors to `#faf8f5` in layout, story detail, and OG image
- Fix inline code background from white overlay (`oklch(100%)`) to dark overlay (`oklch(0%)`) for light theme
- Story card interiors remain dark-toned (book covers on a white shelf) — FALLBACK_STYLES untouched
- OG image: outer background light, inner cover card stays dark, text colors adjusted for contrast
- Version bump 1.15.0 → 1.16.0

## Test plan
- [ ] Verify page backgrounds render white/warm-white
- [ ] Verify text is dark and readable on all surfaces
- [ ] Verify accent (terracotta) buttons/links have sufficient contrast on light bg
- [ ] Verify story cards retain dark interiors with legible overlays
- [ ] Verify nav, footer, sidebar, filters are readable on light background
- [ ] Verify no hardcoded dark OKLCH values remain outside card interiors
- [ ] Verify OG image renders correctly with light outer background

🤖 Generated with [Claude Code](https://claude.com/claude-code)