### PR TITLE
Render cover images on story cards with fallback empty state (#1110)

### DIFF
--- a/lib/cover.ts
+++ b/lib/cover.ts
@@ -1,0 +1,4 @@
+export function getCoverUrl(coverCid: string | null | undefined): string | null {
+  if (!coverCid) return null;
+  return `https://ipfs.filebase.io/ipfs/${coverCid}`;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.18.4",
+  "version": "1.19.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -955,6 +955,7 @@ function StoriesTab({
 }
 
 import { FALLBACK_STYLES, hashToVariant } from "../../../components/StoryCard";
+import { getCoverUrl } from "../../../../lib/cover";
 
 function StoryRow({
   storyline,
@@ -1043,8 +1044,18 @@ function StoryRow({
         className="group relative block overflow-hidden rounded-[var(--card-radius)] border border-border transition-transform hover:scale-[1.03]"
       >
         <div className="relative" style={{ aspectRatio: "2/3" }}>
-          <div className="absolute inset-0" style={FALLBACK_STYLES[hashToVariant(storyline.storyline_id)]} />
-          <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(97%_0.008_70_/_0.6)_85%,oklch(97%_0.008_70_/_0.95)_100%)]" />
+          {(() => {
+            const coverUrl = getCoverUrl(storyline.cover_cid);
+            if (coverUrl) {
+              return (
+                <>
+                  <img src={coverUrl} alt={storyline.title} loading="lazy" className="absolute inset-0 h-full w-full object-cover" />
+                  <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(0%_0_0_/_0.5)_85%,oklch(0%_0_0_/_0.88)_100%)]" />
+                </>
+              );
+            }
+            return <div className="absolute inset-0" style={FALLBACK_STYLES[hashToVariant(storyline.storyline_id)]} />;
+          })()}
 
           {/* Top badges */}
           <div className="absolute top-2 left-2 z-[1] flex flex-wrap items-center gap-1">
@@ -1060,12 +1071,24 @@ function StoryRow({
             )}
           </div>
 
+          {/* Centered title for fallback, or bottom title for cover */}
+          {!storyline.cover_cid && (
+            <div className="absolute inset-0 z-[1] flex flex-col items-center justify-center px-4 text-center">
+              <h3 className="font-heading text-sm font-semibold leading-tight text-[var(--fg)] line-clamp-3 sm:text-base" style={{ maxWidth: "90%" }}>
+                {storyline.title}
+              </h3>
+              <div className="mt-2 h-0.5 w-8 rounded-sm bg-[var(--accent)]" />
+            </div>
+          )}
+
           {/* Bottom info */}
           <div className="absolute bottom-0 left-0 right-0 z-[1] px-2.5 pb-2.5">
-            <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-[var(--fg)] line-clamp-2 sm:text-[15px]">
-              {storyline.title}
-            </h3>
-            <div className="mt-1 flex items-center gap-2 text-[10px] text-[var(--muted)]">
+            {storyline.cover_cid && (
+              <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-white line-clamp-2 sm:text-[15px]">
+                {storyline.title}
+              </h3>
+            )}
+            <div className={`${storyline.cover_cid ? "mt-1" : ""} flex items-center gap-2 text-[10px] ${storyline.cover_cid ? "text-white/60" : "text-[var(--muted)]"}`}>
               <span>{storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"}</span>
               <span>·</span>
               <span>{formatViewCount(storyline.view_count)} views</span>
@@ -1636,18 +1659,36 @@ function PortfolioTab({ address, isOwnProfile }: { address: string; isOwnProfile
                 className="relative overflow-hidden rounded-[var(--card-radius)] border border-border"
                 style={{ aspectRatio: "2/3" }}
               >
-                <div className="absolute inset-0" style={FALLBACK_STYLES[hashToVariant(h.storyline.storyline_id)]} />
-                <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(97%_0.008_70_/_0.6)_85%,oklch(97%_0.008_70_/_0.95)_100%)]" />
+                {(() => {
+                  const hCoverUrl = getCoverUrl(h.storyline.cover_cid);
+                  if (hCoverUrl) {
+                    return (
+                      <>
+                        <img src={hCoverUrl} alt={h.storyline.title} loading="lazy" className="absolute inset-0 h-full w-full object-cover" />
+                        <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(0%_0_0_/_0.5)_85%,oklch(0%_0_0_/_0.88)_100%)]" />
+                      </>
+                    );
+                  }
+                  return <div className="absolute inset-0" style={FALLBACK_STYLES[hashToVariant(h.storyline.storyline_id)]} />;
+                })()}
                 <div className="absolute top-1.5 left-1.5 z-[1]">
                   <span className="rounded-[3px] bg-[oklch(0%_0_0_/_0.45)] px-[5px] py-[1px] text-[8px] font-medium uppercase tracking-wider text-white/90 backdrop-blur-[2px]">
                     {h.storyline.genre || "Uncategorized"}
                   </span>
                 </div>
