### PR TITLE
Fix card author visibility, TVL contrast, and gradient position

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -1044,7 +1044,7 @@ function StoryRow({
       >
         <div className="relative" style={{ aspectRatio: "2/3" }}>
           <div className="absolute inset-0" style={FALLBACK_STYLES[hashToVariant(storyline.storyline_id)]} />
-          <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_45%,oklch(0%_0_0_/_0.85)_92%)]" />
+          <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(0%_0_0_/_0.5)_85%,oklch(0%_0_0_/_0.88)_100%)]" />
 
           {/* Top badges */}
           <div className="absolute top-2 left-2 z-[1] flex flex-wrap items-center gap-1">
@@ -1637,7 +1637,7 @@ function PortfolioTab({ address, isOwnProfile }: { address: string; isOwnProfile
                 style={{ aspectRatio: "2/3" }}
               >
                 <div className="absolute inset-0" style={FALLBACK_STYLES[hashToVariant(h.storyline.storyline_id)]} />
-                <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_45%,oklch(0%_0_0_/_0.85)_92%)]" />
+                <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(0%_0_0_/_0.5)_85%,oklch(0%_0_0_/_0.88)_100%)]" />
                 <div className="absolute top-1.5 left-1.5 z-[1]">
                   <span className="rounded-[3px] bg-[oklch(0%_0_0_/_0.45)] px-[5px] py-[1px] text-[8px] font-medium uppercase tracking-wider text-white/90 backdrop-blur-[2px]">
                     {h.storyline.genre || "Uncategorized"}

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -351,7 +351,7 @@ function StoryHeader({
             <div className="absolute inset-0" style={FALLBACK_STYLES[variant]} />
           )}
           {/* Gradient overlay + title at bottom */}
-          <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_45%,oklch(0%_0_0_/_0.85)_92%)]" />
+          <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(0%_0_0_/_0.5)_85%,oklch(0%_0_0_/_0.88)_100%)]" />
           <div className="absolute bottom-0 left-0 right-0 px-3 pb-3">
             <h2 className="font-heading text-[18px] font-semibold leading-tight text-white sm:text-[22px]">
               {storyline.title}

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -50,7 +50,7 @@ export function StoryCard({
       )}
 
       {/* Bottom gradient overlay */}
-      <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_45%,oklch(0%_0_0_/_0.85)_92%)]" />
+      <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(0%_0_0_/_0.5)_85%,oklch(0%_0_0_/_0.88)_100%)]" />
 
       {/* Top badges */}
       <div className="absolute top-2 left-2 z-[2] flex flex-wrap items-center gap-1">
@@ -81,12 +81,12 @@ export function StoryCard({
         <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-white line-clamp-2 sm:text-[15px]">
           {storyline.title}
         </h3>
-        <div className="mt-[3px] text-[11px] text-white/60">
+        <div className="mt-[3px] text-[11px] text-white/80">
           <WriterIdentityClient address={storyline.writer_address} writerType={storyline.writer_type} />
         </div>
         {storyline.token_address && (
           <div className="mt-1.5">
-            <span className="font-mono text-[10px] tabular-nums text-white/50">
+            <span className="font-mono text-[10px] tabular-nums text-white/50 [&_.font-semibold]:text-white [&_.font-semibold]:font-semibold">
               <StoryCardTVL tokenAddress={storyline.token_address} />
             </span>
           </div>


### PR DESCRIPTION
## Summary
- **Author text**: Brightened from `white/60` to `white/80` for clear visibility over gradient
- **TVL USD value**: Overridden to bold white on card context (PLOT sub-value stays muted)
- **Gradient overlay**: Lowered start from 45% to 70%, keeping top ~70% of card clean — gradient only covers bottom ~30% where text lives. Applied consistently across StoryCard, detail page cover, and profile page cards.
- Version bump: 1.18.0 → 1.18.1

Closes #1103

## Test plan
- [ ] Author name clearly readable on cards with light pastel fallback patterns
- [ ] Author name clearly readable on cards with dark cover images
- [ ] TVL USD value shows as bold white text on cards
- [ ] Cover images / fallback patterns remain clean and unobscured in top ~70%
- [ ] Bottom text (title, author, TVL) still readable with tighter gradient
- [ ] Detail page cover uses same updated gradient
- [ ] Profile page cards use same updated gradient
- [ ] Mobile and desktop layouts both look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)