### PR TITLE
Align desktop column top edges on detail page (#1096)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -171,7 +171,7 @@ export default async function StoryPage({ params }: { params: Params }) {
 
       <StoryHeader storyline={storyline} priceInfo={priceInfo} storylineId={id} />
 
-      <div className="mt-8 grid grid-cols-1 gap-10 lg:grid-cols-[1fr_320px]">
+      <div className="mt-8 grid grid-cols-1 gap-10 lg:grid-cols-[1fr_320px] lg:items-start">
         {/* Story content — genesis + table of contents */}
         <main className="min-w-0">
           {genesis ? (

--- a/src/components/PriceChart.tsx
+++ b/src/components/PriceChart.tsx
@@ -114,7 +114,7 @@ export function PriceChart({ tokenAddress, currentPriceRaw }: PriceChartProps) {
   // Empty state
   if (!hasData) {
     return (
-      <section className="border-border mt-4 rounded border px-4 py-4">
+      <section className="border-border rounded border px-4 py-4">
         <h2 className="text-foreground text-sm font-medium">Price History</h2>
         <div className="mt-3 flex flex-col items-center justify-center py-6">
           <svg width="40" height="40" viewBox="0 0 40 40">
@@ -169,7 +169,7 @@ export function PriceChart({ tokenAddress, currentPriceRaw }: PriceChartProps) {
   if (historicalPoints.length === 0) {
     // All points filtered out — shouldn't happen, but fallback
     return (
-      <section className="border-border mt-4 rounded border px-4 py-4">
+      <section className="border-border rounded border px-4 py-4">
         <h2 className="text-foreground text-sm font-medium">Price History</h2>
         <p className="text-muted mt-2 text-[10px]">USD pricing data not yet available</p>
       </section>
@@ -249,7 +249,7 @@ export function PriceChart({ tokenAddress, currentPriceRaw }: PriceChartProps) {
   const priceLabel = effectiveMode === "usd" ? "USD" : RESERVE_LABEL;
 
   return (
-    <section className="border-border mt-4 rounded border px-4 py-4">
+    <section className="border-border rounded border px-4 py-4">
       <div className="flex items-center justify-between">
         <h2 className="text-foreground text-sm font-medium">Price History</h2>
         {hasUsdData && (


### PR DESCRIPTION
## Summary
- Added `lg:items-start` to the two-column grid so both columns align to the top on desktop
- Removed `mt-4` from all PriceChart `<section>` elements — this was the first sidebar child and the extra top margin pushed it below the main content's top edge
- Sidebar spacing between items is already handled by `space-y-4` on the `<aside>`, so removing `mt-4` from PriceChart doesn't affect inter-widget spacing
- No changes to mobile layout (stacked, single column)
- Version bump 1.17.2 → 1.17.3

Closes #1096

## Test plan
- [ ] On desktop (1024px+), verify the top edge of Genesis section aligns with the top edge of Price History in the sidebar
- [ ] Verify sidebar widgets still have proper spacing between each other (space-y-4)
- [ ] On mobile, verify stacked layout is unchanged
- [ ] Verify PriceChart renders correctly in both sidebar and MobileActionBar contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)