-                <div className="absolute bottom-0 left-0 right-0 z-[1] px-2 pb-2">
-                  <span className="font-heading text-xs font-semibold leading-tight text-[var(--fg)] line-clamp-2 sm:text-sm">
-                    {h.storyline.title}
-                  </span>
-                </div>
+                {!h.storyline.cover_cid && (
+                  <div className="absolute inset-0 z-[1] flex flex-col items-center justify-center px-3 text-center">
+                    <span className="font-heading text-xs font-semibold leading-tight text-[var(--fg)] line-clamp-2 sm:text-sm">{h.storyline.title}</span>
+                    <div className="mt-1.5 h-0.5 w-6 rounded-sm bg-[var(--accent)]" />
+                  </div>
+                )}
+                {h.storyline.cover_cid && (
+                  <div className="absolute bottom-0 left-0 right-0 z-[1] px-2 pb-2">
+                    <span className="font-heading text-xs font-semibold leading-tight text-white line-clamp-2 sm:text-sm">
+                      {h.storyline.title}
+                    </span>
+                  </div>
+                )}
               </div>
             </Link>
             <div className="min-w-0 w-full sm:flex-1">

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -1050,7 +1050,7 @@ function StoryRow({
               return (
                 <>
                   <img src={coverUrl} alt={storyline.title} loading="lazy" className="absolute inset-0 h-full w-full object-cover" />
-                  <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(0%_0_0_/_0.5)_85%,oklch(0%_0_0_/_0.88)_100%)]" />
+                  <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_60%,oklch(98%_0.005_80_/_0.75)_80%,oklch(96%_0.01_80_/_0.95)_100%)]" />
                 </>
               );
             }
@@ -1084,11 +1084,11 @@ function StoryRow({
           {/* Bottom info */}
           <div className="absolute bottom-0 left-0 right-0 z-[1] px-2.5 pb-2.5">
             {storyline.cover_cid && (
-              <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-white line-clamp-2 sm:text-[15px]">
+              <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-[var(--fg)] line-clamp-2 sm:text-[15px]">
                 {storyline.title}
               </h3>
             )}
-            <div className={`${storyline.cover_cid ? "mt-1" : ""} flex items-center gap-2 text-[10px] ${storyline.cover_cid ? "text-white/60" : "text-[var(--muted)]"}`}>
+            <div className={`${storyline.cover_cid ? "mt-1" : ""} flex items-center gap-2 text-[10px] text-[var(--muted)]`}>
               <span>{storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"}</span>
               <span>·</span>
               <span>{formatViewCount(storyline.view_count)} views</span>
@@ -1665,7 +1665,7 @@ function PortfolioTab({ address, isOwnProfile }: { address: string; isOwnProfile
                     return (
                       <>
                         <img src={hCoverUrl} alt={h.storyline.title} loading="lazy" className="absolute inset-0 h-full w-full object-cover" />
-                        <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(0%_0_0_/_0.5)_85%,oklch(0%_0_0_/_0.88)_100%)]" />
+                        <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_60%,oklch(98%_0.005_80_/_0.75)_80%,oklch(96%_0.01_80_/_0.95)_100%)]" />
                       </>
                     );
                   }
