### PR TITLE
Redesign fix: preserve markdown content rendering (#1084)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -89,31 +89,48 @@ code, pre, .font-mono {
   overflow-wrap: break-word;
   word-break: break-word;
 }
+.story-markdown h1,
+.story-markdown h2,
+.story-markdown h3,
+.story-markdown h4,
+.story-markdown h5,
+.story-markdown h6 {
+  font-family: var(--font-heading);
+  letter-spacing: -0.01em;
+}
 .story-markdown h1 {
   font-size: 1.5rem;
-  line-height: 2;
-  font-weight: 700;
-  margin: 1.75rem 0;
+  line-height: 1.3;
+  font-weight: 600;
+  margin: 1.75rem 0 0.75rem;
 }
 .story-markdown h2 {
   font-size: 1.25rem;
-  line-height: 2;
-  font-weight: 700;
-  margin: 1.75rem 0 0;
+  line-height: 1.3;
+  font-weight: 600;
+  margin: 1.75rem 0 0.5rem;
 }
 .story-markdown h3 {
   font-size: 1.1rem;
-  line-height: 1.75;
+  line-height: 1.4;
   font-weight: 600;
-  margin: 1.75rem 0 0;
+  margin: 1.5rem 0 0.5rem;
+}
+.story-markdown h4,
+.story-markdown h5,
+.story-markdown h6 {
+  font-size: 1rem;
+  line-height: 1.4;
+  font-weight: 600;
+  margin: 1.25rem 0 0.5rem;
 }
 .story-markdown p {
-  margin: 0 0 1.75rem;
+  margin: 0 0 1.5rem;
 }
 .story-markdown blockquote {
   border-left: 3px solid var(--accent);
   padding-left: 1rem;
-  margin: 1.75rem 0;
+  margin: 1.5rem 0;
   font-style: italic;
   color: var(--muted);
 }
@@ -131,10 +148,16 @@ code, pre, .font-mono {
 }
 .story-markdown ul,
 .story-markdown ol {
-  margin: 0 0 1.75rem 1.5em;
+  margin: 0 0 1.5rem 1.5em;
+}
+.story-markdown ol {
+  list-style-type: decimal;
+}
+.story-markdown ul {
+  list-style-type: disc;
 }
 .story-markdown li {
-  margin-bottom: 0;
+  margin-bottom: 0.25rem;
 }
 .story-markdown strong {
   font-weight: 700;
@@ -144,13 +167,44 @@ code, pre, .font-mono {
 }
 .story-markdown del {
   text-decoration: line-through;
+  opacity: 0.7;
+}
+.story-markdown a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.story-markdown a:hover {
+  opacity: 0.8;
 }
 .story-markdown code {
   font-family: var(--font-mono), monospace;
-  font-size: 0.9em;
-  background: oklch(0% 0 0 / 0.06);
-  padding: 0.1em 0.3em;
-  border-radius: 2px;
+  font-size: 0.85em;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 0.15em 0.35em;
+  border-radius: 3px;
+}
+.story-markdown pre {
+  margin: 1.5rem 0;
+  padding: 1rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow-x: auto;
+}
+.story-markdown pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 0.85em;
+  line-height: 1.6;
+}
+.story-markdown img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 6px;
+  margin: 1.5rem 0;
 }
 
 /* Prevent iOS Safari auto-zoom on input focus */

--- a/src/components/StoryContent.tsx
+++ b/src/components/StoryContent.tsx
@@ -15,6 +15,9 @@ const sanitizeSchema = {
     "h1",
     "h2",
     "h3",
+    "h4",
+    "h5",
+    "h6",
     "blockquote",
     "hr",
     "ul",
@@ -22,8 +25,14 @@ const sanitizeSchema = {
     "li",
     "br",
     "code",
+    "pre",
+    "a",
+    "img",
   ],
-  attributes: {},
+  attributes: {
+    a: ["href", "title"],
+    img: ["src", "alt", "title"],
+  },
 };
 
 export function StoryContent({ content }: { content: string }) {


### PR DESCRIPTION
## Summary
- Headings (h1-h6) use Newsreader display font with letter-spacing and proper weight hierarchy
- Blockquotes retain accent-color left border with italic muted text
- Code blocks: inline code gets surface bg + border; fenced code in pre blocks with overflow-x scroll
- Links styled with accent color + underline offset
- Images responsive (max-width: 100%) with border-radius
- Added `a`, `img`, `pre`, `h4`-`h6` to sanitize schema with safe attributes (href, src, alt, title)
- Lists get explicit bullet/number styles and consistent spacing
- Write/Preview toggle unchanged

## Test plan
- [ ] Story detail page renders markdown headings (h1-h3) in Newsreader font
- [ ] Bold, italic, strikethrough render correctly
- [ ] Ordered and unordered lists show bullets/numbers
- [ ] Blockquotes show accent left border + italic
- [ ] Inline code has surface background with border
- [ ] Fenced code blocks in pre element with scroll
- [ ] Links show accent color + underline
- [ ] Images render responsively
- [ ] Horizontal rules show "* * *" separator
- [ ] Create page Write/Preview toggle still works
- [ ] No regression in existing story display

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)