### PR TITLE
Add lightbox/expanded view for cover image on detail page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -329,3 +329,13 @@ select {
     background-position-y: calc(var(--line-height) * 2);
   }
 }
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes scaleIn {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -335,7 +335,17 @@ select {
   to { opacity: 1; }
 }
 
+@keyframes fadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
 @keyframes scaleIn {
   from { opacity: 0; transform: scale(0.95); }
   to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes scaleOut {
+  from { opacity: 1; transform: scale(1); }
+  to { opacity: 0; transform: scale(0.95); }
 }

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -25,6 +25,7 @@ import { MobileActionBar } from "../../../components/MobileActionBar";
 import { MarketCapBox } from "../../../components/MarketCapBox";
 import { TokenPriceBox } from "../../../components/TokenPriceBox";
 import { FALLBACK_STYLES, hashToVariant } from "../../../components/StoryCard";
+import { CoverLightbox } from "../../../components/CoverLightbox";
 import { getCoverUrl } from "../../../../lib/cover";
 import { StoryEditPanel } from "../../../components/StoryEditPanel";
 
@@ -357,7 +358,7 @@ function StoryHeader({
           style={{ aspectRatio: "2/3" }}
         >
           {coverUrl ? (
-            <img src={coverUrl} alt={storyline.title} loading="lazy" className="absolute inset-0 h-full w-full object-cover" />
+            <CoverLightbox src={coverUrl} alt={storyline.title} />
           ) : (
             <>
               <div className="absolute inset-0" style={FALLBACK_STYLES[variant]} />

--- a/src/components/CoverLightbox.tsx
+++ b/src/components/CoverLightbox.tsx
@@ -1,35 +1,52 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 
 export function CoverLightbox({ src, alt }: { src: string; alt: string }) {
-  const [open, setOpen] = useState(false);
+  const [visible, setVisible] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
 
-  const close = useCallback(() => setOpen(false), []);
+  const open = useCallback(() => {
+    setClosing(false);
+    setVisible(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setClosing(true);
+    timerRef.current = setTimeout(() => {
+      setVisible(false);
+      setClosing(false);
+    }, 150);
+  }, []);
 
   useEffect(() => {
-    if (!open) return;
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  }, []);
+
+  useEffect(() => {
+    if (!visible || closing) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") close();
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [open, close]);
+  }, [visible, closing, close]);
 
   return (
     <>
       <button
         type="button"
-        onClick={() => setOpen(true)}
+        onClick={open}
         className="absolute inset-0 cursor-pointer"
         aria-label="View full cover image"
       >
         <img src={src} alt={alt} loading="lazy" className="h-full w-full object-cover" />
       </button>
 
-      {open && (
+      {visible && (
         <div
-          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/80 backdrop-blur-sm animate-[fadeIn_150ms_ease-out]"
+          className={`fixed inset-0 z-[9999] flex items-center justify-center bg-black/80 backdrop-blur-sm ${closing ? "animate-[fadeOut_150ms_ease-in_forwards]" : "animate-[fadeIn_150ms_ease-out]"}`}
           onClick={close}
         >
           <button
@@ -46,7 +63,7 @@ export function CoverLightbox({ src, alt }: { src: string; alt: string }) {
             src={src}
             alt={alt}
             onClick={(e) => e.stopPropagation()}
-            className="max-h-[90vh] max-w-[90vw] rounded-md object-contain animate-[scaleIn_150ms_ease-out]"
+            className={`max-h-[90vh] max-w-[90vw] rounded-md object-contain ${closing ? "animate-[scaleOut_150ms_ease-in_forwards]" : "animate-[scaleIn_150ms_ease-out]"}`}
           />
         </div>
       )}

--- a/src/components/CoverLightbox.tsx
+++ b/src/components/CoverLightbox.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export function CoverLightbox({ src, alt }: { src: string; alt: string }) {
+  const [open, setOpen] = useState(false);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, close]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="absolute inset-0 cursor-pointer"
+        aria-label="View full cover image"
+      >
+        <img src={src} alt={alt} loading="lazy" className="h-full w-full object-cover" />
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/80 backdrop-blur-sm animate-[fadeIn_150ms_ease-out]"
+          onClick={close}
+        >
+          <button
+            type="button"
+            onClick={close}
+            className="absolute top-4 right-4 flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white/80 transition-colors hover:bg-white/20 hover:text-white"
+            aria-label="Close lightbox"
+          >
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <path d="M5 5l10 10M15 5L5 15" />
+            </svg>
+          </button>
+          <img
+            src={src}
+            alt={alt}
+            onClick={(e) => e.stopPropagation()}
+            className="max-h-[90vh] max-w-[90vw] rounded-md object-contain animate-[scaleIn_150ms_ease-out]"
+          />
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Add clickable cover image on story detail page that opens a centered lightbox modal
- Full image scales to fit viewport (max 90vh/90vw) preserving aspect ratio
- Dark backdrop (80% black) with backdrop blur
- Close via X button, backdrop click, or Escape key
- Smooth fade-in and scale animations
- Only enabled for custom cover images — generated placeholders are unaffected

Closes #1142

## Test plan
- [ ] Click custom cover image → lightbox opens with full image
- [ ] Image preserves aspect ratio and fits within viewport
- [ ] Close via X button works
- [ ] Close via backdrop click works
- [ ] Close via Escape key works
- [ ] Pointer cursor shown on hover over cover
- [ ] Stories without cover (fallback placeholder) do not show lightbox behavior
- [ ] No layout shift when lightbox opens/closes
- [ ] Animation is smooth on open/close

🤖 Generated with [Claude Code](https://claude.com/claude-code)