### PR TITLE
Remove Token Price label, compact mobile stats grid (#1095)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -287,6 +287,9 @@ function StoryHeader({
   const createdDate = storyline.block_timestamp
     ? new Date(storyline.block_timestamp).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
     : null;
+  const createdDateCompact = storyline.block_timestamp
+    ? new Date(storyline.block_timestamp).toLocaleDateString("en-US", { month: "short", day: "numeric" }) + " '" + new Date(storyline.block_timestamp).getFullYear().toString().slice(2)
+    : null;
   const variant = hashToVariant(storylineId);
 
   const statsGrid = priceInfo ? (
@@ -323,7 +326,7 @@ function StoryHeader({
           {storyline.sunset ? (
             "Complete"
           ) : storyline.has_deadline && storyline.last_plot_time ? (
-            <DeadlineCountdown lastPlotTime={storyline.last_plot_time} hideLabel valueClassName="text-[15px] font-semibold tabular-nums text-foreground" />
+            <DeadlineCountdown lastPlotTime={storyline.last_plot_time} hideLabel compact valueClassName="text-[15px] font-semibold tabular-nums text-foreground" />
           ) : !storyline.has_deadline ? (
             "Open"
           ) : (
@@ -333,7 +336,10 @@ function StoryHeader({
       </div>
       <div className="rounded-[var(--card-radius)] border border-border bg-surface px-3 py-2.5">
         <div className="text-[10px] font-medium uppercase tracking-[0.04em] text-muted mb-1">Created</div>
-        <div className="text-[15px] font-semibold tabular-nums text-foreground">{createdDate ?? "—"}</div>
+        <div className="text-[15px] font-semibold tabular-nums text-foreground">
+          <span className="sm:hidden">{createdDateCompact ?? "—"}</span>
+          <span className="hidden sm:inline">{createdDate ?? "—"}</span>
+        </div>
       </div>
     </div>
   ) : null;

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -284,11 +284,12 @@ function StoryHeader({
   storylineId: number;
   coverUrl?: string;
 }) {
-  const createdDate = storyline.block_timestamp
-    ? new Date(storyline.block_timestamp).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
+  const createdTs = storyline.block_timestamp ? new Date(storyline.block_timestamp) : null;
+  const createdDate = createdTs
+    ? createdTs.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
     : null;
-  const createdDateCompact = storyline.block_timestamp
-    ? new Date(storyline.block_timestamp).toLocaleDateString("en-US", { month: "short", day: "numeric" }) + " '" + new Date(storyline.block_timestamp).getFullYear().toString().slice(2)
+  const createdDateCompact = createdTs
+    ? createdTs.toLocaleDateString("en-US", { month: "short", day: "numeric" }) + " '" + createdTs.getFullYear().toString().slice(2)
     : null;
   const variant = hashToVariant(storylineId);
 

--- a/src/components/DeadlineCountdown.tsx
+++ b/src/components/DeadlineCountdown.tsx
@@ -9,10 +9,12 @@ export function DeadlineCountdown({
   lastPlotTime,
   hideLabel,
   valueClassName,
+  compact,
 }: {
   lastPlotTime: string;
   hideLabel?: boolean;
   valueClassName?: string;
+  compact?: boolean;
 }) {
   const [remaining, setRemaining] = useState<number | null>(null);
 
@@ -52,12 +54,22 @@ export function DeadlineCountdown({
   const seconds = remaining % 60;
 
   let formatted: string;
-  if (days > 0) {
-    formatted = `${days}d ${hours}h ${minutes}m ${seconds}s`;
-  } else if (hours > 0) {
-    formatted = `${hours}h ${minutes}m ${seconds}s`;
+  if (compact) {
+    if (days > 0) {
+      formatted = `${days}d ${hours}h`;
+    } else if (hours > 0) {
+      formatted = `${hours}h ${minutes}m`;
+    } else {
+      formatted = `${minutes}m ${seconds}s`;
+    }
   } else {
-    formatted = `${minutes}m ${seconds}s`;
+    if (days > 0) {
+      formatted = `${days}d ${hours}h ${minutes}m ${seconds}s`;
+    } else if (hours > 0) {
+      formatted = `${hours}h ${minutes}m ${seconds}s`;
+    } else {
+      formatted = `${minutes}m ${seconds}s`;
+    }
   }
 
   return (

--- a/src/components/TokenPriceBox.tsx
+++ b/src/components/TokenPriceBox.tsx
@@ -21,7 +21,6 @@ export function TokenPriceBox({ pricePerToken }: { pricePerToken: number }) {
       {usdPrice !== null && (
         <div className="text-muted text-[10px]">{formatPrice(pricePerToken)} {RESERVE_LABEL}</div>
       )}
-      <div className="text-muted text-[9px]">Token Price</div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Removed redundant "Token Price" subtitle from the Price stats box in `TokenPriceBox`
- Added `compact` prop to `DeadlineCountdown` — shows `3d 18h` instead of `3d 18h 59m 2s` when days > 0
- Created date shows compact format on mobile (`Apr 24, '26`) and full format on desktop (`Apr 24, 2026`)
- Version bump 1.17.1 → 1.17.2

Closes #1095

## Test plan
- [ ] Verify Price stats box no longer shows "Token Price" subtitle text
- [ ] Verify deadline shows compact format (e.g. `3d 18h`) — no wrapping on mobile
- [ ] On mobile (375px), verify Created date shows compact format (e.g. `Apr 24, '26`) fitting one line
- [ ] On desktop, verify Created date shows full format (e.g. `Apr 24, 2026`)
- [ ] Confirm no regressions in other stats boxes (Market Cap, Supply, Plots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)