### PR TITLE
Align 18+ toggle height and style with filter pills (#1121)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -262,7 +262,11 @@ export function FilterBar({ writer, genre, lang, tab, totalCount, showNsfw = fal
             </div>
 
             {/* NSFW toggle */}
-            <label className="flex cursor-pointer items-center gap-1.5 rounded-full border border-[var(--border)] px-2.5 py-1 text-[12px] font-medium text-[var(--muted)] transition-colors hover:text-[var(--fg)]">
+            <label className={`flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors ${
+              nsfw
+                ? "border-[var(--accent)] bg-[var(--accent-bg)] text-[var(--accent)]"
+                : "border-[var(--border)] text-[var(--muted)] hover:border-[var(--muted)] hover:text-[var(--fg)]"
+            }`}>
               <input
                 type="checkbox"
                 checked={nsfw}


### PR DESCRIPTION
## Summary
- Match 18+ checkbox toggle padding (`px-3 py-1.5`) to Genre/Language dropdown pills for consistent height
- Add active state styling (accent border + background) when checked, matching the active filter pill pattern
- Maintain same border radius, font size (12px), and vertical alignment as adjacent elements

## Test plan
- [ ] 18+ toggle visually same height as Genre/Language pills on desktop
- [ ] Toggle shows accent border/bg when checked, muted border when unchecked
- [ ] All filter bar elements aligned on same baseline
- [ ] Mobile filter sheet NSFW section unaffected
- [ ] Run `npm run typecheck` and `npm run lint` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)