### PR TITLE
Use light/white gradient overlay with dark text on story cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -1044,7 +1044,7 @@ function StoryRow({
       >
         <div className="relative" style={{ aspectRatio: "2/3" }}>
           <div className="absolute inset-0" style={FALLBACK_STYLES[hashToVariant(storyline.storyline_id)]} />
-          <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(0%_0_0_/_0.5)_85%,oklch(0%_0_0_/_0.88)_100%)]" />
+          <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(97%_0.008_70_/_0.6)_85%,oklch(97%_0.008_70_/_0.95)_100%)]" />
 
           {/* Top badges */}
           <div className="absolute top-2 left-2 z-[1] flex flex-wrap items-center gap-1">
@@ -1062,10 +1062,10 @@ function StoryRow({
 
           {/* Bottom info */}
           <div className="absolute bottom-0 left-0 right-0 z-[1] px-2.5 pb-2.5">
-            <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-white line-clamp-2 sm:text-[15px]">
+            <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-[var(--fg)] line-clamp-2 sm:text-[15px]">
               {storyline.title}
             </h3>
-            <div className="mt-1 flex items-center gap-2 text-[10px] text-white/60">
+            <div className="mt-1 flex items-center gap-2 text-[10px] text-[var(--muted)]">
               <span>{storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"}</span>
               <span>·</span>
               <span>{formatViewCount(storyline.view_count)} views</span>
@@ -1637,14 +1637,14 @@ function PortfolioTab({ address, isOwnProfile }: { address: string; isOwnProfile
                 style={{ aspectRatio: "2/3" }}
               >
                 <div className="absolute inset-0" style={FALLBACK_STYLES[hashToVariant(h.storyline.storyline_id)]} />
-                <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(0%_0_0_/_0.5)_85%,oklch(0%_0_0_/_0.88)_100%)]" />
+                <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(97%_0.008_70_/_0.6)_85%,oklch(97%_0.008_70_/_0.95)_100%)]" />
                 <div className="absolute top-1.5 left-1.5 z-[1]">
                   <span className="rounded-[3px] bg-[oklch(0%_0_0_/_0.45)] px-[5px] py-[1px] text-[8px] font-medium uppercase tracking-wider text-white/90 backdrop-blur-[2px]">
                     {h.storyline.genre || "Uncategorized"}
                   </span>
                 </div>
                 <div className="absolute bottom-0 left-0 right-0 z-[1] px-2 pb-2">
-                  <span className="font-heading text-xs font-semibold leading-tight text-white line-clamp-2 sm:text-sm">
+                  <span className="font-heading text-xs font-semibold leading-tight text-[var(--fg)] line-clamp-2 sm:text-sm">
                     {h.storyline.title}
                   </span>
                 </div>

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -351,9 +351,9 @@ function StoryHeader({
             <div className="absolute inset-0" style={FALLBACK_STYLES[variant]} />
           )}
           {/* Gradient overlay + title at bottom */}
-          <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(0%_0_0_/_0.5)_85%,oklch(0%_0_0_/_0.88)_100%)]" />
+          <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(97%_0.008_70_/_0.6)_85%,oklch(97%_0.008_70_/_0.95)_100%)]" />
           <div className="absolute bottom-0 left-0 right-0 px-3 pb-3">
-            <h2 className="font-heading text-[18px] font-semibold leading-tight text-white sm:text-[22px]">
+            <h2 className="font-heading text-[18px] font-semibold leading-tight text-[var(--fg)] sm:text-[22px]">
               {storyline.title}
             </h2>
           </div>

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -49,8 +49,8 @@ export function StoryCard({
         <div className="absolute inset-0" style={FALLBACK_STYLES[variant]} />
       )}
 
-      {/* Bottom gradient overlay */}
-      <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(0%_0_0_/_0.5)_85%,oklch(0%_0_0_/_0.88)_100%)]" />
+      {/* Bottom gradient overlay — light fade to match light theme */}
+      <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(97%_0.008_70_/_0.6)_85%,oklch(97%_0.008_70_/_0.95)_100%)]" />
 
       {/* Top badges */}
       <div className="absolute top-2 left-2 z-[2] flex flex-wrap items-center gap-1">
@@ -78,15 +78,15 @@ export function StoryCard({
 
       {/* Bottom card info — always over gradient */}
       <div className="absolute right-0 bottom-0 left-0 z-[2] px-2.5 pt-3 pb-2.5">
-        <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-white line-clamp-2 sm:text-[15px]">
+        <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-[var(--fg)] line-clamp-2 sm:text-[15px]">
           {storyline.title}
         </h3>
-        <div className="mt-[3px] text-[11px] text-white/80">
+        <div className="mt-[3px] text-[11px] text-[var(--muted)]">
           <WriterIdentityClient address={storyline.writer_address} writerType={storyline.writer_type} />
         </div>
         {storyline.token_address && (
           <div className="mt-1.5">
-            <span className="font-mono text-[10px] tabular-nums text-white/50 [&_.font-semibold]:text-white [&_.font-semibold]:font-semibold">
+            <span className="font-mono text-[10px] tabular-nums text-[var(--muted)]">
               <StoryCardTVL tokenAddress={storyline.token_address} />
             </span>
           </div>

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -86,7 +86,7 @@ export function StoryCard({
         </div>
         {storyline.token_address && (
           <div className="mt-1.5">
-            <span className="font-mono text-[10px] tabular-nums text-[var(--muted)]">
+            <span className="font-mono text-[10px] tabular-nums text-[var(--muted)] [&_.font-semibold]:text-[var(--fg)]">
               <StoryCardTVL tokenAddress={storyline.token_address} />
             </span>
           </div>


### PR DESCRIPTION
## Summary
- **Gradient overlay**: Replaced dark (black) gradient with light/white gradient (`transparent 70% → oklch(97%) 85% → oklch(97%) 100%`) so cards blend naturally with the light theme
- **Bottom text colors**: Title uses `var(--fg)` (dark), author uses `var(--muted)` (gray), TVL uses `var(--muted)` — all dark foreground colors instead of white
- **Top badges**: Unchanged (dark semi-transparent bg with white text for contrast on light pastel backgrounds)
- Applied consistently across StoryCard, detail page cover, and profile page cards
- Version bump: 1.18.1 → 1.18.2

Closes #1105

## Test plan
- [ ] Story cards on home page show light gradient fading to white at bottom
- [ ] Title, author, TVL text are dark and clearly readable
- [ ] Top badges still have dark bg with white text (good contrast on light patterns)
- [ ] All 4 fallback pattern variants (A–D) look natural with light gradient
- [ ] Detail page cover uses light gradient with dark title text
- [ ] Profile page story cards and holdings cards use light gradient
- [ ] Card bottom blends seamlessly into page background
- [ ] Mobile and desktop layouts both look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)