### PR TITLE
Story card v2: full-bleed cover, unified fallbacks, filter bar redesign

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.17.3",
+  "version": "1.18.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,7 +53,7 @@ export default async function Home({
       <FilterBar writer={writer} genre={genre} lang={lang} tab={tab} totalCount={storylines.length} />
 
       {/* Section label */}
-      <h2 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.08em] text-muted">
+      <h2 className="mt-4 mb-3 text-[11px] font-semibold uppercase tracking-[0.08em] text-muted">
         Explore Stories
       </h2>
 

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -954,19 +954,7 @@ function StoriesTab({
   );
 }
 
-type FallbackVariant = "A" | "B" | "C" | "D";
-
-function hashToVariant(id: number): FallbackVariant {
-  const variants: FallbackVariant[] = ["A", "B", "C", "D"];
-  return variants[((id * 2654435761) >>> 0) % 4];
-}
-
-const FALLBACK_STYLES: Record<FallbackVariant, React.CSSProperties> = {
-  A: { background: "radial-gradient(ellipse at 30% 20%, oklch(28% 0.04 40), oklch(16% 0.02 50))" },
-  B: { background: "repeating-linear-gradient(135deg, oklch(18% 0.018 50) 0px, oklch(18% 0.018 50) 8px, oklch(22% 0.02 45) 8px, oklch(22% 0.02 45) 16px)" },
-  C: { background: "conic-gradient(from 180deg at 50% 50%, oklch(20% 0.03 220), oklch(18% 0.02 50), oklch(20% 0.03 220))" },
-  D: { background: "oklch(20% 0.025 50)" },
-};
+import { FALLBACK_STYLES, hashToVariant } from "../../../components/StoryCard";
 
 function StoryRow({
   storyline,
@@ -1055,34 +1043,29 @@ function StoryRow({
         className="group relative block overflow-hidden rounded-[var(--card-radius)] border border-border transition-transform hover:scale-[1.03]"
       >
         <div className="relative" style={{ aspectRatio: "2/3" }}>
-          <div className="absolute inset-0" style={FALLBACK_STYLES[hashToVariant(storyline.storyline_id)]}>
-            <div className="flex h-full flex-col items-center justify-center px-4 text-center">
-              <div className="mb-2 h-px w-8 bg-accent/40" />
-              <span className="font-heading text-sm sm:text-base font-medium leading-tight tracking-tight text-white">
-                {storyline.title}
-              </span>
-              <div className="mt-2 h-px w-8 bg-accent/40" />
-            </div>
-          </div>
-          <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/0 to-transparent" />
+          <div className="absolute inset-0" style={FALLBACK_STYLES[hashToVariant(storyline.storyline_id)]} />
+          <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_45%,oklch(0%_0_0_/_0.85)_92%)]" />
 
-          {/* Status badge */}
-          <div className="absolute top-2 right-2">
+          {/* Top badges */}
+          <div className="absolute top-2 left-2 z-[1] flex flex-wrap items-center gap-1">
+            <span className="rounded-[3px] bg-[oklch(0%_0_0_/_0.45)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider text-white/90 backdrop-blur-[2px]">
+              {storyline.genre || "Uncategorized"}
+            </span>
             {storyline.sunset ? (
-              <span className="rounded-sm bg-black/50 px-1.5 py-0.5 text-[8px] font-semibold text-white/60 backdrop-blur-sm">complete</span>
+              <span className="rounded-[3px] bg-[oklch(0%_0_0_/_0.45)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider text-white/60 backdrop-blur-[2px]">Complete</span>
             ) : isExpired ? (
-              <span className="rounded-sm bg-black/50 px-1.5 py-0.5 text-[8px] font-semibold text-danger backdrop-blur-sm">expired</span>
+              <span className="rounded-[3px] bg-[oklch(50%_0.18_25_/_0.6)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider text-white/90 backdrop-blur-[2px]">Expired</span>
             ) : (
-              <span className="rounded-sm bg-black/50 px-1.5 py-0.5 text-[8px] font-semibold text-success backdrop-blur-sm">active</span>
+              <span className="rounded-[3px] bg-[oklch(40%_0.10_145_/_0.6)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider text-white/90 backdrop-blur-[2px]">Active</span>
             )}
           </div>
 
-          {/* Bottom overlay: genre + stats */}
-          <div className="absolute bottom-0 left-0 right-0 p-3 space-y-1.5">
-            <span className="rounded-sm bg-black/50 px-1.5 py-0.5 text-[8px] font-semibold uppercase tracking-wider text-white backdrop-blur-sm">
-              {storyline.genre || "Uncategorized"}
-            </span>
-            <div className="flex items-center gap-2 text-[10px] text-white/80">
+          {/* Bottom info */}
+          <div className="absolute bottom-0 left-0 right-0 z-[1] px-2.5 pb-2.5">
+            <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-white line-clamp-2 sm:text-[15px]">
+              {storyline.title}
+            </h3>
+            <div className="mt-1 flex items-center gap-2 text-[10px] text-white/60">
               <span>{storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"}</span>
               <span>·</span>
               <span>{formatViewCount(storyline.view_count)} views</span>
@@ -1653,19 +1636,16 @@ function PortfolioTab({ address, isOwnProfile }: { address: string; isOwnProfile
                 className="relative overflow-hidden rounded-[var(--card-radius)] border border-border"
                 style={{ aspectRatio: "2/3" }}
               >
-                <div className="absolute inset-0" style={FALLBACK_STYLES[hashToVariant(h.storyline.storyline_id)]}>
-                  <div className="flex h-full flex-col items-center justify-center px-3 text-center">
-                    <div className="mb-2 h-px w-6 bg-accent/40" />
-                    <span className="font-heading text-sm sm:text-base font-medium leading-tight tracking-tight text-white">
-                      {h.storyline.title}
-                    </span>
-                    <div className="mt-2 h-px w-6 bg-accent/40" />
-                  </div>
-                </div>
-                <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent" />
-                <div className="absolute bottom-0 left-0 right-0 p-2">
-                  <span className="rounded-sm bg-black/50 px-1.5 py-0.5 text-[8px] font-semibold uppercase tracking-wider text-white backdrop-blur-sm">
+                <div className="absolute inset-0" style={FALLBACK_STYLES[hashToVariant(h.storyline.storyline_id)]} />
+                <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_45%,oklch(0%_0_0_/_0.85)_92%)]" />
+                <div className="absolute top-1.5 left-1.5 z-[1]">
+                  <span className="rounded-[3px] bg-[oklch(0%_0_0_/_0.45)] px-[5px] py-[1px] text-[8px] font-medium uppercase tracking-wider text-white/90 backdrop-blur-[2px]">
                     {h.storyline.genre || "Uncategorized"}
+                  </span>
+                </div>
+                <div className="absolute bottom-0 left-0 right-0 z-[1] px-2 pb-2">
+                  <span className="font-heading text-xs font-semibold leading-tight text-white line-clamp-2 sm:text-sm">
+                    {h.storyline.title}
                   </span>
                 </div>
               </div>

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -24,6 +24,7 @@ import { CommentSection } from "../../../components/CommentSection";
 import { MobileActionBar } from "../../../components/MobileActionBar";
 import { MarketCapBox } from "../../../components/MarketCapBox";
 import { TokenPriceBox } from "../../../components/TokenPriceBox";
+import { FALLBACK_STYLES, hashToVariant } from "../../../components/StoryCard";
 
 /** Deduplicate plots by plot_index, keeping the first occurrence. */
 function deduplicateByPlotIndex(plots: Plot[]) {
@@ -260,19 +261,6 @@ export default async function StoryPage({ params }: { params: Params }) {
   );
 }
 
-type FallbackVariant = "A" | "C" | "D";
-
-function hashToVariant(id: number): FallbackVariant {
-  const variants: FallbackVariant[] = ["A", "C", "D"];
-  return variants[((id * 2654435761) >>> 0) % 3];
-}
-
-const FALLBACK_STYLES: Record<FallbackVariant, React.CSSProperties> = {
-  A: { background: "radial-gradient(circle at 30% 70%, oklch(88% 0.03 28 / 0.4) 0%, transparent 60%), linear-gradient(160deg, oklch(93% 0.015 50) 0%, oklch(90% 0.012 30) 100%)" },
-  C: { background: "radial-gradient(circle at 70% 30%, oklch(90% 0.02 280 / 0.3) 0%, transparent 50%), linear-gradient(180deg, oklch(94% 0.012 260) 0%, oklch(91% 0.01 240) 100%)" },
-  D: { background: "linear-gradient(175deg, oklch(94% 0.015 50) 0%, oklch(90% 0.02 40) 100%)" },
-};
-
 function StoryHeader({
   storyline,
   priceInfo,
@@ -360,13 +348,15 @@ function StoryHeader({
           {coverUrl ? (
             <img src={coverUrl} alt={storyline.title} loading="lazy" className="absolute inset-0 h-full w-full object-cover" />
           ) : (
-            <div className="absolute inset-0 flex flex-col items-center justify-center px-5 text-center" style={FALLBACK_STYLES[variant]}>
-              <h2 className="font-heading text-[22px] font-semibold leading-tight text-[var(--fg)]">
-                {storyline.title}
-              </h2>
-              <div className="mt-3.5 h-0.5 w-8 rounded-sm bg-accent" />
-            </div>
+            <div className="absolute inset-0" style={FALLBACK_STYLES[variant]} />
           )}
+          {/* Gradient overlay + title at bottom */}
+          <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_45%,oklch(0%_0_0_/_0.85)_92%)]" />
+          <div className="absolute bottom-0 left-0 right-0 px-3 pb-3">
+            <h2 className="font-heading text-[18px] font-semibold leading-tight text-white sm:text-[22px]">
+              {storyline.title}
+            </h2>
+          </div>
         </div>
       </div>
 

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { GENRES, LANGUAGES } from "../../lib/genres";
 
@@ -34,8 +34,107 @@ function buildHref(params: { tab: string; writer: string; genre: string; lang: s
   return `/?${sp.toString()}`;
 }
 
+function FilterSheetContent({
+  onClose,
+  writer,
+  genre,
+  lang,
+  onApply,
+}: {
+  onClose: () => void;
+  writer: string;
+  genre: string;
+  lang: string;
+  onApply: (w: string, g: string, l: string) => void;
+}) {
+  const [localWriter, setLocalWriter] = useState(writer);
+  const [localGenre, setLocalGenre] = useState(genre);
+  const [localLang, setLocalLang] = useState(lang);
+
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = ""; };
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="absolute bottom-0 left-0 right-0 rounded-t-2xl bg-[var(--bg)] pb-8 pt-3 shadow-[0_-4px_20px_oklch(0%_0_0_/_0.15)]">
+        {/* Handle */}
+        <div className="mx-auto mb-5 h-1 w-10 rounded-full bg-[var(--border)]" />
+
+        <div className="space-y-5 px-5">
+          {/* Writer */}
+          <div>
+            <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.06em] text-[var(--muted)]">Writer</div>
+            <div className="flex gap-1.5">
+              {WRITER_OPTIONS.map(({ value, label }) => (
+                <button
+                  key={value}
+                  onClick={() => setLocalWriter(value)}
+                  className={`rounded-full border px-3.5 py-1.5 text-xs font-medium transition-colors ${
+                    localWriter === value
+                      ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-bg)]"
+                      : "border-[var(--border)] text-[var(--muted)]"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Genre */}
+          <div>
+            <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.06em] text-[var(--muted)]">Genre</div>
+            <div className="relative">
+              <select
+                value={localGenre}
+                onChange={(e) => setLocalGenre(e.target.value)}
+                className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2.5 text-sm text-[var(--fg)] focus:border-[var(--accent)] focus:outline-none"
+              >
+                <option value="all">All Genres</option>
+                {GENRES.map((g) => <option key={g} value={g}>{g}</option>)}
+              </select>
+            </div>
+          </div>
+
+          {/* Language */}
+          <div>
+            <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.06em] text-[var(--muted)]">Language</div>
+            <div className="relative">
+              <select
+                value={localLang}
+                onChange={(e) => setLocalLang(e.target.value)}
+                className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2.5 text-sm text-[var(--fg)] focus:border-[var(--accent)] focus:outline-none"
+              >
+                <option value="all">All Languages</option>
+                {LANGUAGES.map((l) => <option key={l} value={l}>{l}</option>)}
+              </select>
+            </div>
+          </div>
+
+          {/* Apply */}
+          <button
+            onClick={() => { onApply(localWriter, localGenre, localLang); onClose(); }}
+            className="w-full rounded-lg bg-[var(--accent)] py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+          >
+            Apply Filters
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FilterSheet({ open, ...props }: { open: boolean; onClose: () => void; writer: string; genre: string; lang: string; onApply: (w: string, g: string, l: string) => void }) {
+  if (!open) return null;
+  return <FilterSheetContent {...props} />;
+}
+
 export function FilterBar({ writer, genre, lang, tab, totalCount }: FilterBarProps) {
   const router = useRouter();
+  const [sheetOpen, setSheetOpen] = useState(false);
 
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
@@ -53,75 +152,147 @@ export function FilterBar({ writer, genre, lang, tab, totalCount }: FilterBarPro
     router.push(buildHref(params));
   }
 
+  const handleApplyFilters = useCallback((w: string, g: string, l: string) => {
+    navigate({ tab, writer: w, genre: g, lang: l });
+  }, [tab]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const activeFilterCount = [writer !== "all", genre !== "all", lang !== "all"].filter(Boolean).length;
+  const activeChips: { label: string; clear: () => void }[] = [];
+  if (writer !== "all") activeChips.push({ label: `Writer: ${writer}`, clear: () => navigate({ tab, writer: "all", genre, lang }) });
+  if (genre !== "all") activeChips.push({ label: genre, clear: () => navigate({ tab, writer, genre: "all", lang }) });
+  if (lang !== "all") activeChips.push({ label: lang, clear: () => navigate({ tab, writer, genre, lang: "all" }) });
+
   return (
-    <div className="flex flex-wrap items-center gap-3 py-6 sm:py-4">
-      {/* Sort tab group */}
-      <div className="flex items-center gap-0.5 rounded-md bg-surface p-[3px]">
-        {SORT_OPTIONS.map(({ value, label }) => (
+    <>
+      <div className="border-b border-[var(--border)] py-3 sm:py-4">
+        <div className="flex items-center justify-between gap-4">
+          {/* Sort tabs — underline style */}
+          <div className="flex items-center gap-0">
+            {SORT_OPTIONS.map(({ value, label }) => (
+              <button
+                key={value}
+                onClick={() => navigate({ tab: value, writer, genre, lang })}
+                className={`relative px-3 py-2 text-[13px] font-medium transition-colors sm:text-sm ${
+                  tab === value
+                    ? "font-semibold text-[var(--fg)]"
+                    : "text-[var(--muted)] hover:text-[var(--fg)]"
+                }`}
+              >
+                {label}
+                {tab === value && (
+                  <span className="absolute bottom-0 left-3 right-3 h-[2px] rounded-full bg-[var(--accent)]" />
+                )}
+              </button>
+            ))}
+          </div>
+
+          {/* Desktop filters — hidden on mobile */}
+          <div className="hidden items-center gap-2 sm:flex">
+            {/* Writer pills — segmented control */}
+            <div className="flex items-center rounded-full border border-[var(--border)] p-0.5">
+              {WRITER_OPTIONS.map(({ value, label }) => (
+                <button
+                  key={value}
+                  onClick={() => navigate({ tab, writer: value, genre, lang })}
+                  className={`rounded-full px-2.5 py-1 text-[12px] font-medium transition-colors ${
+                    writer === value
+                      ? "bg-[var(--accent)] text-white"
+                      : "text-[var(--muted)] hover:text-[var(--fg)]"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+
+            {/* Genre pill */}
+            <div className="relative">
+              <select
+                value={genre}
+                onChange={(e) => navigate({ tab, writer, genre: e.target.value, lang })}
+                className={`rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors focus:border-[var(--accent)] focus:outline-none ${
+                  genre !== "all"
+                    ? "border-[var(--accent)] bg-[var(--accent-bg)] text-[var(--accent)]"
+                    : "border-[var(--border)] bg-transparent text-[var(--muted)] hover:border-[var(--muted)] hover:text-[var(--fg)]"
+                }`}
+              >
+                <option value="all">Genre</option>
+                {GENRES.map((g) => <option key={g} value={g}>{g}</option>)}
+              </select>
+            </div>
+
+            {/* Language pill */}
+            <div className="relative">
+              <select
+                value={lang}
+                onChange={(e) => navigate({ tab, writer, genre, lang: e.target.value })}
+                className={`rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors focus:border-[var(--accent)] focus:outline-none ${
+                  lang !== "all"
+                    ? "border-[var(--accent)] bg-[var(--accent-bg)] text-[var(--accent)]"
+                    : "border-[var(--border)] bg-transparent text-[var(--muted)] hover:border-[var(--muted)] hover:text-[var(--fg)]"
+                }`}
+              >
+                <option value="all">Language</option>
+                {LANGUAGES.map((l) => <option key={l} value={l}>{l}</option>)}
+              </select>
+            </div>
+
+            {/* Result count */}
+            {totalCount !== undefined && (
+              <span className="ml-1 text-[12px] tabular-nums text-[var(--muted)]">
+                {totalCount} {totalCount === 1 ? "story" : "stories"}
+              </span>
+            )}
+          </div>
+
+          {/* Mobile filter button */}
           <button
-            key={value}
-            onClick={() => navigate({ tab: value, writer, genre, lang })}
-            className={`rounded px-3.5 py-1.5 text-[13px] font-medium transition-all ${
-              tab === value
-                ? "bg-accent text-white"
-                : "text-muted hover:text-foreground"
+            onClick={() => setSheetOpen(true)}
+            className={`relative flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors sm:hidden ${
+              activeFilterCount > 0
+                ? "border-[var(--accent)] text-[var(--accent)]"
+                : "border-[var(--border)] text-[var(--muted)]"
             }`}
           >
-            {label}
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+            </svg>
+            Filter
+            {activeFilterCount > 0 && (
+              <span className="flex h-4 w-4 items-center justify-center rounded-full bg-[var(--accent)] text-[9px] font-bold text-white">
+                {activeFilterCount}
+              </span>
+            )}
           </button>
-        ))}
+        </div>
+
+        {/* Mobile active filter chips */}
+        {activeChips.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1.5 sm:hidden">
+            {activeChips.map((chip) => (
+              <button
+                key={chip.label}
+                onClick={chip.clear}
+                className="flex items-center gap-1 rounded-full border border-[var(--accent)] bg-[var(--accent-bg)] px-2.5 py-1 text-[11px] font-medium text-[var(--accent)]"
+              >
+                {chip.label}
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            ))}
+          </div>
+        )}
       </div>
 
-      {/* Vertical divider */}
-      <div className="hidden h-6 w-px bg-border sm:block" />
-
-      {/* Writer pill group */}
-      <div className="flex items-center gap-0.5">
-        {WRITER_OPTIONS.map(({ value, label }) => (
-          <button
-            key={value}
-            onClick={() => navigate({ tab, writer: value, genre, lang })}
-            className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
-              writer === value
-                ? "border-accent text-accent bg-[oklch(52%_0.14_28_/_0.1)]"
-                : "border-border text-muted hover:border-muted hover:text-foreground"
-            }`}
-          >
-            {label}
-          </button>
-        ))}
-      </div>
-
-      {/* Genre select */}
-      <select
-        value={genre}
-        onChange={(e) => navigate({ tab, writer, genre: e.target.value, lang })}
-        className="rounded-full border border-border bg-surface px-3 py-1 text-xs text-muted transition-colors hover:border-muted hover:text-foreground focus:border-accent focus:text-foreground focus:outline-none"
-      >
-        <option value="all">All Genres</option>
-        {GENRES.map((g) => (
-          <option key={g} value={g}>{g}</option>
-        ))}
-      </select>
-
-      {/* Language select */}
-      <select
-        value={lang}
-        onChange={(e) => navigate({ tab, writer, genre, lang: e.target.value })}
-        className="rounded-full border border-border bg-surface px-3 py-1 text-xs text-muted transition-colors hover:border-muted hover:text-foreground focus:border-accent focus:text-foreground focus:outline-none"
-      >
-        <option value="all">All Languages</option>
-        {LANGUAGES.map((l) => (
-          <option key={l} value={l}>{l}</option>
-        ))}
-      </select>
-
-      {/* Result count — right aligned, hidden on mobile */}
-      {totalCount !== undefined && (
-        <span className="ml-auto hidden text-xs tabular-nums text-muted sm:inline">
-          {totalCount} {totalCount === 1 ? "story" : "stories"}
-        </span>
-      )}
-    </div>
+      <FilterSheet
+        open={sheetOpen}
+        onClose={() => setSheetOpen(false)}
+        writer={writer}
+        genre={genre}
+        lang={lang}
+        onApply={handleApplyFilters}
+      />
+    </>
   );
 }

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -61,7 +61,7 @@ export function StoryCard({
         )}
         {storyline.writer_type === 1 && (
           <span className="rounded-[3px] bg-[oklch(45%_0.15_280_/_0.6)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-white/90 backdrop-blur-[2px]">
-            AI
+            AI Writer
           </span>
         )}
         {status === "completed" && (

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -4,15 +4,16 @@ import { WriterIdentityClient } from "./WriterIdentityClient";
 import { StoryCardTVL } from "./StoryCardStats";
 import { getStoryStatus } from "../../lib/story-status";
 
-type FallbackVariant = "A" | "C" | "D";
+export type FallbackVariant = "A" | "B" | "C" | "D";
 
-function hashToVariant(id: number): FallbackVariant {
-  const variants: FallbackVariant[] = ["A", "C", "D"];
-  return variants[((id * 2654435761) >>> 0) % 3];
+export function hashToVariant(id: number): FallbackVariant {
+  const variants: FallbackVariant[] = ["A", "B", "C", "D"];
+  return variants[((id * 2654435761) >>> 0) % 4];
 }
 
-const FALLBACK_STYLES: Record<FallbackVariant, React.CSSProperties> = {
+export const FALLBACK_STYLES: Record<FallbackVariant, React.CSSProperties> = {
   A: { background: "radial-gradient(circle at 30% 70%, oklch(88% 0.03 28 / 0.4) 0%, transparent 60%), linear-gradient(160deg, oklch(93% 0.015 50) 0%, oklch(90% 0.012 30) 100%)" },
+  B: { background: "radial-gradient(circle at 50% 40%, oklch(90% 0.025 160 / 0.35) 0%, transparent 55%), linear-gradient(170deg, oklch(93% 0.015 140) 0%, oklch(89% 0.012 170) 100%)" },
   C: { background: "radial-gradient(circle at 70% 30%, oklch(90% 0.02 280 / 0.3) 0%, transparent 50%), linear-gradient(180deg, oklch(94% 0.012 260) 0%, oklch(91% 0.01 240) 100%)" },
   D: { background: "linear-gradient(175deg, oklch(94% 0.015 50) 0%, oklch(90% 0.02 40) 100%)" },
 };
@@ -36,7 +37,7 @@ export function StoryCard({
       href={`/story/${storyline.storyline_id}`}
       className="group relative block aspect-[2/3] overflow-hidden rounded-[var(--card-radius)] border border-[var(--border)] shadow-[0_1px_3px_oklch(0%_0_0_/_0.06)] transition-[transform,box-shadow] duration-200 ease-out hover:z-[2] hover:scale-[1.03] hover:shadow-[0_12px_40px_oklch(0%_0_0_/_0.12)]"
     >
-      {/* Cover image or fallback pattern */}
+      {/* Cover image or fallback pattern — full bleed, clean middle */}
       {coverUrl ? (
         <img
           src={coverUrl}
@@ -45,60 +46,47 @@ export function StoryCard({
           className="absolute inset-0 h-full w-full object-cover"
         />
       ) : (
-        <div className="absolute inset-0" style={FALLBACK_STYLES[variant]}>
-          <div className="absolute inset-0 z-[1] flex flex-col items-center justify-center px-4 text-center">
-            <div className="font-heading text-base font-semibold leading-tight text-[var(--fg)] sm:text-lg" style={{ maxWidth: "90%" }}>
-              {storyline.title}
-            </div>
-            <div className="mt-2.5 h-0.5 w-8 rounded-sm bg-accent" />
-          </div>
-        </div>
+        <div className="absolute inset-0" style={FALLBACK_STYLES[variant]} />
       )}
 
-      {/* Gradient overlay */}
-      {coverUrl ? (
-        <div className="absolute inset-0 bg-[linear-gradient(to_bottom,oklch(0%_0_0_/_0)_40%,oklch(0%_0_0_/_0.35)_60%,oklch(0%_0_0_/_0.85)_100%)]" />
-      ) : (
-        <div className="absolute inset-0 bg-[linear-gradient(to_bottom,oklch(100%_0_0_/_0)_55%,oklch(100%_0_0_/_0.6)_100%)]" />
-      )}
+      {/* Bottom gradient overlay */}
+      <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_45%,oklch(0%_0_0_/_0.85)_92%)]" />
 
       {/* Top badges */}
-      <div className="absolute top-2 right-2 left-2 z-[2] flex flex-wrap items-center gap-1">
+      <div className="absolute top-2 left-2 z-[2] flex flex-wrap items-center gap-1">
         {displayGenre && (
-          <span className="max-w-[50%] truncate rounded-[3px] border border-[var(--border)] bg-[var(--surface)] px-1.5 py-px text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-[var(--muted)]">
+          <span className="rounded-[3px] bg-[oklch(0%_0_0_/_0.45)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-white/90 backdrop-blur-[2px]">
             {displayGenre}
           </span>
         )}
         {storyline.writer_type === 1 && (
-          <span className="rounded-[3px] border border-[oklch(70%_0.10_280)] bg-[oklch(94%_0.03_280)] px-1.5 py-px text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-[oklch(45%_0.12_280)]">
-            AI Writer
+          <span className="rounded-[3px] bg-[oklch(45%_0.15_280_/_0.6)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-white/90 backdrop-blur-[2px]">
+            AI
           </span>
         )}
         {status === "completed" && (
-          <span className="rounded-[3px] border border-[oklch(70%_0.08_145)] bg-[oklch(94%_0.02_145)] px-1.5 py-px text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-[oklch(40%_0.10_145)]">
-            Completed
+          <span className="rounded-[3px] bg-[oklch(40%_0.10_145_/_0.6)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-white/90 backdrop-blur-[2px]">
+            Complete
           </span>
         )}
         {isActive && (
-          <span className="rounded-[3px] border border-[oklch(72%_0.08_80)] bg-[oklch(94%_0.02_80)] px-1.5 py-px text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-[oklch(42%_0.10_80)]">
+          <span className="rounded-[3px] bg-[oklch(40%_0.10_145_/_0.6)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-white/90 backdrop-blur-[2px]">
             Ongoing
           </span>
         )}
       </div>
 
-      {/* Bottom card info */}
+      {/* Bottom card info — always over gradient */}
       <div className="absolute right-0 bottom-0 left-0 z-[2] px-2.5 pt-3 pb-2.5">
-        {coverUrl && (
-          <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-[oklch(97%_0.005_70)] line-clamp-2 sm:text-[15px]">
-            {storyline.title}
-          </h3>
-        )}
-        <div className={`${coverUrl ? "mt-[3px]" : ""} text-[11px] ${coverUrl ? "text-[oklch(75%_0.01_70)]" : "text-[var(--muted)]"}`}>
+        <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-white line-clamp-2 sm:text-[15px]">
+          {storyline.title}
+        </h3>
+        <div className="mt-[3px] text-[11px] text-white/60">
           <WriterIdentityClient address={storyline.writer_address} writerType={storyline.writer_type} />
         </div>
         {storyline.token_address && (
           <div className="mt-1.5">
-            <span className={`font-mono text-[10px] tabular-nums ${coverUrl ? "text-[oklch(55%_0.01_50)]" : "text-[var(--muted)]"}`}>
+            <span className="font-mono text-[10px] tabular-nums text-white/50">
               <StoryCardTVL tokenAddress={storyline.token_address} />
             </span>
           </div>

--- a/src/components/__tests__/FilterBar.test.tsx
+++ b/src/components/__tests__/FilterBar.test.tsx
@@ -51,6 +51,6 @@ describe("FilterBar", () => {
   it("active sort tab is highlighted", () => {
     render(<FilterBar {...defaultProps} tab="trending" />);
     const trendingBtn = screen.getByText("Trending");
-    expect(trendingBtn).toHaveClass("bg-accent");
+    expect(trendingBtn).toHaveClass("font-semibold");
   });
 });

--- a/src/components/__tests__/StoryCard.test.tsx
+++ b/src/components/__tests__/StoryCard.test.tsx
@@ -88,6 +88,6 @@ describe("StoryCard", () => {
 
   it("shows AI Writer badge for AI writers", () => {
     render(<StoryCard storyline={makeStoryline({ writer_type: 1 })} />);
-    expect(screen.getByText("AI Writer")).toBeInTheDocument();
+    expect(screen.getByText("AI")).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/StoryCard.test.tsx
+++ b/src/components/__tests__/StoryCard.test.tsx
@@ -88,6 +88,6 @@ describe("StoryCard", () => {
 
   it("shows AI Writer badge for AI writers", () => {
     render(<StoryCard storyline={makeStoryline({ writer_type: 1 })} />);
-    expect(screen.getByText("AI")).toBeInTheDocument();
+    expect(screen.getByText("AI Writer")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- **StoryCard**: Full-bleed cover with clean middle area, bottom gradient overlay (`transparent → black at 92%`), title/author/TVL over gradient. Dark semi-transparent badge overlays at top-left. Added 4th fallback variant (`B` — green pastel). Removed old centered-title fallback style.
- **FilterBar**: Underline-style sort tabs (New/Trending/Market Cap) on left, segmented writer pills + genre/language dropdown pills on right (desktop). Mobile: compact "Filter" button with badge count, removable chip badges, bottom sheet with grouped options + Apply button.
- **Profile page**: Replaced dark fallback patterns and centered-title cards with unified light pastel fallbacks + gradient overlay card pattern. Imports shared `FALLBACK_STYLES`/`hashToVariant` from StoryCard.
- **Detail page**: Cover now uses shared fallback patterns with gradient overlay and bottom-positioned title. Removed duplicate `FALLBACK_STYLES`/`hashToVariant` definitions.
- Version bump: 1.17.3 → 1.18.0

Closes #1101

## Test plan
- [ ] Verify story cards on home page show clean middle, gradient bottom, title/author at bottom
- [ ] Verify fallback pattern cards (no cover image) look correct with light pastel backgrounds
- [ ] Test filter bar sort tabs with underline style on desktop
- [ ] Test writer/genre/language filter pills on desktop
- [ ] Test mobile filter button + bottom sheet + apply flow
- [ ] Test mobile chip badges appear and are removable
- [ ] Verify detail page cover uses gradient overlay with title at bottom
- [ ] Verify profile page story cards use unified card pattern
- [ ] Verify portfolio holdings cards use unified pattern
- [ ] Check mobile (375px) and desktop (1280px) layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)