### PR TITLE
Redesign fix: USD value first, PLOT as secondary (#1083)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.16.3",
+  "version": "1.16.4",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/ClaimRoyalties.tsx
+++ b/src/components/ClaimRoyalties.tsx
@@ -115,10 +115,10 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary, plotUsd }
       <div className="flex items-center gap-2">
         <span className="text-muted">Claimable:</span>{" "}
         <span className={`font-medium ${unclaimed > BigInt(0) ? "text-accent" : "text-foreground"}`}>
-          {formatTruncated(unclaimed, decimals)} {RESERVE_LABEL}
+          {plotUsd != null && unclaimed > BigInt(0) ? formatUsdValue(parseFloat(formatUnits(unclaimed, decimals)) * plotUsd) : `${formatTruncated(unclaimed, decimals)} ${RESERVE_LABEL}`}
         </span>
-        {plotUsd != null && unclaimed > BigInt(0) && (
-          <span className="text-muted"> ({formatUsdValue(parseFloat(formatUnits(unclaimed, decimals)) * plotUsd)})</span>
+        {unclaimed > BigInt(0) && (
+          <span className="text-muted"> ({formatTruncated(unclaimed, decimals)} {RESERVE_LABEL})</span>
         )}
         <button
           onClick={txState === "error" ? reset : executeClaim}
@@ -163,11 +163,9 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary, plotUsd }
         <div>
           <span className="text-muted">Claimed:</span>{" "}
           <span className="text-foreground font-medium">
-            {formatTruncated(totalClaimed, decimals)} {RESERVE_LABEL}
+            {plotUsd != null ? formatUsdValue(parseFloat(formatUnits(totalClaimed, decimals)) * plotUsd) : `${formatTruncated(totalClaimed, decimals)} ${RESERVE_LABEL}`}
           </span>
-          {plotUsd != null && (
-            <span className="text-muted"> ({formatUsdValue(parseFloat(formatUnits(totalClaimed, decimals)) * plotUsd)})</span>
-          )}
+          <span className="text-muted"> ({formatTruncated(totalClaimed, decimals)} {RESERVE_LABEL})</span>
         </div>
       )}
       {!eligible && txState === "idle" && (

--- a/src/components/ClaimRoyalties.tsx
+++ b/src/components/ClaimRoyalties.tsx
@@ -165,7 +165,7 @@ export function ClaimRoyalties({ tokenAddress, plotCount, beneficiary, plotUsd }
           <span className="text-foreground font-medium">
             {plotUsd != null ? formatUsdValue(parseFloat(formatUnits(totalClaimed, decimals)) * plotUsd) : `${formatTruncated(totalClaimed, decimals)} ${RESERVE_LABEL}`}
           </span>
-          <span className="text-muted"> ({formatTruncated(totalClaimed, decimals)} {RESERVE_LABEL})</span>
+          {plotUsd != null && <span className="text-muted"> ({formatTruncated(totalClaimed, decimals)} {RESERVE_LABEL})</span>}
         </div>
       )}
       {!eligible && txState === "idle" && (

--- a/src/components/StoryCardStats.tsx
+++ b/src/components/StoryCardStats.tsx
@@ -52,8 +52,8 @@ export function StoryCardStats({ tokenAddress }: { tokenAddress: string }) {
 
   return (
     <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-[var(--text-muted)]">
-      <span>Price: <span className="font-semibold text-[var(--accent)]">{price} {RESERVE_LABEL}</span>{priceUsd && <span className="ml-1 opacity-60">({priceUsd})</span>}</span>
-      <span>TVL: <span className="font-semibold text-[var(--accent)]">{tvl} {RESERVE_LABEL}</span>{tvlUsd && <span className="ml-1 opacity-60">({tvlUsd})</span>}</span>
+      <span>Price: {priceUsd ? <><span className="font-semibold text-[var(--accent)]">{priceUsd}</span><span className="ml-1 opacity-60">({price} {RESERVE_LABEL})</span></> : <span className="font-semibold text-[var(--accent)]">{price} {RESERVE_LABEL}</span>}</span>
+      <span>TVL: {tvlUsd ? <><span className="font-semibold text-[var(--accent)]">{tvlUsd}</span><span className="ml-1 opacity-60">({tvl} {RESERVE_LABEL})</span></> : <span className="font-semibold text-[var(--accent)]">{tvl} {RESERVE_LABEL}</span>}</span>
     </div>
   );
 }
@@ -78,7 +78,7 @@ export function StoryCardPrice({ tokenAddress }: { tokenAddress: string }) {
     : null;
 
   return (
-    <span>{price} {RESERVE_LABEL}{priceUsd && <span className="ml-1 opacity-60">({priceUsd})</span>}</span>
+    <span>{priceUsd ? <>{priceUsd}<span className="ml-1 opacity-60">({price} {RESERVE_LABEL})</span></> : <>{price} {RESERVE_LABEL}</>}</span>
   );
 }
 

--- a/src/components/TokenPriceBox.tsx
+++ b/src/components/TokenPriceBox.tsx
@@ -18,6 +18,9 @@ export function TokenPriceBox({ pricePerToken }: { pricePerToken: number }) {
       <div className="text-foreground text-sm font-bold">
         {usdPrice !== null ? formatUsdTokenPrice(usdPrice) : `${formatPrice(pricePerToken)} ${RESERVE_LABEL}`}
       </div>
+      {usdPrice !== null && (
+        <div className="text-muted text-[10px]">{formatPrice(pricePerToken)} {RESERVE_LABEL}</div>
+      )}
       <div className="text-muted text-[9px]">Token Price</div>
     </>
   );

--- a/src/components/TradingWidget.tsx
+++ b/src/components/TradingWidget.tsx
@@ -572,15 +572,17 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
         </div>
       )}
       {!isZapMode && estimate != null && parsedAmount > BigInt(0) && (() => {
-        const plotAmount = formatTokenAmount(applySlippage(estimate, tab === "buy"), 18);
-        const usd = plotUsd ? formatUsdValue(parseFloat(plotAmount) * plotUsd) : null;
+        const slippageAmount = applySlippage(estimate, tab === "buy");
+        const plotDisplay = formatTokenAmount(slippageAmount, 18);
+        const plotNumeric = parseFloat(formatUnits(slippageAmount, 18));
+        const usd = plotUsd ? formatUsdValue(plotNumeric * plotUsd) : null;
         return (
           <div className="text-muted mt-2 text-xs">
             {tab === "buy" ? "Max cost" : "Min return"}:{" "}
             <span className="font-semibold text-accent">
-              {usd || `${plotAmount} ${RESERVE_LABEL}`}
+              {usd || `${plotDisplay} ${RESERVE_LABEL}`}
             </span>
-            {usd && <span className="ml-1 opacity-60">({plotAmount} {RESERVE_LABEL})</span>}
+            {usd && <span className="ml-1 opacity-60">({plotDisplay} {RESERVE_LABEL})</span>}
             <span className="ml-2">(incl. 3% slippage)</span>
           </div>
         );

--- a/src/components/TradingWidget.tsx
+++ b/src/components/TradingWidget.tsx
@@ -13,6 +13,8 @@ import {
 } from "../../lib/contracts/constants";
 import { getZapQuote, buildZapMintTx } from "../../lib/zap";
 import { indexFetch } from "../../lib/index-fetch";
+import { usePlotUsdPrice } from "../hooks/usePlotUsdPrice";
+import { formatUsdValue } from "../../lib/usd-price";
 
 type Tab = "buy" | "sell";
 type TxState = "idle" | "approving" | "confirming" | "pending" | "done" | "error";
@@ -66,6 +68,7 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
   const [txHash, setTxHash] = useState<string | null>(null);
 
   const { writeContractAsync } = useWriteContract();
+  const { data: plotUsd } = usePlotUsdPrice();
   const { data: ethBalanceData, refetch: refetchEthBalance } = useBalance({ address });
 
   const isPlotMode = payToken === "PLOT" || !isZapAvailable;
@@ -568,15 +571,20 @@ export function TradingWidget({ tokenAddress }: { tokenAddress: Address }) {
           <span className="ml-2">(incl. 3% slippage)</span>
         </div>
       )}
-      {!isZapMode && estimate != null && parsedAmount > BigInt(0) && (
-        <div className="text-muted mt-2 text-xs">
-          {tab === "buy" ? "Max cost" : "Min return"}:{" "}
-          <span className="font-semibold text-accent">
-            {formatTokenAmount(applySlippage(estimate, tab === "buy"), 18)} {RESERVE_LABEL}
-          </span>
-          <span className="ml-2">(incl. 3% slippage)</span>
-        </div>
-      )}
+      {!isZapMode && estimate != null && parsedAmount > BigInt(0) && (() => {
+        const plotAmount = formatTokenAmount(applySlippage(estimate, tab === "buy"), 18);
+        const usd = plotUsd ? formatUsdValue(parseFloat(plotAmount) * plotUsd) : null;
+        return (
+          <div className="text-muted mt-2 text-xs">
+            {tab === "buy" ? "Max cost" : "Min return"}:{" "}
+            <span className="font-semibold text-accent">
+              {usd || `${plotAmount} ${RESERVE_LABEL}`}
+            </span>
+            {usd && <span className="ml-1 opacity-60">({plotAmount} {RESERVE_LABEL})</span>}
+            <span className="ml-2">(incl. 3% slippage)</span>
+          </div>
+        );
+      })()}
 
       {/* Action button */}
       <button

--- a/src/components/UsdPriceTag.tsx
+++ b/src/components/UsdPriceTag.tsx
@@ -2,15 +2,24 @@
 
 import { usePlotUsdPrice } from "../hooks/usePlotUsdPrice";
 import { formatUsdValue } from "../../lib/usd-price";
+import { RESERVE_LABEL } from "../../lib/contracts/constants";
 
 /**
- * Inline USD price tag that converts a PLOT-denominated value to USD.
- * Renders nothing while loading or if price is unavailable.
+ * Inline USD-first price display for a PLOT-denominated value.
+ * Shows: "$X.XX (Y PLOT)" when USD available, "Y PLOT" when not.
  */
 export function UsdPriceTag({ plotAmount }: { plotAmount: number }) {
   const { data: plotUsd } = usePlotUsdPrice();
-  if (!plotUsd || plotAmount <= 0) return null;
+
+  if (plotAmount <= 0) return <span>$0.00 (0 {RESERVE_LABEL})</span>;
+
+  if (!plotUsd) return <span>{plotAmount.toLocaleString(undefined, { maximumFractionDigits: 4 })} {RESERVE_LABEL}</span>;
 
   const usd = plotAmount * plotUsd;
-  return <span className="ml-1 opacity-60">({formatUsdValue(usd)})</span>;
+  return (
+    <span>
+      <span className="font-semibold">{formatUsdValue(usd)}</span>
+      <span className="ml-1 opacity-60">({plotAmount.toLocaleString(undefined, { maximumFractionDigits: 4 })} {RESERVE_LABEL})</span>
+    </span>
+  );
 }

--- a/src/components/WriterTradingStats.tsx
+++ b/src/components/WriterTradingStats.tsx
@@ -48,14 +48,14 @@ export function WriterTradingStats({ storyline, plotUsd, showPrice = true }: Wri
       {showPrice && (
         <div>
           <span className="text-muted">Price:</span>{" "}
-          <span className="text-foreground font-medium">{data ? `${formatPrice(data.price)} ${RESERVE_LABEL}` : "—"}</span>
-          {data && plotUsd && <span className="text-muted"> ({formatUsdValue(parseFloat(data.price) * plotUsd)})</span>}
+          <span className="text-foreground font-medium">{data && plotUsd ? formatUsdValue(parseFloat(data.price) * plotUsd) : data ? `${formatPrice(data.price)} ${RESERVE_LABEL}` : "—"}</span>
+          {data && plotUsd && <span className="text-muted"> ({formatPrice(data.price)} {RESERVE_LABEL})</span>}
         </div>
       )}
       <div>
         <span className="text-muted">TVL:</span>{" "}
-        <span className="text-foreground font-medium">{data ? `${formatPrice(data.tvl)} ${RESERVE_LABEL}` : "—"}</span>
-        {data && plotUsd && <span className="text-muted"> ({formatUsdValue(parseFloat(data.tvl) * plotUsd)})</span>}
+        <span className="text-foreground font-medium">{data && plotUsd ? formatUsdValue(parseFloat(data.tvl) * plotUsd) : data ? `${formatPrice(data.tvl)} ${RESERVE_LABEL}` : "—"}</span>
+        {data && plotUsd && <span className="text-muted"> ({formatPrice(data.tvl)} {RESERVE_LABEL})</span>}
       </div>
     </div>
   );

--- a/src/components/airdrop/ClaimPanel.tsx
+++ b/src/components/airdrop/ClaimPanel.tsx
@@ -207,8 +207,8 @@ function ClaimPanelInner({ address }: { address: string }) {
       <div className="text-center space-y-2">
         <div>
           <div className="text-muted text-[10px]">You earned</div>
-          <div className="text-foreground text-xl font-bold">{amountDisplay} PLOT</div>
-          {usdValue && <div className="text-muted text-xs">({usdValue})</div>}
+          <div className="text-foreground text-xl font-bold">{usdValue || `${amountDisplay} PLOT`}</div>
+          <div className="text-muted text-xs">({amountDisplay} PLOT)</div>
         </div>
 
         {alreadyClaimed ? (

--- a/src/components/airdrop/ClaimPanel.tsx
+++ b/src/components/airdrop/ClaimPanel.tsx
@@ -208,7 +208,7 @@ function ClaimPanelInner({ address }: { address: string }) {
         <div>
           <div className="text-muted text-[10px]">You earned</div>
           <div className="text-foreground text-xl font-bold">{usdValue || `${amountDisplay} PLOT`}</div>
-          <div className="text-muted text-xs">({amountDisplay} PLOT)</div>
+          {usdValue && <div className="text-muted text-xs">({amountDisplay} PLOT)</div>}
         </div>
 
         {alreadyClaimed ? (

--- a/src/components/airdrop/UserPoints.tsx
+++ b/src/components/airdrop/UserPoints.tsx
@@ -178,7 +178,7 @@ function UserPointsInner({ address }: { address: string }) {
             <span className="text-foreground font-medium">
               {currentEstimate.usd ? `~${formatUsdValue(currentEstimate.usd)}` : `${currentEstimate.amount.toLocaleString()} PLOT`}
             </span>
-            <span className="text-muted"> ({currentEstimate.amount.toLocaleString()} PLOT)</span>
+            {currentEstimate.usd && <span className="text-muted"> ({currentEstimate.amount.toLocaleString()} PLOT)</span>}
             <InfoTooltip>
               <div className="space-y-1">
                 {TIER_KEYS.map((key) => {
@@ -192,7 +192,7 @@ function UserPointsInner({ address }: { address: string }) {
                       <span className="text-foreground font-medium">
                         {scenarioUsd ? `~${scenarioUsd}` : `${amount.toLocaleString()} PLOT`}
                       </span>
-                      <span> ({amount.toLocaleString()} PLOT)</span>
+                      {scenarioUsd && <span> ({amount.toLocaleString()} PLOT)</span>}
                     </div>
                   );
                 })}

--- a/src/components/airdrop/UserPoints.tsx
+++ b/src/components/airdrop/UserPoints.tsx
@@ -176,11 +176,9 @@ function UserPointsInner({ address }: { address: string }) {
           <div className="mt-2 text-xs">
             <span className="text-muted">Est. airdrop: </span>
             <span className="text-foreground font-medium">
-              {currentEstimate.amount.toLocaleString()} PLOT
+              {currentEstimate.usd ? `~${formatUsdValue(currentEstimate.usd)}` : `${currentEstimate.amount.toLocaleString()} PLOT`}
             </span>
-            {currentEstimate.usd && (
-              <span className="text-muted"> (~{formatUsdValue(currentEstimate.usd)})</span>
-            )}
+            <span className="text-muted"> ({currentEstimate.amount.toLocaleString()} PLOT)</span>
             <InfoTooltip>
               <div className="space-y-1">
                 {TIER_KEYS.map((key) => {
@@ -192,9 +190,9 @@ function UserPointsInner({ address }: { address: string }) {
                     <div key={key} className="text-muted">
                       At {formatCompact(fdv)} MCap →{" "}
                       <span className="text-foreground font-medium">
-                        {amount.toLocaleString()} PLOT
+                        {scenarioUsd ? `~${scenarioUsd}` : `${amount.toLocaleString()} PLOT`}
                       </span>
-                      {scenarioUsd && <span> (~{scenarioUsd})</span>}
+                      <span> ({amount.toLocaleString()} PLOT)</span>
                     </div>
                   );
                 })}


### PR DESCRIPTION
## Summary
- Flipped all monetary display patterns site-wide to show USD as primary value with PLOT in parentheses
- Pattern: `$14.52 (433.00 PLOT)` instead of `433.00 PLOT ($14.52)`
- Falls back to PLOT-only when USD price unavailable (e.g., `— (X PLOT)`)
- Files updated: StoryCardStats, StoryCardPrice, WriterTradingStats, ClaimRoyalties, TokenPriceBox, UserPoints, ClaimPanel

## Test plan
- [ ] Detail page price shows USD first: `$X.XX (Y PLOT)`
- [ ] Detail page TVL shows USD first: `$X.XX (Y PLOT)`
- [ ] Writer trading stats (profile page) show USD first
- [ ] Royalties display USD first with PLOT in parens
- [ ] TokenPriceBox shows USD with PLOT sub-line
- [ ] Airdrop estimates show USD first: `~$X (Y PLOT)`
- [ ] ClaimPanel shows USD first
- [ ] When USD unavailable, gracefully falls back to PLOT-only
- [ ] All tests pass

Closes #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)