### PR TITLE
[hotfix] Increase indexer tx age limit to 30min

### DIFF
--- a/lib/index-auth.ts
+++ b/lib/index-auth.ts
@@ -9,7 +9,7 @@
 import { type Hex } from "viem";
 import { publicClient, getReceiptWithRetry } from "./rpc";
 
-const MAX_TX_AGE_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_TX_AGE_MS = 30 * 60 * 1000; // 30 minutes
 
 /**
  * Validate that a tx hash corresponds to a real, recent, successful transaction.


### PR DESCRIPTION
## Summary
- Increases `MAX_TX_AGE_MS` in `lib/index-auth.ts` from 5 minutes to 30 minutes
- Users retrying indexing after slow Base L2 confirmations were getting 400 errors because `validateRecentTx` rejected their valid transactions as "too old"
- 30 minutes still prevents DoS from stale tx hashes while accommodating retry scenarios

## Root Cause
User submitted a storyline creation tx → Base L2 was slow to confirm → by the time they clicked "Retry Indexing", the tx was >5 min old → indexer rejected it with 400

## Test plan
- [x] Typecheck passes
- [ ] Verify user can retry indexing after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)