### PR TITLE
Restore ruled-paper textarea styling on create page (#1130)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -604,7 +604,7 @@ function CreatePage() {
                   disabled={newBusy}
                   rows={12}
                   placeholder="Write the genesis plot (500–10,000 characters)"
-                  className="bg-surface border-border text-foreground placeholder:text-muted font-prose w-full resize-y rounded border focus:border-accent focus:outline-none disabled:opacity-50"
+                  className="ruled-paper border-border text-foreground placeholder:text-muted w-full resize-y rounded border focus:border-accent focus:outline-none disabled:opacity-50"
                 />
               ) : (
                 <ContentPreview content={newContent} />
@@ -779,7 +779,7 @@ function CreatePage() {
                   disabled={chainBusy || noStoryline}
                   rows={12}
                   placeholder={noStoryline ? "Select a storyline above to chain a plot" : "Write the next plot (500–10,000 characters)"}
-                  className="bg-surface border-border text-foreground placeholder:text-muted font-prose w-full resize-y rounded border focus:border-accent focus:outline-none disabled:opacity-50"
+                  className="ruled-paper border-border text-foreground placeholder:text-muted w-full resize-y rounded border focus:border-accent focus:outline-none disabled:opacity-50"
                 />
               ) : (
                 <ContentPreview content={chainContent} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,6 +31,8 @@
   --error: var(--danger);
   --bg-shelf: var(--surface-raised);
   --paper-bg: var(--surface);
+  --paper-line: oklch(87% 0.006 250);
+  --paper-margin: oklch(82% 0.04 20);
 }
 
 @theme inline {
@@ -277,4 +279,53 @@ select {
   background-repeat: no-repeat;
   background-position: right 0.75rem center;
   padding-right: 2.5rem;
+}
+
+/* Ruled-paper textarea — create page only */
+.ruled-paper {
+  --line-height: 28px;
+  background-color: var(--paper-bg);
+  padding: calc(var(--line-height) * 2) 2rem var(--line-height) 4.5rem;
+  font-size: 1rem;
+  line-height: var(--line-height);
+  font-family: var(--font-prose), Georgia, serif;
+  background-image:
+    linear-gradient(
+      90deg,
+      transparent, transparent 3.5rem,
+      var(--paper-margin) 3.5rem,
+      var(--paper-margin) calc(3.5rem + 2px),
+      transparent calc(3.5rem + 2px)
+    ),
+    repeating-linear-gradient(
+      transparent,
+      transparent calc(var(--line-height) - 1px),
+      var(--paper-line) calc(var(--line-height) - 1px),
+      var(--paper-line) var(--line-height)
+    );
+  background-position-y: calc(var(--line-height) * 2);
+  border-radius: 4px;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+@media (max-width: 640px) {
+  .ruled-paper {
+    padding: calc(var(--line-height) * 2) 1rem var(--line-height) 2.5rem;
+    background-image:
+      linear-gradient(
+        90deg,
+        transparent, transparent 1.75rem,
+        var(--paper-margin) 1.75rem,
+        var(--paper-margin) calc(1.75rem + 2px),
+        transparent calc(1.75rem + 2px)
+      ),
+      repeating-linear-gradient(
+        transparent,
+        transparent calc(var(--line-height) - 1px),
+        var(--paper-line) calc(var(--line-height) - 1px),
+        var(--paper-line) var(--line-height)
+      );
+    background-position-y: calc(var(--line-height) * 2);
+  }
 }


### PR DESCRIPTION
## Summary
- Restore ruled-paper CSS with lined notebook styling adapted for the current light theme
- Add `--paper-line` and `--paper-margin` CSS variables using OKLCH colors
- Apply `ruled-paper` class to both New tab and Add Plot tab textareas on the create page
- Scoped to create page only — does not affect story detail or reading mode
- Version bump 1.23.0 → 1.23.1

## Test plan
- [ ] Open create page — New tab textarea shows ruled-paper lines with left margin
- [ ] Switch to Add Plot tab — textarea also shows ruled-paper styling
- [ ] Test on mobile viewport (375px) — margin and padding adjust for smaller screen
- [ ] Verify story detail page content is NOT affected by ruled-paper
- [ ] Verify reading mode is NOT affected by ruled-paper
- [ ] Check styling fits the light theme (no dark-theme artifacts)

Closes #1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)