### PR TITLE
Add wallet signature auth to /api/upload-cover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.23.2",
+  "version": "1.23.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/api/upload-cover/route.ts
+++ b/src/app/api/upload-cover/route.ts
@@ -57,7 +57,16 @@ export async function POST(req: NextRequest) {
     }
 
     const timestamp = Number(timestampMatch[1]);
-    if (Date.now() - timestamp > SIGNATURE_MAX_AGE_MS) {
+    const expectedMessage = `PlotLink: Upload cover image\nTimestamp: ${timestamp}`;
+    if (message !== expectedMessage) {
+      return NextResponse.json(
+        { error: "Invalid message format." },
+        { status: 401 }
+      );
+    }
+
+    const age = Date.now() - timestamp;
+    if (age > SIGNATURE_MAX_AGE_MS || age < -30_000) {
       return NextResponse.json(
         { error: "Signature expired. Please try again." },
         { status: 401 }

--- a/src/app/api/upload-cover/route.ts
+++ b/src/app/api/upload-cover/route.ts
@@ -1,21 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
+import { recoverMessageAddress } from "viem";
 import { uploadBinaryWithRetry } from "../../../../lib/filebase";
 
 const MAX_FILE_SIZE = 500 * 1024; // 500KB
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 5;
+const SIGNATURE_MAX_AGE_MS = 5 * 60 * 1000;
 
 const ALLOWED_MIME_TYPES = new Set(["image/webp", "image/jpeg"]);
 
-const ipRequestLog = new Map<string, number[]>();
+const walletRequestLog = new Map<string, number[]>();
 
-function checkRateLimit(ip: string): boolean {
+function checkRateLimit(wallet: string): boolean {
   const now = Date.now();
-  const timestamps = ipRequestLog.get(ip) ?? [];
+  const timestamps = walletRequestLog.get(wallet) ?? [];
   const recent = timestamps.filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
   if (recent.length >= RATE_LIMIT_MAX) return false;
   recent.push(now);
-  ipRequestLog.set(ip, recent);
+  walletRequestLog.set(wallet, recent);
   return true;
 }
 
@@ -25,7 +27,6 @@ function validateMagicBytes(buffer: Uint8Array, mimeType: string): boolean {
       buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff;
   }
   if (mimeType === "image/webp") {
-    // RIFF at bytes 0-3, WEBP at bytes 8-11
     return buffer.length >= 12 &&
       buffer[0] === 0x52 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x46 &&
       buffer[8] === 0x57 && buffer[9] === 0x45 && buffer[10] === 0x42 && buffer[11] === 0x50;
@@ -34,20 +35,48 @@ function validateMagicBytes(buffer: Uint8Array, mimeType: string): boolean {
 }
 
 export async function POST(req: NextRequest) {
-  const ip =
-    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-    req.headers.get("x-real-ip") ??
-    "unknown";
-
-  if (!checkRateLimit(ip)) {
-    return NextResponse.json(
-      { error: "Rate limit exceeded. Max 5 uploads per minute." },
-      { status: 429 }
-    );
-  }
-
   try {
     const formData = await req.formData();
+
+    const message = formData.get("message");
+    const signature = formData.get("signature");
+
+    if (typeof message !== "string" || typeof signature !== "string") {
+      return NextResponse.json(
+        { error: "Missing wallet signature. Please connect your wallet and try again." },
+        { status: 401 }
+      );
+    }
+
+    const timestampMatch = message.match(/Timestamp:\s*(\d+)/);
+    if (!timestampMatch) {
+      return NextResponse.json(
+        { error: "Invalid message format." },
+        { status: 401 }
+      );
+    }
+
+    const timestamp = Number(timestampMatch[1]);
+    if (Date.now() - timestamp > SIGNATURE_MAX_AGE_MS) {
+      return NextResponse.json(
+        { error: "Signature expired. Please try again." },
+        { status: 401 }
+      );
+    }
+
+    const signer = await recoverMessageAddress({
+      message,
+      signature: signature as `0x${string}`,
+    });
+    const walletKey = signer.toLowerCase();
+
+    if (!checkRateLimit(walletKey)) {
+      return NextResponse.json(
+        { error: "Rate limit exceeded. Max 5 uploads per minute." },
+        { status: 429 }
+      );
+    }
+
     const file = formData.get("file");
 
     if (!file || !(file instanceof File)) {

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Suspense, useState, useMemo, useEffect, useRef, useCallback } from "react";
-import { useAccount } from "wagmi";
+import { useAccount, useSignMessage } from "wagmi";
 import { useSearchParams } from "next/navigation";
 import { useDraft } from "../../hooks/useDraft";
 import { useQuery } from "@tanstack/react-query";
@@ -127,6 +127,7 @@ export default function CreatePageWrapper() {
 function CreatePage() {
   const searchParams = useSearchParams();
   const { address, isConnected } = useAccount();
+  const { signMessageAsync } = useSignMessage();
 
   // Tab selection from query params
   const initialTab: Tab =
@@ -151,6 +152,10 @@ function CreatePage() {
 
   const handleCoverSelect = useCallback(async (file: File) => {
     setCoverError(null);
+    if (!isConnected) {
+      setCoverError("Connect your wallet to upload a cover image.");
+      return;
+    }
     const allowed = ["image/webp", "image/jpeg"];
     if (!allowed.includes(file.type)) {
       setCoverError("Only WebP and JPEG files are accepted.");
@@ -162,8 +167,14 @@ function CreatePage() {
     }
     setCoverUploading(true);
     try {
+      const timestamp = Date.now();
+      const message = `PlotLink: Upload cover image\nTimestamp: ${timestamp}`;
+      const signature = await signMessageAsync({ message });
+
       const formData = new FormData();
       formData.append("file", file);
+      formData.append("message", message);
+      formData.append("signature", signature);
       const res = await fetch("/api/upload-cover", { method: "POST", body: formData });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Upload failed");
@@ -173,7 +184,7 @@ function CreatePage() {
     } finally {
       setCoverUploading(false);
     }
-  }, []);
+  }, [isConnected, signMessageAsync]);
 
   const handleCoverRemove = useCallback(() => {
     setCoverCid(null);

--- a/src/components/StoryEditPanel.tsx
+++ b/src/components/StoryEditPanel.tsx
@@ -62,8 +62,14 @@ export function StoryEditPanel({
     }
     setCoverUploading(true);
     try {
+      const timestamp = Date.now();
+      const message = `PlotLink: Upload cover image\nTimestamp: ${timestamp}`;
+      const signature = await signMessageAsync({ message });
+
       const formData = new FormData();
       formData.append("file", file);
+      formData.append("message", message);
+      formData.append("signature", signature);
       const res = await fetch("/api/upload-cover", { method: "POST", body: formData });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Upload failed");
@@ -73,7 +79,7 @@ export function StoryEditPanel({
     } finally {
       setCoverUploading(false);
     }
-  }, []);
+  }, [signMessageAsync]);
 
   const handleSave = async () => {
     setSaveError(null);


### PR DESCRIPTION
## Summary
- Adds EIP-191 wallet signature requirement to `POST /api/upload-cover` — rejects unsigned requests with 401, expired signatures (>5 min) with 401
- Switches in-memory rate limit key from IP address to recovered wallet address (keeps 5/min limit)
- Updates both frontend callers (`src/app/create/page.tsx`, `src/components/StoryEditPanel.tsx`) to sign before uploading
- Handles wallet-not-connected edge case on create page with user-friendly error message

Closes #1136

## Test plan
- [ ] Verify API rejects uploads without signature (401)
- [ ] Verify API rejects expired timestamps (>5 min old)
- [ ] Verify rate limit keyed by recovered wallet address
- [ ] Verify StoryEditPanel signs before uploading
- [ ] Verify create page signs before uploading
- [ ] Verify create page shows "Connect your wallet" error if wallet not connected
- [ ] Verify existing upload flow works for authenticated users
- [ ] Version bumped to 1.23.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)