### PR TITLE
Apply proper markdown prose styling to Terms and Privacy pages

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -75,6 +75,72 @@ h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-newsreader), 'Newsreader', 'Iowan Old Style', Georgia, serif;
 }
 
+.prose {
+  color: var(--fg);
+  line-height: 1.7;
+}
+.prose h1 {
+  font-family: var(--font-heading);
+  font-size: 1.75rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--fg);
+  margin-bottom: 0.5rem;
+}
+.prose h2 {
+  font-family: var(--font-heading);
+  font-size: 1.15rem;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  color: var(--fg);
+  margin-top: 2rem;
+  margin-bottom: 0.6rem;
+}
+.prose h3 {
+  font-family: var(--font-heading);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--fg);
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+.prose p {
+  margin-top: 0;
+  margin-bottom: 0.85rem;
+  color: var(--fg);
+}
+.prose ul {
+  margin-top: 0.4rem;
+  margin-bottom: 0.85rem;
+  padding-left: 1.5rem;
+  list-style-type: disc;
+}
+.prose li {
+  margin-bottom: 0.3rem;
+  color: var(--fg);
+}
+.prose li::marker {
+  color: var(--muted);
+}
+.prose a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.prose a:hover {
+  color: var(--accent-hover, var(--accent));
+}
+.prose strong {
+  font-weight: 650;
+}
+.prose code {
+  font-size: 0.85em;
+  padding: 0.15em 0.35em;
+  border-radius: 3px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+
 /* Monospace elements */
 code, pre, .font-mono {
   font-family: 'SF Mono', ui-monospace, Menlo, monospace;

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,7 +1,7 @@
 export default function PrivacyPage() {
   return (
     <div className="mx-auto max-w-2xl px-6 py-12">
-      <article className="prose prose-sm max-w-none font-prose">
+      <article className="prose max-w-none">
         <h1>Privacy Policy</h1>
         <p className="text-muted"><strong>PlotLink &mdash; plotlink.xyz</strong><br />Last updated: April 24, 2026</p>
 

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,7 +1,7 @@
 export default function TermsPage() {
   return (
     <div className="mx-auto max-w-2xl px-6 py-12">
-      <article className="prose prose-sm max-w-none font-prose">
+      <article className="prose max-w-none">
         <h1>Terms of Service</h1>
         <p className="text-muted"><strong>PlotLink &mdash; plotlink.xyz</strong><br />Last updated: May 8, 2026</p>
 


### PR DESCRIPTION
## Summary
- Add comprehensive `.prose` CSS rules to globals.css with proper heading hierarchy, spacing, list indentation, link styling, and code formatting
- Uses design tokens (--fg, --muted, --accent, --surface, --border) for consistent colors
- Serif font (Newsreader) via existing `.prose` font-family rule
- Clean up page classes from `prose prose-sm max-w-none font-prose` to `prose max-w-none`

Closes #1147

## Test plan
- [ ] Terms page (/terms) renders with proper heading sizes and hierarchy
- [ ] Privacy page (/privacy) renders with proper heading sizes and hierarchy
- [ ] Lists are indented with disc markers
- [ ] Links show accent color with underline
- [ ] Code elements have background/border styling
- [ ] Spacing between sections is consistent and readable
- [ ] No regressions on story content (uses separate .story-markdown class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)