### PR TITLE
Add cover_cid and is_nsfw columns to storylines

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -64,6 +64,8 @@ export interface Database {
           contract_address: string;
           genre: string | null;
           language: string;
+          cover_cid: string | null;
+          is_nsfw: boolean;
         };
         Insert: {
           id?: never;
@@ -85,6 +87,8 @@ export interface Database {
           contract_address: string;
           genre?: string | null;
           language?: string;
+          cover_cid?: string | null;
+          is_nsfw?: boolean;
         };
         Update: {
           id?: never;
@@ -106,6 +110,8 @@ export interface Database {
           contract_address?: string;
           genre?: string | null;
           language?: string;
+          cover_cid?: string | null;
+          is_nsfw?: boolean;
         };
         Relationships: [];
       };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/supabase/migrations/00038_add_cover_cid_is_nsfw.sql
+++ b/supabase/migrations/00038_add_cover_cid_is_nsfw.sql
@@ -1,0 +1,5 @@
+ALTER TABLE storylines
+  ADD COLUMN cover_cid text,
+  ADD COLUMN is_nsfw boolean NOT NULL DEFAULT false;
+
+CREATE INDEX idx_storylines_is_nsfw ON storylines (is_nsfw);


### PR DESCRIPTION
## Summary
- **Migration** (`00038`): Adds `cover_cid` (nullable text) and `is_nsfw` (boolean, default false) columns to `storylines` table, with index on `is_nsfw`
- **TypeScript types**: Updated `Database["public"]["Tables"]["storylines"]` Row, Insert, and Update types to include new fields
- Foundation for book cover image support (required by #1108, #1109, #1110, #1111, #1112)
- Version bump: 1.18.2 → 1.18.3

Closes #1107

## Test plan
- [ ] Migration runs successfully on Supabase (cover_cid nullable, is_nsfw defaults false)
- [ ] Existing storylines unaffected (cover_cid=null, is_nsfw=false)
- [ ] TypeScript types compile correctly
- [ ] Index `idx_storylines_is_nsfw` created

🤖 Generated with [Claude Code](https://claude.com/claude-code)