### PR TITLE
Remove title overlay from cover image on detail page

### DIFF
--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -357,15 +357,7 @@ function StoryHeader({
           style={{ aspectRatio: "2/3" }}
         >
           {coverUrl ? (
-            <>
-              <img src={coverUrl} alt={storyline.title} loading="lazy" className="absolute inset-0 h-full w-full object-cover" />
-              <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_60%,oklch(98%_0.005_80_/_0.75)_80%,oklch(96%_0.01_80_/_0.95)_100%)]" />
-              <div className="absolute bottom-0 left-0 right-0 px-3 pb-3">
-                <h2 className="font-heading text-[18px] font-semibold leading-tight text-[var(--fg)] sm:text-[22px]">
-                  {storyline.title}
-                </h2>
-              </div>
-            </>
+            <img src={coverUrl} alt={storyline.title} loading="lazy" className="absolute inset-0 h-full w-full object-cover" />
           ) : (
             <>
               <div className="absolute inset-0" style={FALLBACK_STYLES[variant]} />


### PR DESCRIPTION
## Summary
- Remove gradient overlay and title text from cover image on story detail page when a custom cover exists
- The full cover image now displays cleanly without any overlays
- Fallback (no-cover) cards retain the centered title overlay with accent line as before
- Title is already shown in the adjacent info column, so no information is lost

Closes #1141

## Test plan
- [ ] Story detail page with custom cover: no gradient, no title text on image
- [ ] Story detail page without cover: fallback still shows centered title + accent line
- [ ] Title is visible in the info column beside the cover
- [ ] No layout regressions on mobile or desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)