### PR TITLE
Redesign fix: remove stripe fallback, TVL-only grid cards (#1082)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -1,19 +1,18 @@
 import Link from "next/link";
 import type { Storyline } from "../../lib/supabase";
 import { WriterIdentityClient } from "./WriterIdentityClient";
-import { StoryCardTVL, StoryCardPrice } from "./StoryCardStats";
+import { StoryCardTVL } from "./StoryCardStats";
 import { getStoryStatus } from "../../lib/story-status";
 
-type FallbackVariant = "A" | "B" | "C" | "D";
+type FallbackVariant = "A" | "C" | "D";
 
 function hashToVariant(id: number): FallbackVariant {
-  const variants: FallbackVariant[] = ["A", "B", "C", "D"];
-  return variants[((id * 2654435761) >>> 0) % 4];
+  const variants: FallbackVariant[] = ["A", "C", "D"];
+  return variants[((id * 2654435761) >>> 0) % 3];
 }
 
 const FALLBACK_STYLES: Record<FallbackVariant, React.CSSProperties> = {
   A: { background: "radial-gradient(circle at 30% 70%, oklch(30% 0.06 28 / 0.5) 0%, transparent 60%), linear-gradient(160deg, oklch(22% 0.03 50) 0%, oklch(16% 0.025 30) 100%)" },
-  B: { background: "repeating-linear-gradient(-45deg, oklch(20% 0.02 50) 0px, oklch(20% 0.02 50) 2px, oklch(23% 0.025 50) 2px, oklch(23% 0.025 50) 12px)" },
   C: { background: "conic-gradient(from 45deg at 80% 20%, oklch(25% 0.04 280 / 0.3), transparent 120deg), linear-gradient(180deg, oklch(20% 0.03 260) 0%, oklch(15% 0.02 240) 100%)" },
   D: { background: "oklch(18% 0.035 50)" },
 };
@@ -102,10 +101,7 @@ export function StoryCard({
           <WriterIdentityClient address={storyline.writer_address} writerType={storyline.writer_type} />
         </div>
         {storyline.token_address && (
-          <div className="mt-1.5 flex items-center gap-2">
-            <span className="rounded-[3px] bg-[oklch(52%_0.14_28_/_0.15)] px-1.5 py-[2px] font-mono text-[10px] font-medium tabular-nums text-accent">
-              <StoryCardPrice tokenAddress={storyline.token_address} />
-            </span>
+          <div className="mt-1.5">
             <span className="font-mono text-[10px] tabular-nums text-[oklch(55%_0.01_50)]">
               <StoryCardTVL tokenAddress={storyline.token_address} />
             </span>

--- a/src/components/StoryCardStats.tsx
+++ b/src/components/StoryCardStats.tsx
@@ -104,6 +104,6 @@ export function StoryCardTVL({ tokenAddress }: { tokenAddress: string }) {
     : null;
 
   return (
-    <span>TVL: <span className="font-semibold text-[var(--accent)]">{tvl} {RESERVE_LABEL}</span>{tvlUsd && <span className="ml-1 opacity-60">({tvlUsd})</span>}</span>
+    <span>TVL: {tvlUsd ? <><span className="font-semibold text-[var(--accent)]">{tvlUsd}</span><span className="ml-1 opacity-60">({tvl} {RESERVE_LABEL})</span></> : <span className="font-semibold text-[var(--accent)]">{tvl} {RESERVE_LABEL}</span>}</span>
   );
 }

--- a/src/components/__tests__/StoryCard.test.tsx
+++ b/src/components/__tests__/StoryCard.test.tsx
@@ -76,9 +76,9 @@ describe("StoryCard", () => {
     expect(link).toHaveClass("group");
   });
 
-  it("shows token price when token_address is present", () => {
+  it("shows TVL when token_address is present", () => {
     render(<StoryCard storyline={makeStoryline()} />);
-    expect(screen.getByTestId("price")).toBeInTheDocument();
+    expect(screen.getByTestId("tvl")).toBeInTheDocument();
   });
 
   it("displays genre prop when provided", () => {


### PR DESCRIPTION
## Summary
- Removed diagonal stripe fallback pattern (variant B) — only 3 subtle fallbacks remain (warm radial, cool conic, solid warm surface)
- Removed token price from main grid story cards — cards now show TVL only
- TVL displays USD value first with PLOT amount as secondary text (per #1083 direction)
- Story detail page still shows full token price info

## Test plan
- [ ] Grid cards show TVL only (no token price chip)
- [ ] Stories without covers use only 3 fallback patterns (no stripes)
- [ ] TVL format: `$X.XX (Y PLOT)` — USD first
- [ ] Story detail page still shows token price
- [ ] All existing tests pass

Closes #1082

🤖 Generated with [Claude Code](https://claude.com/claude-code)