@@ -1684,7 +1684,7 @@ function PortfolioTab({ address, isOwnProfile }: { address: string; isOwnProfile
                 )}
                 {h.storyline.cover_cid && (
                   <div className="absolute bottom-0 left-0 right-0 z-[1] px-2 pb-2">
-                    <span className="font-heading text-xs font-semibold leading-tight text-white line-clamp-2 sm:text-sm">
+                    <span className="font-heading text-xs font-semibold leading-tight text-[var(--fg)] line-clamp-2 sm:text-sm">
                       {h.storyline.title}
                     </span>
                   </div>

--- a/src/app/story/[storylineId]/og/route.tsx
+++ b/src/app/story/[storylineId]/og/route.tsx
@@ -114,14 +114,14 @@ export async function GET(
     >
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img src={coverUrl} alt="" style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", objectFit: "cover" }} />
-      <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, background: "linear-gradient(to bottom, transparent, rgba(0,0,0,0.85))", padding: "60px 28px 28px", display: "flex", flexDirection: "column", gap: "6px" }}>
+      <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, background: "linear-gradient(to bottom, transparent, rgba(250,248,245,0.85))", padding: "60px 28px 28px", display: "flex", flexDirection: "column", gap: "6px" }}>
         {sl.genre && (
-          <div style={{ display: "flex", fontSize: "11px", color: "rgba(255,255,255,0.7)", textTransform: "uppercase", letterSpacing: "0.1em" }}>{sl.genre}</div>
+          <div style={{ display: "flex", fontSize: "11px", color: "#6a5e50", textTransform: "uppercase", letterSpacing: "0.1em" }}>{sl.genre}</div>
         )}
-        <div style={{ fontSize: titleDisplay.length > 30 ? "28px" : "34px", fontWeight: 500, color: "#fff", lineHeight: 1.25, display: "flex" }}>{titleDisplay}</div>
-        <div style={{ display: "flex", fontSize: "14px", color: "rgba(255,255,255,0.6)" }}>{plotLabel}</div>
+        <div style={{ fontSize: titleDisplay.length > 30 ? "28px" : "34px", fontWeight: 500, color: "#1a1a1a", lineHeight: 1.25, display: "flex" }}>{titleDisplay}</div>
+        <div style={{ display: "flex", fontSize: "14px", color: "#8a7e70" }}>{plotLabel}</div>
         {tvlDisplay && (
-          <div style={{ display: "flex", fontWeight: 500, color: "#e8a87c", fontSize: "14px" }}>{tvlDisplay}</div>
+          <div style={{ display: "flex", fontWeight: 500, color: "#b05c3a", fontSize: "14px" }}>{tvlDisplay}</div>
         )}
       </div>
     </div>

--- a/src/app/story/[storylineId]/og/route.tsx
+++ b/src/app/story/[storylineId]/og/route.tsx
@@ -7,6 +7,7 @@ import { RESERVE_LABEL, STORY_FACTORY } from "../../../../../lib/contracts/const
 import { formatPrice } from "../../../../../lib/format";
 import { truncateAddress } from "../../../../../lib/utils";
 import { getPlotUsdPrice, formatUsdValue } from "../../../../../lib/usd-price";
+import { getCoverUrl } from "../../../../../lib/cover";
 
 export const runtime = "nodejs";
 
@@ -93,9 +94,72 @@ export async function GET(
     D: "#302820",
   };
 
+  const coverUrl = getCoverUrl(sl.cover_cid);
+
   const fonts = fontData
     ? [{ name: "Newsreader", data: fontData, weight: 500 as const }]
     : [];
