### PR TITLE
[hotfix] Fix infinite RPC polling on tx receipt

### DIFF
--- a/src/hooks/usePublish.ts
+++ b/src/hooks/usePublish.ts
@@ -106,9 +106,13 @@ export function usePublish() {
         });
         opts.onTxConfirmed?.(hash);
 
-        // 3. Wait for tx confirmation
+        // 3. Wait for tx confirmation (2-min timeout, 4s polling to avoid request spam)
         setState("pending");
-        const receipt = await publicClient.waitForTransactionReceipt({ hash });
+        const receipt = await publicClient.waitForTransactionReceipt({
+          hash,
+          timeout: 120_000,
+          pollingInterval: 4_000,
+        });
 
         setReceipt(receipt);
 
@@ -127,8 +131,11 @@ export function usePublish() {
         setState("published");
         cachedCid.current = null;
       } catch (err) {
-        const message =
-          err instanceof Error ? err.message : "Unknown error";
+        let message = err instanceof Error ? err.message : "Unknown error";
+        if (message.includes("Timed out") && message.includes("transaction")) {
+          message =
+            "Transaction confirmation timed out. It may still be processing — check your wallet and refresh the page in a few minutes.";
+        }
         setError(message);
         setState("error");
       }


### PR DESCRIPTION
## Summary
- Adds `timeout: 120_000` (2 min) and `pollingInterval: 4_000` (4s) to `waitForTransactionReceipt` in `usePublish.ts`
- Previously had no timeout → infinite polling loop (250+ requests flooding RPC nodes)
- Replaces raw viem timeout error with user-friendly message: "Transaction confirmation timed out. It may still be processing — check your wallet and refresh the page in a few minutes."

## Root Cause
When a wallet returns a tx hash that isn't found by the RPC node (dropped tx, propagation delay), viem's `waitForTransactionReceipt` polls forever with no exit condition.

## Test plan
- [x] Typecheck passes
- [ ] Verify tx submission stops polling after 2 minutes
- [ ] Verify friendly error message displays on timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)