### PR TITLE
Redesign fix: remove duplicated hero, add tagline (#1081)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,13 +40,13 @@ export default async function Home({
 
   return (
     <div className="mx-auto max-w-[var(--grid-max)] px-3 py-5 sm:px-5 sm:py-8">
-      {/* Hero */}
+      {/* Hero tagline */}
       <header className="mb-0 pt-2">
         <h1 className="font-heading text-[22px] font-medium tracking-tight text-foreground sm:text-[28px]">
-          Plot<span className="text-accent">Link</span>
+          Your story is a token.
         </h1>
         <p className="mt-1 text-[13px] text-muted">
-          On-chain stories, tokenized by their writers
+          Write, tokenize, and trade storylines on a bonding curve — from day one.
         </p>
       </header>
 

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -33,7 +33,7 @@ export function NavBar() {
 
   return (
     <nav className="fixed top-0 right-0 left-0 z-50 border-b border-[var(--border)] bg-[var(--bg)]/95 backdrop-blur-sm">
-      <div className="mx-auto flex h-11 max-w-5xl items-center justify-between px-4">
+      <div className="mx-auto flex h-11 max-w-[var(--grid-max)] items-center justify-between px-4">
         {/* Logo */}
         <Link
           href="/"


### PR DESCRIPTION
## Summary
- Removed the duplicated "PlotLink / On-chain stories" hero section from the main page — the logo now only appears once in the nav bar
- Replaced with a proper marketing tagline: "Your story is a token." + descriptive subtitle
- Aligned NavBar max-width to `--grid-max` (1280px) so nav and page content edges match

## Test plan
- [ ] Verify PlotLink logo appears only in the nav bar, not repeated below
- [ ] Hero shows "Your story is a token." tagline with subtitle
- [ ] Content edges align between nav and page body
- [ ] Mobile layout still works (responsive)

Closes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)