### PR TITLE
Add cover image moderation notice on upload areas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -484,8 +484,11 @@ function CreatePage() {
             {/* Cover Image Upload */}
             <div>
               <label className="text-foreground mb-1 block text-sm">Cover Image</label>
-              <p className="text-muted mb-2 text-[11px]">
+              <p className="text-muted mb-1 text-[11px]">
                 Optional. WebP or JPEG, max 500KB. Recommended: 600×900px (2:3 portrait).
+              </p>
+              <p className="text-muted mb-2 text-[10px]">
+                PlotLink may replace or remove cover images that violate our Terms or do not meet quality guidelines.
               </p>
               {coverCid ? (
                 <div className="flex items-start gap-3">

--- a/src/components/StoryEditPanel.tsx
+++ b/src/components/StoryEditPanel.tsx
@@ -153,7 +153,10 @@ export function StoryEditPanel({
       {/* Cover Image */}
       <div>
         <label className="text-foreground mb-1 block text-xs font-medium">Cover Image</label>
-        <p className="text-muted mb-2 text-[10px]">WebP or JPEG, max 500KB. Recommended: 600×900px (2:3 portrait).</p>
+        <p className="text-muted mb-1 text-[10px]">WebP or JPEG, max 500KB. Recommended: 600×900px (2:3 portrait).</p>
+        <p className="text-muted mb-2 text-[9px]">
+          PlotLink may replace or remove cover images that violate our Terms or do not meet quality guidelines.
+        </p>
         {coverUrl ? (
           <div className="flex items-start gap-3">
             <div className="relative h-[90px] w-[60px] shrink-0 overflow-hidden rounded border border-border">


### PR DESCRIPTION
## Summary
- Adds a subtle moderation notice below the cover image upload guidelines on both the create page (`src/app/create/page.tsx`) and the story edit panel (`src/components/StoryEditPanel.tsx`)
- Notice text: "PlotLink may replace or remove cover images that violate our Terms or do not meet quality guidelines."
- Styled as muted, smaller text (`text-[10px]`/`text-[9px]`) — informational, not alarming

Closes #1135

## Test plan
- [ ] Verify notice appears below upload guideline on the create page
- [ ] Verify notice appears below upload guideline on the story edit panel
- [ ] Confirm styling is subtle muted text, not a warning banner
- [ ] Version bumped to 1.23.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)