### PR TITLE
Improve cover image gradient on story cards

### DIFF
--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -1052,7 +1052,7 @@ function StoryRow({
               return (
                 <>
                   <img src={coverUrl} alt={storyline.title} loading="lazy" className="absolute inset-0 h-full w-full object-cover" />
-                  <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_60%,oklch(98%_0.005_80_/_0.75)_80%,oklch(96%_0.01_80_/_0.95)_100%)]" />
+                  <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_40%,oklch(0%_0_0_/_0.15)_60%,oklch(0%_0_0_/_0.55)_80%,oklch(0%_0_0_/_0.78)_100%)]" />
                 </>
               );
             }
@@ -1086,11 +1086,11 @@ function StoryRow({
           {/* Bottom info */}
           <div className="absolute bottom-0 left-0 right-0 z-[1] px-2.5 pb-2.5">
             {storyline.cover_cid && (
-              <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-[var(--fg)] line-clamp-2 sm:text-[15px]">
+              <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-white drop-shadow-[0_1px_2px_oklch(0%_0_0_/_0.6)] line-clamp-2 sm:text-[15px]">
                 {storyline.title}
               </h3>
             )}
-            <div className={`${storyline.cover_cid ? "mt-1" : ""} flex items-center gap-2 text-[10px] text-[var(--muted)]`}>
+            <div className={`${storyline.cover_cid ? "mt-1" : ""} flex items-center gap-2 text-[10px] ${storyline.cover_cid ? "text-white/70 drop-shadow-[0_1px_1px_oklch(0%_0_0_/_0.5)]" : "text-[var(--muted)]"}`}>
               <span>{storyline.plot_count} {storyline.plot_count === 1 ? "plot" : "plots"}</span>
               <span>·</span>
               <span>{formatViewCount(storyline.view_count)} views</span>
@@ -1666,7 +1666,7 @@ function PortfolioTab({ address, isOwnProfile }: { address: string; isOwnProfile
                     return (
                       <>
                         <img src={hCoverUrl} alt={h.storyline.title} loading="lazy" className="absolute inset-0 h-full w-full object-cover" />
-                        <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_60%,oklch(98%_0.005_80_/_0.75)_80%,oklch(96%_0.01_80_/_0.95)_100%)]" />
+                        <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_40%,oklch(0%_0_0_/_0.15)_60%,oklch(0%_0_0_/_0.55)_80%,oklch(0%_0_0_/_0.78)_100%)]" />
                       </>
                     );
                   }
@@ -1685,7 +1685,7 @@ function PortfolioTab({ address, isOwnProfile }: { address: string; isOwnProfile
                 )}
                 {h.storyline.cover_cid && (
                   <div className="absolute bottom-0 left-0 right-0 z-[1] px-2 pb-2">
-                    <span className="font-heading text-xs font-semibold leading-tight text-[var(--fg)] line-clamp-2 sm:text-sm">
+                    <span className="font-heading text-xs font-semibold leading-tight text-white drop-shadow-[0_1px_2px_oklch(0%_0_0_/_0.6)] line-clamp-2 sm:text-sm">
                       {h.storyline.title}
                     </span>
                   </div>

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -75,20 +75,20 @@ export function StoryCard({
           loading="lazy"
           className="absolute inset-0 h-full w-full object-cover"
         />
-        <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_60%,oklch(98%_0.005_80_/_0.75)_80%,oklch(96%_0.01_80_/_0.95)_100%)]" />
+        <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_40%,oklch(0%_0_0_/_0.15)_60%,oklch(0%_0_0_/_0.55)_80%,oklch(0%_0_0_/_0.78)_100%)]" />
 
         <Badges genre={displayGenre} writerType={storyline.writer_type} status={status} isNsfw={storyline.is_nsfw} />
 
         <div className="absolute right-0 bottom-0 left-0 z-[2] px-2.5 pt-3 pb-2.5">
-          <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-[var(--fg)] line-clamp-2 sm:text-[15px]">
+          <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-white drop-shadow-[0_1px_2px_oklch(0%_0_0_/_0.6)] line-clamp-2 sm:text-[15px]">
             {storyline.title}
           </h3>
-          <div className="mt-[3px] text-[11px] text-[var(--muted)]">
+          <div className="mt-[3px] text-[11px] text-white/75 drop-shadow-[0_1px_1px_oklch(0%_0_0_/_0.5)]">
             <WriterIdentityClient address={storyline.writer_address} writerType={storyline.writer_type} />
           </div>
           {storyline.token_address && (
             <div className="mt-1.5">
-              <span className="font-mono text-[10px] tabular-nums text-[var(--muted)] [&_.font-semibold]:text-[var(--fg)]">
+              <span className="font-mono text-[10px] tabular-nums text-white/70 drop-shadow-[0_1px_1px_oklch(0%_0_0_/_0.5)]">
                 <StoryCardTVL tokenAddress={storyline.token_address} />
               </span>
             </div>


### PR DESCRIPTION
## Summary
- Replace harsh white gradient overlay with a smooth dark gradient (transparent → 78% black) that blends naturally with cover images of any brightness/color
- Switch bottom text elements (title, author, TVL) to white with drop shadows for readability on the dark overlay
- Applied consistently across StoryCard component and profile page card variants

Closes #1140

## Test plan
- [ ] Verify gradient looks natural on light cover images
- [ ] Verify gradient looks natural on dark cover images
- [ ] Verify title text is clearly readable on all cover variants
- [ ] Verify author and TVL text remain legible
- [ ] Check profile page story cards have the same improved gradient
- [ ] Confirm fallback cards (no cover image) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)