+
+  const cardContent = coverUrl ? (
+    <div
+      style={{
+        width: "380px",
+        height: "520px",
+        display: "flex",
+        flexDirection: "column",
+        borderRadius: "12px",
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={coverUrl} alt="" style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", objectFit: "cover" }} />
+      <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, background: "linear-gradient(to bottom, transparent, rgba(0,0,0,0.85))", padding: "60px 28px 28px", display: "flex", flexDirection: "column", gap: "6px" }}>
+        {sl.genre && (
+          <div style={{ display: "flex", fontSize: "11px", color: "rgba(255,255,255,0.7)", textTransform: "uppercase", letterSpacing: "0.1em" }}>{sl.genre}</div>
+        )}
+        <div style={{ fontSize: titleDisplay.length > 30 ? "28px" : "34px", fontWeight: 500, color: "#fff", lineHeight: 1.25, display: "flex" }}>{titleDisplay}</div>
+        <div style={{ display: "flex", fontSize: "14px", color: "rgba(255,255,255,0.6)" }}>{plotLabel}</div>
+        {tvlDisplay && (
+          <div style={{ display: "flex", fontWeight: 500, color: "#e8a87c", fontSize: "14px" }}>{tvlDisplay}</div>
+        )}
+      </div>
+    </div>
+  ) : (
+    <div
+      style={{
+        width: "380px",
+        height: "520px",
+        display: "flex",
+        flexDirection: "column",
+        background: FALLBACK_BG[variant],
+        borderRadius: "12px",
+        border: "1px solid #3a332c",
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      <div style={{ display: "flex", height: "3px", background: "linear-gradient(90deg, #b05c3a, #b05c3a80, transparent)" }} />
+      <div style={{ display: "flex", padding: "28px 28px 0" }}>
+        {sl.genre ? (
+          <div style={{ display: "flex", fontSize: "12px", color: "#b05c3a", backgroundColor: "rgba(176, 92, 58, 0.12)", borderRadius: "4px", padding: "4px 12px", textTransform: "uppercase", letterSpacing: "0.12em", fontWeight: 500 }}>{sl.genre}</div>
+        ) : (
+          <div style={{ display: "flex" }} />
+        )}
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center", flex: 1, padding: "0 32px", textAlign: "center" }}>
+        <div style={{ width: "40px", height: "1px", background: "rgba(176, 92, 58, 0.4)", marginBottom: "20px", display: "flex" }} />
+        <div style={{ fontSize: titleDisplay.length > 30 ? "30px" : "36px", fontWeight: 500, color: "#ede4d6", lineHeight: 1.3, display: "flex", textAlign: "center", justifyContent: "center", maxWidth: "340px" }}>{titleDisplay}</div>
+        <div style={{ width: "40px", height: "1px", background: "rgba(176, 92, 58, 0.4)", marginTop: "20px", display: "flex" }} />
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: "6px", padding: "0 28px 28px", fontSize: "14px", color: "#8a7e70" }}>
+        <div style={{ display: "flex" }}>{plotLabel}</div>
+        {tvlDisplay && (
+          <div style={{ display: "flex", fontWeight: 500, color: "#b05c3a" }}>{tvlDisplay}</div>
+        )}
+      </div>
+    </div>
+  );
 
   return new ImageResponse(
     (
@@ -111,124 +175,8 @@ export async function GET(
           fontFamily: fontData ? "Newsreader" : "Georgia, serif",
         }}
       >
-        {/* Cover card with deterministic fallback pattern */}
-        <div
-          style={{
-            width: "380px",
-            height: "520px",
-            display: "flex",
-            flexDirection: "column",
-            background: FALLBACK_BG[variant],
-            borderRadius: "12px",
-            border: "1px solid #3a332c",
-            position: "relative",
-            overflow: "hidden",
-          }}
-        >
-          {/* Accent strip at top */}
-          <div
-            style={{
-              display: "flex",
-              height: "3px",
-              background: "linear-gradient(90deg, #b05c3a, #b05c3a80, transparent)",
-            }}
-          />
+        {cardContent}
 
-          {/* Top: genre tag */}
-          <div
-            style={{
-              display: "flex",
-              padding: "28px 28px 0",
-            }}
-          >
-            {sl.genre ? (
-              <div
-                style={{
-                  display: "flex",
-                  fontSize: "12px",
-                  color: "#b05c3a",
-                  backgroundColor: "rgba(176, 92, 58, 0.12)",
-                  borderRadius: "4px",
-                  padding: "4px 12px",
-                  textTransform: "uppercase",
-                  letterSpacing: "0.12em",
-                  fontWeight: 500,
-                }}
-              >
-                {sl.genre}
-              </div>
-            ) : (
-              <div style={{ display: "flex" }} />
-            )}
-          </div>
-
-          {/* Center: title */}
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              justifyContent: "center",
-              alignItems: "center",
-              flex: 1,
-              padding: "0 32px",
-              textAlign: "center",
-            }}
-          >
-            <div
-              style={{
-                width: "40px",
-                height: "1px",
-                background: "rgba(176, 92, 58, 0.4)",
-                marginBottom: "20px",
-                display: "flex",
-              }}
-            />
-            <div
-              style={{
-                fontSize: titleDisplay.length > 30 ? "30px" : "36px",
-                fontWeight: 500,
-                color: "#ede4d6",
-                lineHeight: 1.3,
-                display: "flex",
-                textAlign: "center",
-                justifyContent: "center",
-                maxWidth: "340px",
-              }}
-            >
-              {titleDisplay}
-            </div>
-            <div
-              style={{
-                width: "40px",
-                height: "1px",
-                background: "rgba(176, 92, 58, 0.4)",
-                marginTop: "20px",
-                display: "flex",
-              }}
-            />
-          </div>
-
-          {/* Bottom: stats */}
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "6px",
-              padding: "0 28px 28px",
-              fontSize: "14px",
-              color: "#8a7e70",
-            }}
-          >
-            <div style={{ display: "flex" }}>{plotLabel}</div>
-            {tvlDisplay && (
-              <div style={{ display: "flex", fontWeight: 500, color: "#b05c3a" }}>
-                {tvlDisplay}
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* Below card: author + branding */}
         <div
           style={{
             display: "flex",

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -349,9 +349,9 @@ function StoryHeader({
           {coverUrl ? (
             <>
               <img src={coverUrl} alt={storyline.title} loading="lazy" className="absolute inset-0 h-full w-full object-cover" />
-              <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(0%_0_0_/_0.5)_85%,oklch(0%_0_0_/_0.88)_100%)]" />
+              <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_60%,oklch(98%_0.005_80_/_0.75)_80%,oklch(96%_0.01_80_/_0.95)_100%)]" />
               <div className="absolute bottom-0 left-0 right-0 px-3 pb-3">
-                <h2 className="font-heading text-[18px] font-semibold leading-tight text-white sm:text-[22px]">
+                <h2 className="font-heading text-[18px] font-semibold leading-tight text-[var(--fg)] sm:text-[22px]">
                   {storyline.title}
                 </h2>
               </div>

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -25,6 +25,7 @@ import { MobileActionBar } from "../../../components/MobileActionBar";
 import { MarketCapBox } from "../../../components/MarketCapBox";
 import { TokenPriceBox } from "../../../components/TokenPriceBox";
 import { FALLBACK_STYLES, hashToVariant } from "../../../components/StoryCard";
+import { getCoverUrl } from "../../../../lib/cover";
 
 /** Deduplicate plots by plot_index, keeping the first occurrence. */
 function deduplicateByPlotIndex(plots: Plot[]) {
@@ -170,7 +171,7 @@ export default async function StoryPage({ params }: { params: Params }) {
         <span className="text-foreground">{sl.title}</span>
       </nav>
 
-      <StoryHeader storyline={storyline} priceInfo={priceInfo} storylineId={id} />
+      <StoryHeader storyline={storyline} priceInfo={priceInfo} storylineId={id} coverUrl={getCoverUrl(sl.cover_cid) ?? undefined} />
 
       <div className="mt-8 grid grid-cols-1 gap-10 lg:grid-cols-[1fr_320px] lg:items-start">
         {/* Story content — genesis + table of contents */}
@@ -346,17 +347,26 @@ function StoryHeader({
           style={{ aspectRatio: "2/3" }}
         >
           {coverUrl ? (
-            <img src={coverUrl} alt={storyline.title} loading="lazy" className="absolute inset-0 h-full w-full object-cover" />
+            <>
+              <img src={coverUrl} alt={storyline.title} loading="lazy" className="absolute inset-0 h-full w-full object-cover" />
+              <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(0%_0_0_/_0.5)_85%,oklch(0%_0_0_/_0.88)_100%)]" />
+              <div className="absolute bottom-0 left-0 right-0 px-3 pb-3">
+                <h2 className="font-heading text-[18px] font-semibold leading-tight text-white sm:text-[22px]">
+                  {storyline.title}
+                </h2>
+              </div>
+            </>
           ) : (
-            <div className="absolute inset-0" style={FALLBACK_STYLES[variant]} />
+            <>
+              <div className="absolute inset-0" style={FALLBACK_STYLES[variant]} />
+              <div className="absolute inset-0 flex flex-col items-center justify-center px-5 text-center">
+                <h2 className="font-heading text-[22px] font-semibold leading-tight text-[var(--fg)]">
+                  {storyline.title}
+                </h2>
+                <div className="mt-3.5 h-0.5 w-8 rounded-sm bg-[var(--accent)]" />
+              </div>
+            </>
           )}
-          {/* Gradient overlay + title at bottom */}
-          <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(97%_0.008_70_/_0.6)_85%,oklch(97%_0.008_70_/_0.95)_100%)]" />
-          <div className="absolute bottom-0 left-0 right-0 px-3 pb-3">
-            <h2 className="font-heading text-[18px] font-semibold leading-tight text-[var(--fg)] sm:text-[22px]">
-              {storyline.title}
-            </h2>
-          </div>
         </div>
       </div>
 

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -70,20 +70,20 @@ export function StoryCard({
           loading="lazy"
           className="absolute inset-0 h-full w-full object-cover"
         />
-        <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(0%_0_0_/_0.5)_85%,oklch(0%_0_0_/_0.88)_100%)]" />
+        <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_60%,oklch(98%_0.005_80_/_0.75)_80%,oklch(96%_0.01_80_/_0.95)_100%)]" />
 
         <Badges genre={displayGenre} writerType={storyline.writer_type} status={status} />
 
         <div className="absolute right-0 bottom-0 left-0 z-[2] px-2.5 pt-3 pb-2.5">
-          <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-white line-clamp-2 sm:text-[15px]">
+          <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-[var(--fg)] line-clamp-2 sm:text-[15px]">
             {storyline.title}
           </h3>
-          <div className="mt-[3px] text-[11px] text-white/80">
+          <div className="mt-[3px] text-[11px] text-[var(--muted)]">
             <WriterIdentityClient address={storyline.writer_address} writerType={storyline.writer_type} />
           </div>
           {storyline.token_address && (
             <div className="mt-1.5">
-              <span className="font-mono text-[10px] tabular-nums text-white/50 [&_.font-semibold]:text-white">
+              <span className="font-mono text-[10px] tabular-nums text-[var(--muted)] [&_.font-semibold]:text-[var(--fg)]">
                 <StoryCardTVL tokenAddress={storyline.token_address} />
               </span>
             </div>

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -3,6 +3,7 @@ import type { Storyline } from "../../lib/supabase";
 import { WriterIdentityClient } from "./WriterIdentityClient";
 import { StoryCardTVL } from "./StoryCardStats";
 import { getStoryStatus } from "../../lib/story-status";
+import { getCoverUrl } from "../../lib/cover";
 
 export type FallbackVariant = "A" | "B" | "C" | "D";
 
@@ -18,74 +19,101 @@ export const FALLBACK_STYLES: Record<FallbackVariant, React.CSSProperties> = {
   D: { background: "linear-gradient(175deg, oklch(94% 0.015 50) 0%, oklch(90% 0.02 40) 100%)" },
 };
 
+function Badges({ genre, writerType, status }: { genre?: string | null; writerType: number | null; status: string }) {
+  const isActive = status === "active";
+  return (
+    <div className="absolute top-2 left-2 z-[2] flex flex-wrap items-center gap-1">
+      {genre && (
+        <span className="rounded-[3px] bg-[oklch(0%_0_0_/_0.45)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-white/90 backdrop-blur-[2px]">
+          {genre}
+        </span>
+      )}
+      {writerType === 1 && (
+        <span className="rounded-[3px] bg-[oklch(45%_0.15_280_/_0.6)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-white/90 backdrop-blur-[2px]">
+          AI Writer
+        </span>
+      )}
+      {status === "completed" && (
+        <span className="rounded-[3px] bg-[oklch(40%_0.10_145_/_0.6)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-white/90 backdrop-blur-[2px]">
+          Complete
+        </span>
+      )}
+      {isActive && (
+        <span className="rounded-[3px] bg-[oklch(40%_0.10_145_/_0.6)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-white/90 backdrop-blur-[2px]">
+          Ongoing
+        </span>
+      )}
+    </div>
+  );
+}
+
+const cardClass = "group relative block aspect-[2/3] overflow-hidden rounded-[var(--card-radius)] border border-[var(--border)] shadow-[0_1px_3px_oklch(0%_0_0_/_0.06)] transition-[transform,box-shadow] duration-200 ease-out hover:z-[2] hover:scale-[1.03] hover:shadow-[0_12px_40px_oklch(0%_0_0_/_0.12)]";
+
 export function StoryCard({
   storyline,
   genre,
-  coverUrl,
 }: {
   storyline: Storyline;
   genre?: string;
-  coverUrl?: string;
 }) {
   const displayGenre = genre || storyline.genre;
   const status = getStoryStatus(storyline);
-  const isActive = status === "active";
   const variant = hashToVariant(storyline.storyline_id);
+  const coverUrl = getCoverUrl(storyline.cover_cid);
 
-  return (
-    <Link
-      href={`/story/${storyline.storyline_id}`}
-      className="group relative block aspect-[2/3] overflow-hidden rounded-[var(--card-radius)] border border-[var(--border)] shadow-[0_1px_3px_oklch(0%_0_0_/_0.06)] transition-[transform,box-shadow] duration-200 ease-out hover:z-[2] hover:scale-[1.03] hover:shadow-[0_12px_40px_oklch(0%_0_0_/_0.12)]"
-    >
-      {/* Cover image or fallback pattern — full bleed, clean middle */}
-      {coverUrl ? (
+  if (coverUrl) {
+    return (
+      <Link href={`/story/${storyline.storyline_id}`} className={cardClass}>
         <img
           src={coverUrl}
           alt={storyline.title}
           loading="lazy"
           className="absolute inset-0 h-full w-full object-cover"
         />
-      ) : (
-        <div className="absolute inset-0" style={FALLBACK_STYLES[variant]} />
-      )}
+        <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(0%_0_0_/_0.5)_85%,oklch(0%_0_0_/_0.88)_100%)]" />
 
-      {/* Bottom gradient overlay — light fade to match light theme */}
-      <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_70%,oklch(97%_0.008_70_/_0.6)_85%,oklch(97%_0.008_70_/_0.95)_100%)]" />
+        <Badges genre={displayGenre} writerType={storyline.writer_type} status={status} />
 
-      {/* Top badges */}
-      <div className="absolute top-2 left-2 z-[2] flex flex-wrap items-center gap-1">
-        {displayGenre && (
-          <span className="rounded-[3px] bg-[oklch(0%_0_0_/_0.45)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-white/90 backdrop-blur-[2px]">
-            {displayGenre}
-          </span>
-        )}
-        {storyline.writer_type === 1 && (
-          <span className="rounded-[3px] bg-[oklch(45%_0.15_280_/_0.6)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-white/90 backdrop-blur-[2px]">
-            AI Writer
-          </span>
-        )}
-        {status === "completed" && (
-          <span className="rounded-[3px] bg-[oklch(40%_0.10_145_/_0.6)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-white/90 backdrop-blur-[2px]">
-            Complete
-          </span>
-        )}
-        {isActive && (
-          <span className="rounded-[3px] bg-[oklch(40%_0.10_145_/_0.6)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-white/90 backdrop-blur-[2px]">
-            Ongoing
-          </span>
-        )}
-      </div>
+        <div className="absolute right-0 bottom-0 left-0 z-[2] px-2.5 pt-3 pb-2.5">
+          <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-white line-clamp-2 sm:text-[15px]">
+            {storyline.title}
+          </h3>
+          <div className="mt-[3px] text-[11px] text-white/80">
+            <WriterIdentityClient address={storyline.writer_address} writerType={storyline.writer_type} />
+          </div>
+          {storyline.token_address && (
+            <div className="mt-1.5">
+              <span className="font-mono text-[10px] tabular-nums text-white/50 [&_.font-semibold]:text-white">
+                <StoryCardTVL tokenAddress={storyline.token_address} />
+              </span>
+            </div>
+          )}
+        </div>
+      </Link>
+    );
+  }
 
-      {/* Bottom card info — always over gradient */}
-      <div className="absolute right-0 bottom-0 left-0 z-[2] px-2.5 pt-3 pb-2.5">
-        <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-[var(--fg)] line-clamp-2 sm:text-[15px]">
+  return (
+    <Link href={`/story/${storyline.storyline_id}`} className={cardClass}>
+      <div className="absolute inset-0" style={FALLBACK_STYLES[variant]} />
+
+      <Badges genre={displayGenre} writerType={storyline.writer_type} status={status} />
+
+      {/* Centered title with accent line */}
+      <div className="absolute inset-0 z-[1] flex flex-col items-center justify-center px-4 text-center">
+        <h3 className="font-heading text-base font-semibold leading-tight text-[var(--fg)] line-clamp-3 sm:text-lg" style={{ maxWidth: "90%" }}>
           {storyline.title}
         </h3>
-        <div className="mt-[3px] text-[11px] text-[var(--muted)]">
+        <div className="mt-2.5 h-0.5 w-8 rounded-sm bg-[var(--accent)]" />
+      </div>
+
+      {/* Bottom author + TVL */}
+      <div className="absolute right-0 bottom-0 left-0 z-[2] px-2.5 pb-2.5">
+        <div className="text-[11px] text-[var(--muted)]">
           <WriterIdentityClient address={storyline.writer_address} writerType={storyline.writer_type} />
         </div>
         {storyline.token_address && (
-          <div className="mt-1.5">
+          <div className="mt-1">
             <span className="font-mono text-[10px] tabular-nums text-[var(--muted)] [&_.font-semibold]:text-[var(--fg)]">
               <StoryCardTVL tokenAddress={storyline.token_address} />
             </span>


### PR DESCRIPTION
## Summary
- Extract shared `getCoverUrl(coverCid)` helper into `lib/cover.ts` for constructing IPFS gateway URLs from CIDs
- Add two-branch card rendering (cover image with dark gradient vs pattern fallback) to `StoryCard`, story detail page `StoryHeader`, profile page story/holdings rows, and OG image route
- Cover cards: full-bleed image, bottom gradient overlay, white text; Fallback cards: pastel pattern background, centered title with accent line

## Test plan
- [ ] Verify story cards with `cover_cid` show the IPFS cover image with dark gradient and white text
- [ ] Verify story cards without `cover_cid` show the pastel pattern fallback with centered title
- [ ] Check story detail page header renders cover/fallback correctly
- [ ] Check profile page story rows and holdings rows render cover/fallback correctly
- [ ] Verify OG image generation works for both cover and fallback cases
- [ ] Run `npm run typecheck` and `npm run lint` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)