### PR TITLE
Fix author text not visible on dark gradient cover cards

### DIFF
--- a/src/components/WriterIdentityClient.tsx
+++ b/src/components/WriterIdentityClient.tsx
@@ -59,7 +59,7 @@ export function WriterIdentityClient({
     const label = truncateAddress(address);
     if (!linkProfile) return <span>{label}</span>;
     return (
-      <Link href={`/profile/${address}`} className="text-foreground hover:text-accent transition-colors">
+      <Link href={`/profile/${address}`} className="text-inherit hover:text-accent transition-colors">
         {label}
       </Link>
     );
@@ -78,7 +78,7 @@ export function WriterIdentityClient({
     );
     if (!linkProfile) return inner;
     return (
-      <Link href={`/profile/${address}`} className="text-foreground hover:text-accent transition-colors">
+      <Link href={`/profile/${address}`} className="text-inherit hover:text-accent transition-colors">
         {inner}
       </Link>
     );
@@ -89,7 +89,7 @@ export function WriterIdentityClient({
     const label = `AI Writer #${ownerInfo.agentId}`;
     if (!linkProfile) return <span>{label}</span>;
     return (
-      <Link href={`/profile/${address}`} className="text-foreground hover:text-accent transition-colors">
+      <Link href={`/profile/${address}`} className="text-inherit hover:text-accent transition-colors">
         {label}
       </Link>
     );
@@ -108,7 +108,7 @@ export function WriterIdentityClient({
     );
     if (!linkProfile) return inner;
     return (
-      <Link href={`/profile/${address}`} className="text-foreground hover:text-accent transition-colors">
+      <Link href={`/profile/${address}`} className="text-inherit hover:text-accent transition-colors">
         {inner}
       </Link>
     );
@@ -118,7 +118,7 @@ export function WriterIdentityClient({
   const label = truncateAddress(address);
   if (!linkProfile) return <span>{label}</span>;
   return (
-    <Link href={`/profile/${address}`} className="text-foreground hover:text-accent transition-colors">
+    <Link href={`/profile/${address}`} className="text-inherit hover:text-accent transition-colors">
       {label}
     </Link>
   );


### PR DESCRIPTION
## Summary
- Fix `WriterIdentityClient` link color from hardcoded `text-foreground` to `text-inherit`
- On cover cards with dark gradient, parent sets `text-white/75` which now flows through correctly
- On non-cover cards and other contexts, inherits from parent (typically `text-muted`) — no regression
- Hover to accent color still works

Closes #1146

## Test plan
- [ ] Story cards with cover images show white author text
- [ ] Author text has drop shadow (inherited from parent wrapper)
- [ ] Hover on author name shows accent color
- [ ] Story cards without covers still show muted author text
- [ ] Profile page, detail page author links unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)