### PR TITLE
Fix /agents page not showing linked agent for operator wallet

### DIFF
--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -45,10 +45,12 @@ function AgentsPageInner() {
   const dbDetected = dbAgentId != null;
 
   // Check if user has a linked OWS agent (human → OWS wallet link)
+  // Always fetch: operator may have a separate user row with linked_agent_wallet
+  // even when getAgentUserFromDB returns the agent's row via agent_owner match
   const { data: humanUser, isLoading: humanUserLoading } = useQuery({
     queryKey: ["human-user", address],
     queryFn: () => getUserFromDB(address!),
-    enabled: !!address && !dbDetected,
+    enabled: !!address,
   });
   const linkedAgentWallet = humanUser?.linked_agent_wallet ?? null;
   const hasLinkedAgent = linkedAgentWallet !== null;
@@ -110,7 +112,7 @@ function AgentsPageInner() {
   }
 
   const hasExistingAgent = (detectedAgentId !== undefined && detectedRole !== undefined) || rpcHasNft || hasLinkedAgent;
-  const detectLoading = dbLoading || (!dbDetected && humanUserLoading) || (!dbDetected && rpcBalanceLoading) || (needsRpcFallback && (rpcWalletLoading || (rpcHasNft && rpcTokenLoading)));
+  const detectLoading = dbLoading || humanUserLoading || (!dbDetected && rpcBalanceLoading) || (needsRpcFallback && (rpcWalletLoading || (rpcHasNft && rpcTokenLoading)));
 
   // Auto-cache: when RPC fallback detects an agent not in DB, persist it
   const cachedRef = useRef(false);


### PR DESCRIPTION
## Summary
- Remove `!dbDetected` gate from the `getUserFromDB` query on `/agents` page
- Root cause: operator wallet's `getAgentUserFromDB` succeeds (via `agent_owner` match on the agent's row), setting `dbDetected = true`, which skipped the `getUserFromDB` call that fetches the operator's own row containing `linked_agent_wallet`
- Also update `detectLoading` to always include `humanUserLoading` since the query now always runs

Closes #1148

## Test plan
- [ ] Operator wallet with linked agent sees the agent on /agents Manage tab
- [ ] Agent wallet still works correctly on /agents
- [ ] Wallet with no agent still sees Register tab
- [ ] Profile page behavior unchanged
- [ ] Loading state displays correctly while queries resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)