### PR TITLE
Add sort icon to active sort tab on discover page

### DIFF
--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -202,7 +202,14 @@ export function FilterBar({ writer, genre, lang, tab, totalCount, showNsfw = fal
                     : "text-[var(--muted)] hover:text-[var(--fg)]"
                 }`}
               >
-                {label}
+                <span className="inline-flex items-center gap-1">
+                  {label}
+                  {tab === value && (
+                    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className="opacity-50">
+                      <path d="M4 6l4-3 4 3M4 10l4 3 4-3" />
+                    </svg>
+                  )}
+                </span>
                 {tab === value && (
                   <span className="absolute bottom-0 left-3 right-3 h-[2px] rounded-full bg-[var(--accent)]" />
                 )}

--- a/src/components/__tests__/FilterBar.test.tsx
+++ b/src/components/__tests__/FilterBar.test.tsx
@@ -50,7 +50,7 @@ describe("FilterBar", () => {
 
   it("active sort tab is highlighted", () => {
     render(<FilterBar {...defaultProps} tab="trending" />);
-    const trendingBtn = screen.getByText("Trending");
+    const trendingBtn = screen.getByText("Trending").closest("button");
     expect(trendingBtn).toHaveClass("font-semibold");
   });
 });


### PR DESCRIPTION
## Summary
- Add a subtle sort icon (up/down chevron arrows) next to the label on the active sort tab
- Icon only renders for the active tab; inactive tabs remain plain text
- Uses inline SVG at 50% opacity to keep it subtle and consistent with design

Closes #1149

## Test plan
- [ ] Active sort tab (New/Trending/Market Cap) shows sort icon beside label
- [ ] Inactive tabs show no icon
- [ ] Switching tabs moves the icon to the newly active tab
- [ ] Icon is subtle and doesn't shift layout noticeably
- [ ] Underline indicator still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)