### PR TITLE
Allow admin wallet to update any story's metadata (#1122)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,3 +73,4 @@ NEYNAR_API_KEY=
 # Admin (Content Moderation)
 # -----------------------------------------------------------------------------
 ADMIN_API_KEY=
+ADMIN_WALLET_ADDRESS=0x4d6823B083a7d03BcE47d50E224903016353B6C8

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/api/storyline/update/route.ts
+++ b/src/app/api/storyline/update/route.ts
@@ -11,6 +11,8 @@ function error(message: string, status = 400) {
   return NextResponse.json({ error: message }, { status });
 }
 
+const ADMIN_WALLET = process.env.ADMIN_WALLET_ADDRESS?.toLowerCase();
+
 export async function POST(req: Request) {
   const body = await req.json();
   const {
@@ -23,6 +25,7 @@ export async function POST(req: Request) {
     genre?: string;
     language?: string;
     isNsfw?: boolean;
+    hidden?: boolean;
     signature?: string;
     message?: string;
   };
@@ -81,8 +84,11 @@ export async function POST(req: Request) {
     return error("Storyline not found", 404);
   }
 
-  if (storyline.writer_address.toLowerCase() !== recoveredAddress) {
-    return error("Signature address does not match storyline author", 401);
+  const isAuthor = storyline.writer_address.toLowerCase() === recoveredAddress;
+  const isAdmin = !!ADMIN_WALLET && recoveredAddress === ADMIN_WALLET;
+
+  if (!isAuthor && !isAdmin) {
+    return error("Unauthorized", 401);
   }
 
   const updates: Partial<Database["public"]["Tables"]["storylines"]["Update"]> =
@@ -114,6 +120,13 @@ export async function POST(req: Request) {
 
   if ("isNsfw" in body) {
     updates.is_nsfw = Boolean(body.isNsfw);
+  }
+
+  if ("hidden" in body) {
+    if (!isAdmin) {
+      return error("Only admin can update the hidden field", 403);
+    }
+    updates.hidden = Boolean(body.hidden);
   }
 
   if (Object.keys(updates).length === 0) {


### PR DESCRIPTION
## Summary
- Admin wallet (`ADMIN_WALLET_ADDRESS` env var) can now update any storyline's metadata via `/api/storyline/update`, not just the author's own
- Added `hidden` field support gated to admin-only, enabling content moderation
- Regular authors retain edit access to their own stories only and cannot set `hidden`

## Test plan
- [ ] Admin wallet can sign and update metadata on stories it does not own
- [ ] Admin wallet can set `hidden: true` / `hidden: false` on any story
- [ ] Regular author can still edit their own story's genre, language, cover, NSFW
- [ ] Regular author receives 403 if they attempt to set `hidden`
- [ ] Non-author, non-admin wallet receives 401

Closes #1122

🤖 Generated with [Claude Code](https://claude.com/claude-code)