### PR TITLE
Add POST /api/upload-cover for image upload to Filebase

### DIFF
--- a/lib/filebase.ts
+++ b/lib/filebase.ts
@@ -66,6 +66,66 @@ export async function uploadToIPFS(
 }
 
 /**
+ * Upload binary data (e.g. images) to Filebase and return the CID.
+ */
+export async function uploadBinaryToIPFS(
+  data: Buffer | Uint8Array,
+  key: string,
+  contentType: string
+): Promise<string> {
+  const bucket = process.env.FILEBASE_BUCKET;
+  if (!bucket) {
+    throw new Error("Filebase not configured: Missing FILEBASE_BUCKET");
+  }
+
+  const s3 = getFilebaseClient();
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: data,
+      ContentType: contentType,
+    })
+  );
+
+  const head = await s3.send(
+    new HeadObjectCommand({ Bucket: bucket, Key: key })
+  );
+  const cid = head.Metadata?.cid;
+  if (!cid) {
+    throw new Error("Filebase response missing CID in metadata");
+  }
+
+  return cid;
+}
+
+/**
+ * Upload binary data to IPFS with retry logic.
+ */
+export async function uploadBinaryWithRetry(
+  data: Buffer | Uint8Array,
+  key: string,
+  contentType: string,
+  maxRetries = 3
+): Promise<string> {
+  let lastError: Error | null = null;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await uploadBinaryToIPFS(data, key, contentType);
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error("Unknown error");
+      if (attempt < maxRetries) {
+        await new Promise((r) =>
+          setTimeout(r, Math.pow(2, attempt - 1) * 1000)
+        );
+      }
+    }
+  }
+  throw lastError || new Error("IPFS binary upload failed after retries");
+}
+
+/**
  * Upload content to IPFS with retry logic.
  *
  * 3 attempts with exponential backoff (1s, 2s, 4s).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/api/upload-cover/route.ts
+++ b/src/app/api/upload-cover/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { uploadBinaryWithRetry } from "../../../../lib/filebase";
+
+const MAX_FILE_SIZE = 500 * 1024; // 500KB
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 5;
+
+const ALLOWED_TYPES: Record<string, number[]> = {
+  "image/webp": [0x52, 0x49, 0x46, 0x46], // RIFF header
+  "image/jpeg": [0xff, 0xd8, 0xff],
+};
+
+const ipRequestLog = new Map<string, number[]>();
+
+function checkRateLimit(ip: string): boolean {
+  const now = Date.now();
+  const timestamps = ipRequestLog.get(ip) ?? [];
+  const recent = timestamps.filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
+  if (recent.length >= RATE_LIMIT_MAX) return false;
+  recent.push(now);
+  ipRequestLog.set(ip, recent);
+  return true;
+}
+
+function matchesMagicBytes(buffer: Uint8Array, expected: number[]): boolean {
+  if (buffer.length < expected.length) return false;
+  return expected.every((byte, i) => buffer[i] === byte);
+}
+
+export async function POST(req: NextRequest) {
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown";
+
+  if (!checkRateLimit(ip)) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded. Max 5 uploads per minute." },
+      { status: 429 }
+    );
+  }
+
+  try {
+    const formData = await req.formData();
+    const file = formData.get("file");
+
+    if (!file || !(file instanceof File)) {
+      return NextResponse.json(
+        { error: "Missing file in request" },
+        { status: 400 }
+      );
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json(
+        { error: `File too large. Maximum size is ${MAX_FILE_SIZE / 1024}KB.` },
+        { status: 400 }
+      );
+    }
+
+    const declaredType = file.type;
+    if (!Object.keys(ALLOWED_TYPES).includes(declaredType)) {
+      return NextResponse.json(
+        { error: "Invalid file type. Only WebP and JPEG are accepted." },
+        { status: 400 }
+      );
+    }
+
+    const arrayBuffer = await file.arrayBuffer();
+    const bytes = new Uint8Array(arrayBuffer);
+
+    const expectedMagic = ALLOWED_TYPES[declaredType];
+    if (!matchesMagicBytes(bytes, expectedMagic)) {
+      return NextResponse.json(
+        { error: "File content does not match declared type." },
+        { status: 400 }
+      );
+    }
+
+    const key = `plotlink/covers/${Date.now()}-${Math.random().toString(36).slice(2, 8)}${declaredType === "image/webp" ? ".webp" : ".jpg"}`;
+
+    const cid = await uploadBinaryWithRetry(
+      Buffer.from(arrayBuffer),
+      key,
+      declaredType
+    );
+
+    return NextResponse.json({
+      cid,
+      url: `https://ipfs.filebase.io/ipfs/${cid}`,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Upload failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/upload-cover/route.ts
+++ b/src/app/api/upload-cover/route.ts
@@ -5,10 +5,7 @@ const MAX_FILE_SIZE = 500 * 1024; // 500KB
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 5;
 
-const ALLOWED_TYPES: Record<string, number[]> = {
-  "image/webp": [0x52, 0x49, 0x46, 0x46], // RIFF header
-  "image/jpeg": [0xff, 0xd8, 0xff],
-};
+const ALLOWED_MIME_TYPES = new Set(["image/webp", "image/jpeg"]);
 
 const ipRequestLog = new Map<string, number[]>();
 
@@ -22,9 +19,18 @@ function checkRateLimit(ip: string): boolean {
   return true;
 }
 
-function matchesMagicBytes(buffer: Uint8Array, expected: number[]): boolean {
-  if (buffer.length < expected.length) return false;
-  return expected.every((byte, i) => buffer[i] === byte);
+function validateMagicBytes(buffer: Uint8Array, mimeType: string): boolean {
+  if (mimeType === "image/jpeg") {
+    return buffer.length >= 3 &&
+      buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff;
+  }
+  if (mimeType === "image/webp") {
+    // RIFF at bytes 0-3, WEBP at bytes 8-11
+    return buffer.length >= 12 &&
+      buffer[0] === 0x52 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x46 &&
+      buffer[8] === 0x57 && buffer[9] === 0x45 && buffer[10] === 0x42 && buffer[11] === 0x50;
+  }
+  return false;
 }
 
 export async function POST(req: NextRequest) {
@@ -59,7 +65,7 @@ export async function POST(req: NextRequest) {
     }
 
     const declaredType = file.type;
-    if (!Object.keys(ALLOWED_TYPES).includes(declaredType)) {
+    if (!ALLOWED_MIME_TYPES.has(declaredType)) {
       return NextResponse.json(
         { error: "Invalid file type. Only WebP and JPEG are accepted." },
         { status: 400 }
@@ -69,8 +75,7 @@ export async function POST(req: NextRequest) {
     const arrayBuffer = await file.arrayBuffer();
     const bytes = new Uint8Array(arrayBuffer);
 
-    const expectedMagic = ALLOWED_TYPES[declaredType];
-    if (!matchesMagicBytes(bytes, expectedMagic)) {
+    if (!validateMagicBytes(bytes, declaredType)) {
       return NextResponse.json(
         { error: "File content does not match declared type." },
         { status: 400 }


### PR DESCRIPTION
## Summary
- **New endpoint** `POST /api/upload-cover`: Accepts multipart `file` field, validates WebP/JPEG (Content-Type + magic bytes), enforces 500KB max size, rate limits 5/min per IP, uploads to Filebase with correct `ContentType`, returns `{ cid, url }`
- **lib/filebase.ts**: Added `uploadBinaryToIPFS` and `uploadBinaryWithRetry` for Buffer/Uint8Array uploads, reusing existing S3 client and retry pattern
- Does NOT write to database — CID is returned to client for later use during storyline creation
- Version bump: 1.18.3 → 1.18.4

Closes #1108

## Test plan
- [ ] Upload valid WebP file → returns `{ cid, url }` with 200
- [ ] Upload valid JPEG file → returns `{ cid, url }` with 200
- [ ] Upload PNG file → rejected with 400 (invalid file type)
- [ ] Upload file >500KB → rejected with 400
- [ ] Upload file with wrong Content-Type but valid magic bytes → rejected with 400
- [ ] Upload file with correct Content-Type but wrong magic bytes → rejected with 400
- [ ] 6th upload within 1 minute → rejected with 429
- [ ] Missing file field → rejected with 400
- [ ] Filebase receives file with correct ContentType (image/webp or image/jpeg)
- [ ] Returned URL is valid IPFS gateway link

🤖 Generated with [Claude Code](https://claude.com/claude-code)