### PR TITLE
Add author edit for cover image, genre, language, NSFW flag (#1120)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/api/storyline/update/route.ts
+++ b/src/app/api/storyline/update/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse } from "next/server";
+import { recoverMessageAddress } from "viem";
+import { createServerClient } from "../../../../../lib/supabase";
+import { STORY_FACTORY } from "../../../../../lib/contracts/constants";
+import { GENRES, LANGUAGES } from "../../../../../lib/genres";
+import type { Database } from "../../../../../lib/supabase";
+
+const MAX_TIMESTAMP_AGE_MS = 5 * 60 * 1000;
+
+function error(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const {
+    storylineId,
+    signature,
+    message,
+  } = body as {
+    storylineId?: number;
+    coverCid?: string | null;
+    genre?: string;
+    language?: string;
+    isNsfw?: boolean;
+    signature?: string;
+    message?: string;
+  };
+
+  if (!storylineId || !signature || !message) {
+    return error("Missing required fields: storylineId, signature, message");
+  }
+
+  const msgMatch = message.match(
+    /^PlotLink: Update storyline #(\d+)\nTimestamp: (\d+)$/,
+  );
+  if (!msgMatch) {
+    return error("Invalid message format");
+  }
+
+  const msgStorylineId = Number(msgMatch[1]);
+  const msgTimestamp = Number(msgMatch[2]);
+
+  if (msgStorylineId !== storylineId) {
+    return error("Message storylineId mismatch");
+  }
+
+  if (Date.now() - msgTimestamp > MAX_TIMESTAMP_AGE_MS) {
+    return error("Signature expired (older than 5 minutes)", 401);
+  }
+
+  let recoveredAddress: string;
+  try {
+    recoveredAddress = (
+      await recoverMessageAddress({
+        message,
+        signature: signature as `0x${string}`,
+      })
+    ).toLowerCase();
+  } catch {
+    return error("Invalid signature", 401);
+  }
+
+  const supabase = createServerClient();
+  if (!supabase) {
+    return error("Database unavailable", 503);
+  }
+
+  const { data: storyline } = await supabase
+    .from("storylines")
+    .select("writer_address")
+    .eq("storyline_id", storylineId)
+    .eq("contract_address", STORY_FACTORY.toLowerCase())
+    .single();
+
+  if (!storyline) {
+    return error("Storyline not found", 404);
+  }
+
+  if (storyline.writer_address.toLowerCase() !== recoveredAddress) {
+    return error("Signature address does not match storyline author", 401);
+  }
+
+  const updates: Partial<Database["public"]["Tables"]["storylines"]["Update"]> =
+    {};
+
+  if ("coverCid" in body) {
+    const cid = body.coverCid as string | null;
+    if (cid !== null && !/^[a-zA-Z0-9]{46,64}$/.test(cid)) {
+      return error("Invalid cover CID format");
+    }
+    updates.cover_cid = cid ?? null;
+  }
+
+  if ("genre" in body) {
+    const g = body.genre as string;
+    if (g && !(GENRES as readonly string[]).includes(g)) {
+      return error("Invalid genre");
+    }
+    updates.genre = g || null;
+  }
+
+  if ("language" in body) {
+    const l = body.language as string;
+    if (l && !(LANGUAGES as readonly string[]).includes(l)) {
+      return error("Invalid language");
+    }
+    updates.language = l;
+  }
+
+  if ("isNsfw" in body) {
+    updates.is_nsfw = Boolean(body.isNsfw);
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return error("No fields to update");
+  }
+
+  const { error: dbError } = await supabase
+    .from("storylines")
+    .update(updates)
+    .eq("storyline_id", storylineId)
+    .eq("contract_address", STORY_FACTORY.toLowerCase());
+
+  if (dbError) {
+    return error(`Database error: ${dbError.message}`, 500);
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/storyline/update/route.ts
+++ b/src/app/api/storyline/update/route.ts
@@ -45,7 +45,11 @@ export async function POST(req: Request) {
     return error("Message storylineId mismatch");
   }
 
-  if (Date.now() - msgTimestamp > MAX_TIMESTAMP_AGE_MS) {
+  const now = Date.now();
+  if (!Number.isFinite(msgTimestamp) || msgTimestamp > now + 30_000) {
+    return error("Invalid or future-dated timestamp", 401);
+  }
+  if (now - msgTimestamp > MAX_TIMESTAMP_AGE_MS) {
     return error("Signature expired (older than 5 minutes)", 401);
   }
 
@@ -102,7 +106,7 @@ export async function POST(req: Request) {
 
   if ("language" in body) {
     const l = body.language as string;
-    if (l && !(LANGUAGES as readonly string[]).includes(l)) {
+    if (!l || !(LANGUAGES as readonly string[]).includes(l)) {
       return error("Invalid language");
     }
     updates.language = l;

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -26,6 +26,7 @@ import { MarketCapBox } from "../../../components/MarketCapBox";
 import { TokenPriceBox } from "../../../components/TokenPriceBox";
 import { FALLBACK_STYLES, hashToVariant } from "../../../components/StoryCard";
 import { getCoverUrl } from "../../../../lib/cover";
+import { StoryEditPanel } from "../../../components/StoryEditPanel";
 
 /** Deduplicate plots by plot_index, keeping the first occurrence. */
 function deduplicateByPlotIndex(plots: Plot[]) {
@@ -172,6 +173,15 @@ export default async function StoryPage({ params }: { params: Params }) {
       </nav>
 
       <StoryHeader storyline={storyline} priceInfo={priceInfo} storylineId={id} coverUrl={getCoverUrl(sl.cover_cid) ?? undefined} />
+
+      <StoryEditPanel
+        storylineId={id}
+        writerAddress={sl.writer_address}
+        currentGenre={sl.genre}
+        currentLanguage={sl.language}
+        currentCoverCid={sl.cover_cid}
+        currentIsNsfw={sl.is_nsfw}
+      />
 
       <div className="mt-8 grid grid-cols-1 gap-10 lg:grid-cols-[1fr_320px] lg:items-start">
         {/* Story content — genesis + table of contents */}

--- a/src/components/StoryEditPanel.tsx
+++ b/src/components/StoryEditPanel.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import { useAccount, useSignMessage } from "wagmi";
+import { useRouter } from "next/navigation";
+import { DropdownSelect } from "./DropdownSelect";
+import { GENRES, LANGUAGES } from "../../lib/genres";
+import { getCoverUrl } from "../../lib/cover";
+
+const genreOptions = [
+  { value: "", label: "Select genre..." },
+  ...GENRES.map((g) => ({ value: g, label: g })),
+];
+const languageOptions = LANGUAGES.map((l) => ({ value: l, label: l }));
+
+interface StoryEditPanelProps {
+  storylineId: number;
+  writerAddress: string;
+  currentGenre: string | null;
+  currentLanguage: string | null;
+  currentCoverCid: string | null;
+  currentIsNsfw: boolean;
+}
+
+export function StoryEditPanel({
+  storylineId,
+  writerAddress,
+  currentGenre,
+  currentLanguage,
+  currentCoverCid,
+  currentIsNsfw,
+}: StoryEditPanelProps) {
+  const { address } = useAccount();
+  const router = useRouter();
+  const { signMessageAsync } = useSignMessage();
+
+  const isAuthor = address?.toLowerCase() === writerAddress.toLowerCase();
+  const [editing, setEditing] = useState(false);
+  const [genre, setGenre] = useState(currentGenre ?? "");
+  const [language, setLanguage] = useState(currentLanguage ?? "English");
+  const [coverCid, setCoverCid] = useState<string | null>(currentCoverCid);
+  const [isNsfw, setIsNsfw] = useState(currentIsNsfw);
+  const [coverUploading, setCoverUploading] = useState(false);
+  const [coverError, setCoverError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const coverInputRef = useRef<HTMLInputElement>(null);
+
+  const handleCoverSelect = useCallback(async (file: File) => {
+    setCoverError(null);
+    if (!["image/webp", "image/jpeg"].includes(file.type)) {
+      setCoverError("Only WebP and JPEG files are accepted.");
+      return;
+    }
+    if (file.size > 500 * 1024) {
+      setCoverError("File too large. Maximum size is 500KB.");
+      return;
+    }
+    setCoverUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      const res = await fetch("/api/upload-cover", { method: "POST", body: formData });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Upload failed");
+      setCoverCid(data.cid);
+    } catch (err) {
+      setCoverError(err instanceof Error ? err.message : "Upload failed");
+    } finally {
+      setCoverUploading(false);
+    }
+  }, []);
+
+  const handleSave = async () => {
+    setSaveError(null);
+    setSaving(true);
+    try {
+      const timestamp = Date.now();
+      const message = `PlotLink: Update storyline #${storylineId}\nTimestamp: ${timestamp}`;
+      const signature = await signMessageAsync({ message });
+
+      const body: Record<string, unknown> = {
+        storylineId,
+        signature,
+        message,
+      };
+      if (genre !== (currentGenre ?? "")) body.genre = genre || null;
+      if (language !== (currentLanguage ?? "English")) body.language = language;
+      if (coverCid !== currentCoverCid) body.coverCid = coverCid;
+      if (isNsfw !== currentIsNsfw) body.isNsfw = isNsfw;
+
+      const res = await fetch("/api/storyline/update", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Update failed");
+
+      setSaveSuccess(true);
+      setTimeout(() => {
+        setEditing(false);
+        setSaveSuccess(false);
+        router.refresh();
+      }, 1000);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Update failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setGenre(currentGenre ?? "");
+    setLanguage(currentLanguage ?? "English");
+    setCoverCid(currentCoverCid);
+    setIsNsfw(currentIsNsfw);
+    setCoverError(null);
+    setSaveError(null);
+    setEditing(false);
+  };
+
+  if (!isAuthor) return null;
+
+  if (!editing) {
+    return (
+      <div className="mt-4">
+        <button
+          onClick={() => setEditing(true)}
+          className="border-border text-muted hover:text-foreground hover:border-foreground/30 rounded border px-3 py-1.5 text-xs font-medium transition-colors"
+        >
+          Edit Details
+        </button>
+      </div>
+    );
+  }
+
+  const coverUrl = coverCid ? getCoverUrl(coverCid) : null;
+
+  return (
+    <div className="mt-4 rounded-[var(--card-radius)] border border-border bg-surface p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-foreground">Edit Story Details</h3>
+        <button onClick={handleCancel} className="text-muted hover:text-foreground text-xs transition-colors">
+          Cancel
+        </button>
+      </div>
+
+      {/* Cover Image */}
+      <div>
+        <label className="text-foreground mb-1 block text-xs font-medium">Cover Image</label>
+        <p className="text-muted mb-2 text-[10px]">WebP or JPEG, max 500KB.</p>
+        {coverUrl ? (
+          <div className="flex items-start gap-3">
+            <div className="relative h-[90px] w-[60px] shrink-0 overflow-hidden rounded border border-border">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={coverUrl} alt="Cover" className="h-full w-full object-cover" />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <span className="text-muted break-all text-[9px] font-mono">{coverCid}</span>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => coverInputRef.current?.click()}
+                  disabled={coverUploading || saving}
+                  className="text-accent text-[11px] transition-colors hover:opacity-80 disabled:opacity-50"
+                >
+                  Replace
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setCoverCid(null); setCoverError(null); if (coverInputRef.current) coverInputRef.current.value = ""; }}
+                  disabled={saving}
+                  className="text-error text-[11px] transition-colors hover:opacity-80 disabled:opacity-50"
+                >
+                  Remove
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => coverInputRef.current?.click()}
+            disabled={coverUploading || saving}
+            className="flex w-full items-center justify-center rounded border border-dashed border-border px-4 py-4 text-xs text-muted transition-colors hover:border-accent disabled:opacity-50"
+          >
+            {coverUploading ? "Uploading..." : "Upload cover image"}
+          </button>
+        )}
+        <input
+          ref={coverInputRef}
+          type="file"
+          accept="image/webp,image/jpeg"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) handleCoverSelect(file);
+          }}
+        />
+        {coverError && <p className="text-error mt-1 text-[10px]">{coverError}</p>}
+      </div>
+
+      {/* Genre & Language */}
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="text-foreground mb-1 block text-xs font-medium">Genre</label>
+          <DropdownSelect
+            value={genre}
+            onChange={setGenre}
+            options={genreOptions}
+            placeholder="Select genre..."
+            disabled={saving}
+          />
+        </div>
+        <div>
+          <label className="text-foreground mb-1 block text-xs font-medium">Language</label>
+          <DropdownSelect
+            value={language}
+            onChange={setLanguage}
+            options={languageOptions}
+            disabled={saving}
+          />
+        </div>
+      </div>
+
+      {/* NSFW Toggle */}
+      <div>
+        <label className="flex cursor-pointer items-center gap-2">
+          <input
+            type="checkbox"
+            checked={isNsfw}
+            onChange={(e) => setIsNsfw(e.target.checked)}
+            disabled={saving}
+            className="h-3.5 w-3.5 rounded border-border accent-accent"
+          />
+          <span className="text-foreground text-xs">This story contains adult content (18+)</span>
+        </label>
+        {isNsfw && (
+          <p className="text-muted mt-1 ml-5.5 text-[10px]">
+            Adult content will be hidden from the default browse view.
+          </p>
+        )}
+      </div>
+
+      {/* Error / Success */}
+      {saveError && (
+        <div className="border-error/30 text-error rounded border px-3 py-2 text-[11px]">{saveError}</div>
+      )}
+      {saveSuccess && (
+        <div className="border-accent/30 text-accent rounded border px-3 py-2 text-[11px]">Updated successfully!</div>
+      )}
+
+      {/* Save */}
+      <div className="flex gap-2">
+        <button
+          onClick={handleSave}
+          disabled={saving || coverUploading}
+          className="border-accent text-accent hover:bg-accent hover:text-background rounded border px-4 py-1.5 text-xs font-medium transition-colors disabled:opacity-50"
+        >
+          {saving ? "Signing..." : "Save Changes"}
+        </button>
+        <button
+          onClick={handleCancel}
+          disabled={saving}
+          className="border-border text-muted hover:text-foreground rounded border px-4 py-1.5 text-xs font-medium transition-colors disabled:opacity-50"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `POST /api/storyline/update` endpoint with EIP-191 personal_sign wallet verification — recovers signer address via viem's `recoverMessageAddress`, validates message format and timestamp within 5 minutes, confirms signer matches `storylines.writer_address`
- New `StoryEditPanel` client component rendered on story detail page — inline edit panel with cover image upload/replace/remove (reuses `/api/upload-cover`), genre and language dropdowns, NSFW toggle, wallet signature prompt on save
- Edit button only visible when connected wallet matches the story's writer address
- On successful save: success feedback, then page data refreshes via `router.refresh()`
- API validates genre/language against allowed lists, CID format, and only updates provided fields

## Test plan
- [ ] Visit a story as the author — "Edit Details" button visible
- [ ] Visit a story as non-author — no edit button shown
- [ ] Click Edit — inline panel opens with current values pre-filled
- [ ] Upload a new cover image — verify upload and preview
- [ ] Replace/remove existing cover — verify state updates
- [ ] Change genre and language — verify dropdown selections
- [ ] Toggle NSFW — verify checkbox behavior
- [ ] Click Save — wallet signature prompt appears
- [ ] After signing — API validates and updates DB, success message shown, page refreshes
- [ ] Click Cancel — changes discarded, panel closes
- [ ] Verify expired signatures (>5min) are rejected
- [ ] Verify non-author signatures are rejected (401)
- [ ] Run `npm run typecheck` and `npm run lint` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)