### PR TITLE
Hide NSFW stories by default, add 18+ toggle and badge (#1111)

### DIFF
--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -128,6 +128,7 @@ async function fetchCandidatesAndRatings(
   writerType?: number,
   genre?: string,
   lang?: string,
+  showNsfw = false,
 ) {
   function applyBase(q: ReturnType<typeof supabase.from>) {
     let filtered = q
@@ -137,6 +138,7 @@ async function fetchCandidatesAndRatings(
     if (writerType !== undefined) filtered = filtered.eq("writer_type", writerType);
     if (genre) filtered = filtered.eq("genre", genre);
     if (lang) filtered = filtered.eq("language", lang);
+    if (!showNsfw) filtered = filtered.eq("is_nsfw", false);
     return filtered;
   }
 
@@ -247,8 +249,9 @@ export async function getTrendingStorylines(
   offset = 0,
   genre?: string,
   lang?: string,
+  showNsfw = false,
 ): Promise<RankedStoryline[]> {
-  const { storylines, ratingMap, userMap } = await fetchCandidatesAndRatings(supabase, writerType, genre, lang);
+  const { storylines, ratingMap, userMap } = await fetchCandidatesAndRatings(supabase, writerType, genre, lang, showNsfw);
   if (storylines.length === 0) return [];
 
   const enriched = await Promise.all(
@@ -294,6 +297,7 @@ export async function getMcapStorylines(
   offset = 0,
   genre?: string,
   lang?: string,
+  showNsfw = false,
 ): Promise<Storyline[]> {
   // Fetch all eligible stories — MCap needs the full set, not a recency-biased subset
   let q = supabase
@@ -305,6 +309,7 @@ export async function getMcapStorylines(
   if (writerType !== undefined) q = q.eq("writer_type", writerType);
   if (genre) q = q.eq("genre", genre);
   if (lang) q = q.eq("language", lang);
+  if (!showNsfw) q = q.eq("is_nsfw", false);
   const { data } = await q.returns<Storyline[]>();
   const storylines = data ?? [];
   if (storylines.length === 0) return [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,14 +13,14 @@ const WRITER_VALUES: WriterFilterValue[] = ["all", "human", "agent"];
 
 const PAGE_SIZE = 24;
 
-type SearchParams = Promise<{ tab?: string; writer?: string; page?: string; genre?: string; lang?: string }>;
+type SearchParams = Promise<{ tab?: string; writer?: string; page?: string; genre?: string; lang?: string; nsfw?: string }>;
 
 export default async function Home({
   searchParams,
 }: {
   searchParams: SearchParams;
 }) {
-  const { tab: rawTab, writer: rawWriter, page: rawPage, genre: rawGenre, lang: rawLang } = await searchParams;
+  const { tab: rawTab, writer: rawWriter, page: rawPage, genre: rawGenre, lang: rawLang, nsfw: rawNsfw } = await searchParams;
   const tab: Tab = TABS.includes(rawTab as Tab) ? (rawTab as Tab) : "trending";
   const writer: WriterFilterValue = WRITER_VALUES.includes(
     rawWriter as WriterFilterValue,
@@ -30,12 +30,13 @@ export default async function Home({
   const page = Math.max(1, parseInt(rawPage ?? "1", 10) || 1);
   const genre = rawGenre && (GENRES as readonly string[]).includes(rawGenre) ? rawGenre : "all";
   const lang = rawLang && (LANGUAGES as readonly string[]).includes(rawLang) ? rawLang : "all";
+  const showNsfw = rawNsfw === "1";
 
   const supabase = createServerClient();
 
   let storylines: Storyline[] = [];
   if (supabase) {
-    storylines = await queryTab(supabase, tab, writer, page, genre, lang);
+    storylines = await queryTab(supabase, tab, writer, page, genre, lang, showNsfw);
   }
 
   return (
@@ -50,7 +51,7 @@ export default async function Home({
         </p>
       </header>
 
-      <FilterBar writer={writer} genre={genre} lang={lang} tab={tab} totalCount={storylines.length} />
+      <FilterBar writer={writer} genre={genre} lang={lang} tab={tab} totalCount={storylines.length} showNsfw={showNsfw} />
 
       {/* Section label */}
       <h2 className="mt-4 mb-3 text-[11px] font-semibold uppercase tracking-[0.08em] text-muted">
@@ -65,7 +66,7 @@ export default async function Home({
         <div className="mt-8 flex items-center justify-center gap-4">
           {page > 1 && (
             <Link
-              href={buildPageHref(tab, writer, page - 1, genre, lang)}
+              href={buildPageHref(tab, writer, page - 1, genre, lang, showNsfw)}
               className="border-border text-muted hover:text-foreground rounded border px-4 py-2 text-xs transition-colors"
             >
               &larr; Previous
@@ -74,7 +75,7 @@ export default async function Home({
           <span className="text-muted text-xs">Page {page}</span>
           {storylines.length === PAGE_SIZE && (
             <Link
-              href={buildPageHref(tab, writer, page + 1, genre, lang)}
+              href={buildPageHref(tab, writer, page + 1, genre, lang, showNsfw)}
               className="border-border text-muted hover:text-foreground rounded border px-4 py-2 text-xs transition-colors"
             >
               Next &rarr;
@@ -103,11 +104,12 @@ export default async function Home({
   );
 }
 
-function buildPageHref(tab: string, writer: string, page: number, genre: string, lang: string): string {
+function buildPageHref(tab: string, writer: string, page: number, genre: string, lang: string, showNsfw?: boolean): string {
   const params = new URLSearchParams({ tab });
   if (writer !== "all") params.set("writer", writer);
   if (genre !== "all") params.set("genre", genre);
   if (lang !== "all") params.set("lang", lang);
+  if (showNsfw) params.set("nsfw", "1");
   if (page > 1) params.set("page", String(page));
   return `/?${params.toString()}`;
 }
@@ -119,6 +121,7 @@ async function queryTab(
   page: number,
   genre: string,
   lang: string,
+  showNsfw: boolean,
 ): Promise<Storyline[]> {
   const from = (page - 1) * PAGE_SIZE;
   const to = from + PAGE_SIZE - 1;
@@ -129,6 +132,7 @@ async function queryTab(
     if (writer === "agent") filtered = filtered.eq("writer_type", 1);
     if (genre !== "all") filtered = filtered.eq("genre", genre);
     if (lang !== "all") filtered = filtered.eq("language", lang);
+    if (!showNsfw) filtered = filtered.eq("is_nsfw", false);
     return filtered;
   }
 
@@ -152,14 +156,14 @@ async function queryTab(
       const wt = writer === "human" ? 0 : writer === "agent" ? 1 : undefined;
       const g = genre !== "all" ? genre : undefined;
       const l = lang !== "all" ? lang : undefined;
-      return getTrendingStorylines(supabase, PAGE_SIZE, wt, from, g, l);
+      return getTrendingStorylines(supabase, PAGE_SIZE, wt, from, g, l, showNsfw);
     }
 
     case "mcap": {
       const wt = writer === "human" ? 0 : writer === "agent" ? 1 : undefined;
       const g = genre !== "all" ? genre : undefined;
       const l = lang !== "all" ? lang : undefined;
-      return getMcapStorylines(supabase, PAGE_SIZE, wt, from, g, l);
+      return getMcapStorylines(supabase, PAGE_SIZE, wt, from, g, l, showNsfw);
     }
   }
 }

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -1411,19 +1411,18 @@ function PortfolioTab({ address, isOwnProfile }: { address: string; isOwnProfile
 
   // Fetch on-chain token holdings
   const { data: holdings, isLoading: holdingsLoading } = useQuery({
-    queryKey: ["profile-holdings", address],
+    queryKey: ["profile-holdings", address, isOwnProfile],
     queryFn: async (): Promise<PortfolioHolding[]> => {
       if (!supabase) return [];
 
-      // Scan all storylines with tokens to catch holdings acquired via
-      // direct transfers, not just indexed trades
-      const { data: storylines } = await supabase
+      let q = supabase
         .from("storylines")
         .select("*")
         .eq("hidden", false)
         .neq("token_address", "")
-        .eq("contract_address", STORY_FACTORY.toLowerCase())
-        .returns<Storyline[]>();
+        .eq("contract_address", STORY_FACTORY.toLowerCase());
+      if (!isOwnProfile) q = q.eq("is_nsfw", false);
+      const { data: storylines } = await q.returns<Storyline[]>();
       if (!storylines || storylines.length === 0) return [];
 
       // Multicall balanceOf for all storyline tokens

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -689,15 +689,17 @@ function StoriesTab({
 }) {
   const { data: plotUsd } = usePlotUsdPrice();
   const { data: storylines = [], isLoading, error } = useQuery({
-    queryKey: ["profile-storylines", address],
+    queryKey: ["profile-storylines", address, isOwnProfile],
     queryFn: async () => {
       if (!supabase) return [];
-      const { data, error } = await supabase
+      let q = supabase
         .from("storylines")
         .select("*")
         .eq("writer_address", address)
         .eq("hidden", false)
-        .eq("contract_address", STORY_FACTORY.toLowerCase())
+        .eq("contract_address", STORY_FACTORY.toLowerCase());
+      if (!isOwnProfile) q = q.eq("is_nsfw", false);
+      const { data, error } = await q
         .order("block_timestamp", { ascending: false })
         .returns<Storyline[]>();
       if (error) throw error;

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -24,13 +24,15 @@ interface FilterBarProps {
   lang: string;
   tab: string;
   totalCount?: number;
+  showNsfw?: boolean;
 }
 
-function buildHref(params: { tab: string; writer: string; genre: string; lang: string }) {
+function buildHref(params: { tab: string; writer: string; genre: string; lang: string; nsfw?: boolean }) {
   const sp = new URLSearchParams({ tab: params.tab });
   if (params.writer !== "all") sp.set("writer", params.writer);
   if (params.genre !== "all") sp.set("genre", params.genre);
   if (params.lang !== "all") sp.set("lang", params.lang);
+  if (params.nsfw) sp.set("nsfw", "1");
   return `/?${sp.toString()}`;
 }
 
@@ -39,17 +41,20 @@ function FilterSheetContent({
   writer,
   genre,
   lang,
+  nsfw,
   onApply,
 }: {
   onClose: () => void;
   writer: string;
   genre: string;
   lang: string;
-  onApply: (w: string, g: string, l: string) => void;
+  nsfw: boolean;
+  onApply: (w: string, g: string, l: string, nsfw: boolean) => void;
 }) {
   const [localWriter, setLocalWriter] = useState(writer);
   const [localGenre, setLocalGenre] = useState(genre);
   const [localLang, setLocalLang] = useState(lang);
+  const [localNsfw, setLocalNsfw] = useState(nsfw);
 
   useEffect(() => {
     document.body.style.overflow = "hidden";
@@ -114,9 +119,22 @@ function FilterSheetContent({
             </div>
           </div>
 
+          {/* NSFW */}
+          <div>
+            <label className="flex cursor-pointer items-center gap-2.5">
+              <input
+                type="checkbox"
+                checked={localNsfw}
+                onChange={(e) => setLocalNsfw(e.target.checked)}
+                className="h-4 w-4 rounded border-[var(--border)] accent-[var(--accent)]"
+              />
+              <span className="text-sm text-[var(--fg)]">Show 18+ content</span>
+            </label>
+          </div>
+
           {/* Apply */}
           <button
-            onClick={() => { onApply(localWriter, localGenre, localLang); onClose(); }}
+            onClick={() => { onApply(localWriter, localGenre, localLang, localNsfw); onClose(); }}
             className="w-full rounded-lg bg-[var(--accent)] py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90"
           >
             Apply Filters
@@ -127,40 +145,46 @@ function FilterSheetContent({
   );
 }
 
-function FilterSheet({ open, ...props }: { open: boolean; onClose: () => void; writer: string; genre: string; lang: string; onApply: (w: string, g: string, l: string) => void }) {
+function FilterSheet({ open, ...props }: { open: boolean; onClose: () => void; writer: string; genre: string; lang: string; nsfw: boolean; onApply: (w: string, g: string, l: string, nsfw: boolean) => void }) {
   if (!open) return null;
   return <FilterSheetContent {...props} />;
 }
 
-export function FilterBar({ writer, genre, lang, tab, totalCount }: FilterBarProps) {
+export function FilterBar({ writer, genre, lang, tab, totalCount, showNsfw = false }: FilterBarProps) {
   const router = useRouter();
   const [sheetOpen, setSheetOpen] = useState(false);
+  const nsfw = showNsfw;
 
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.has("lang")) return;
+    if (urlParams.has("lang") || urlParams.has("nsfw")) return;
     try {
-      const saved = localStorage.getItem("plotlink_lang");
-      if (saved && saved !== "all" && (LANGUAGES as readonly string[]).includes(saved)) {
-        router.replace(buildHref({ tab, writer, genre, lang: saved }));
+      const savedLang = localStorage.getItem("plotlink_lang");
+      const savedNsfw = localStorage.getItem("plotlink_nsfw") === "1";
+      if ((savedLang && savedLang !== "all" && (LANGUAGES as readonly string[]).includes(savedLang)) || savedNsfw) {
+        router.replace(buildHref({ tab, writer, genre, lang: savedLang && savedLang !== "all" ? savedLang : lang, nsfw: savedNsfw }));
       }
     } catch {}
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  function navigate(params: { tab: string; writer: string; genre: string; lang: string }) {
-    try { localStorage.setItem("plotlink_lang", params.lang); } catch {}
+  function navigate(params: { tab: string; writer: string; genre: string; lang: string; nsfw?: boolean }) {
+    try {
+      localStorage.setItem("plotlink_lang", params.lang);
+      localStorage.setItem("plotlink_nsfw", params.nsfw ? "1" : "0");
+    } catch {}
     router.push(buildHref(params));
   }
 
-  const handleApplyFilters = useCallback((w: string, g: string, l: string) => {
-    navigate({ tab, writer: w, genre: g, lang: l });
+  const handleApplyFilters = useCallback((w: string, g: string, l: string, n: boolean) => {
+    navigate({ tab, writer: w, genre: g, lang: l, nsfw: n });
   }, [tab]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const activeFilterCount = [writer !== "all", genre !== "all", lang !== "all"].filter(Boolean).length;
+  const activeFilterCount = [writer !== "all", genre !== "all", lang !== "all", nsfw].filter(Boolean).length;
   const activeChips: { label: string; clear: () => void }[] = [];
-  if (writer !== "all") activeChips.push({ label: `Writer: ${writer}`, clear: () => navigate({ tab, writer: "all", genre, lang }) });
-  if (genre !== "all") activeChips.push({ label: genre, clear: () => navigate({ tab, writer, genre: "all", lang }) });
-  if (lang !== "all") activeChips.push({ label: lang, clear: () => navigate({ tab, writer, genre, lang: "all" }) });
+  if (writer !== "all") activeChips.push({ label: `Writer: ${writer}`, clear: () => navigate({ tab, writer: "all", genre, lang, nsfw }) });
+  if (genre !== "all") activeChips.push({ label: genre, clear: () => navigate({ tab, writer, genre: "all", lang, nsfw }) });
+  if (lang !== "all") activeChips.push({ label: lang, clear: () => navigate({ tab, writer, genre, lang: "all", nsfw }) });
+  if (nsfw) activeChips.push({ label: "18+", clear: () => navigate({ tab, writer, genre, lang, nsfw: false }) });
 
   return (
     <>
@@ -171,7 +195,7 @@ export function FilterBar({ writer, genre, lang, tab, totalCount }: FilterBarPro
             {SORT_OPTIONS.map(({ value, label }) => (
               <button
                 key={value}
-                onClick={() => navigate({ tab: value, writer, genre, lang })}
+                onClick={() => navigate({ tab: value, writer, genre, lang, nsfw })}
                 className={`relative px-3 py-2 text-[13px] font-medium transition-colors sm:text-sm ${
                   tab === value
                     ? "font-semibold text-[var(--fg)]"
@@ -193,7 +217,7 @@ export function FilterBar({ writer, genre, lang, tab, totalCount }: FilterBarPro
               {WRITER_OPTIONS.map(({ value, label }) => (
                 <button
                   key={value}
-                  onClick={() => navigate({ tab, writer: value, genre, lang })}
+                  onClick={() => navigate({ tab, writer: value, genre, lang, nsfw })}
                   className={`rounded-full px-2.5 py-1 text-[12px] font-medium transition-colors ${
                     writer === value
                       ? "bg-[var(--accent)] text-white"
@@ -209,7 +233,7 @@ export function FilterBar({ writer, genre, lang, tab, totalCount }: FilterBarPro
             <div className="relative">
               <select
                 value={genre}
-                onChange={(e) => navigate({ tab, writer, genre: e.target.value, lang })}
+                onChange={(e) => navigate({ tab, writer, genre: e.target.value, lang, nsfw })}
                 className={`rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors focus:border-[var(--accent)] focus:outline-none ${
                   genre !== "all"
                     ? "border-[var(--accent)] bg-[var(--accent-bg)] text-[var(--accent)]"
@@ -225,7 +249,7 @@ export function FilterBar({ writer, genre, lang, tab, totalCount }: FilterBarPro
             <div className="relative">
               <select
                 value={lang}
-                onChange={(e) => navigate({ tab, writer, genre, lang: e.target.value })}
+                onChange={(e) => navigate({ tab, writer, genre, lang: e.target.value, nsfw })}
                 className={`rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors focus:border-[var(--accent)] focus:outline-none ${
                   lang !== "all"
                     ? "border-[var(--accent)] bg-[var(--accent-bg)] text-[var(--accent)]"
@@ -236,6 +260,17 @@ export function FilterBar({ writer, genre, lang, tab, totalCount }: FilterBarPro
                 {LANGUAGES.map((l) => <option key={l} value={l}>{l}</option>)}
               </select>
             </div>
+
+            {/* NSFW toggle */}
+            <label className="flex cursor-pointer items-center gap-1.5 rounded-full border border-[var(--border)] px-2.5 py-1 text-[12px] font-medium text-[var(--muted)] transition-colors hover:text-[var(--fg)]">
+              <input
+                type="checkbox"
+                checked={nsfw}
+                onChange={(e) => navigate({ tab, writer, genre, lang, nsfw: e.target.checked })}
+                className="h-3 w-3 rounded accent-[var(--accent)]"
+              />
+              18+
+            </label>
 
             {/* Result count */}
             {totalCount !== undefined && (
@@ -291,6 +326,7 @@ export function FilterBar({ writer, genre, lang, tab, totalCount }: FilterBarPro
         writer={writer}
         genre={genre}
         lang={lang}
+        nsfw={nsfw}
         onApply={handleApplyFilters}
       />
     </>

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -19,7 +19,7 @@ export const FALLBACK_STYLES: Record<FallbackVariant, React.CSSProperties> = {
   D: { background: "linear-gradient(175deg, oklch(94% 0.015 50) 0%, oklch(90% 0.02 40) 100%)" },
 };
 
-function Badges({ genre, writerType, status }: { genre?: string | null; writerType: number | null; status: string }) {
+function Badges({ genre, writerType, status, isNsfw }: { genre?: string | null; writerType: number | null; status: string; isNsfw?: boolean }) {
   const isActive = status === "active";
   return (
     <div className="absolute top-2 left-2 z-[2] flex flex-wrap items-center gap-1">
@@ -41,6 +41,11 @@ function Badges({ genre, writerType, status }: { genre?: string | null; writerTy
       {isActive && (
         <span className="rounded-[3px] bg-[oklch(40%_0.10_145_/_0.6)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-white/90 backdrop-blur-[2px]">
           Ongoing
+        </span>
+      )}
+      {isNsfw && (
+        <span className="rounded-[3px] bg-[oklch(45%_0.18_25_/_0.7)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-white/90 backdrop-blur-[2px]">
+          18+
         </span>
       )}
     </div>
@@ -72,7 +77,7 @@ export function StoryCard({
         />
         <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_60%,oklch(98%_0.005_80_/_0.75)_80%,oklch(96%_0.01_80_/_0.95)_100%)]" />
 
-        <Badges genre={displayGenre} writerType={storyline.writer_type} status={status} />
+        <Badges genre={displayGenre} writerType={storyline.writer_type} status={status} isNsfw={storyline.is_nsfw} />
 
         <div className="absolute right-0 bottom-0 left-0 z-[2] px-2.5 pt-3 pb-2.5">
           <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-[var(--fg)] line-clamp-2 sm:text-[15px]">
@@ -97,7 +102,7 @@ export function StoryCard({
     <Link href={`/story/${storyline.storyline_id}`} className={cardClass}>
       <div className="absolute inset-0" style={FALLBACK_STYLES[variant]} />
 
-      <Badges genre={displayGenre} writerType={storyline.writer_type} status={status} />
+      <Badges genre={displayGenre} writerType={storyline.writer_type} status={status} isNsfw={storyline.is_nsfw} />
 
       {/* Centered title with accent line */}
       <div className="absolute inset-0 z-[1] flex flex-col items-center justify-center px-4 text-center">


### PR DESCRIPTION
## Summary
- NSFW stories (`is_nsfw = true`) hidden by default on browse page across all sort modes (New, Trending, Market Cap)
- Add "18+" checkbox toggle in FilterBar — desktop inline filters and mobile bottom sheet — persisted in localStorage
- Show red-toned "18+" badge on NSFW story cards alongside existing genre/status badges
- Profile page: writers see their own NSFW stories, visitors don't
- NSFW preference flows via URL param (`?nsfw=1`) for proper server-side filtering
- Updated `lib/ranking.ts` (`fetchCandidatesAndRatings`, `getTrendingStorylines`, `getMcapStorylines`) to accept and apply `showNsfw` parameter

## Test plan
- [ ] Browse page hides NSFW stories by default
- [ ] Toggle "18+" in desktop filter bar — NSFW stories appear with red "18+" badge
- [ ] Toggle "18+" in mobile filter sheet — same behavior
- [ ] Refresh page — NSFW preference restored from localStorage
- [ ] Visit another writer's profile — their NSFW stories are hidden
- [ ] Visit own profile — own NSFW stories are visible
- [ ] Verify all sort modes (New, Trending, Market Cap) respect the filter
- [ ] "18+" chip appears in mobile active chips and can be cleared
- [ ] Run `npm run typecheck` and `npm run lint` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)