### PR TITLE
Add recommended resolution to cover image upload guidelines (#1126)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -485,7 +485,7 @@ function CreatePage() {
             <div>
               <label className="text-foreground mb-1 block text-sm">Cover Image</label>
               <p className="text-muted mb-2 text-[11px]">
-                Optional. WebP or JPEG, max 500KB.
+                Optional. WebP or JPEG, max 500KB. Recommended: 600×900px (2:3 portrait).
               </p>
               {coverCid ? (
                 <div className="flex items-start gap-3">

--- a/src/components/StoryEditPanel.tsx
+++ b/src/components/StoryEditPanel.tsx
@@ -150,7 +150,7 @@ export function StoryEditPanel({
       {/* Cover Image */}
       <div>
         <label className="text-foreground mb-1 block text-xs font-medium">Cover Image</label>
-        <p className="text-muted mb-2 text-[10px]">WebP or JPEG, max 500KB.</p>
+        <p className="text-muted mb-2 text-[10px]">WebP or JPEG, max 500KB. Recommended: 600×900px (2:3 portrait).</p>
         {coverUrl ? (
           <div className="flex items-start gap-3">
             <div className="relative h-[90px] w-[60px] shrink-0 overflow-hidden rounded border border-border">


### PR DESCRIPTION
## Summary
- Update cover image upload hint text to include `Recommended: 600×900px (2:3 portrait).`
- Updated in both `src/app/create/page.tsx` (create page) and `src/components/StoryEditPanel.tsx` (edit panel)
- Version bump 1.22.3 → 1.22.4

## Test plan
- [ ] Verify create page shows updated hint: "Optional. WebP or JPEG, max 500KB. Recommended: 600×900px (2:3 portrait)."
- [ ] Verify edit panel shows updated hint: "WebP or JPEG, max 500KB. Recommended: 600×900px (2:3 portrait)."
- [ ] Confirm no layout issues with the longer text on mobile viewports

Closes #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)