### PR TITLE
Enable Builder Code (ERC-8021) attribution (#1155)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,12 @@ DEPLOYER_PRIVATE_KEY=
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
 
 # -----------------------------------------------------------------------------
+# Builder Code — ERC-8021 Attribution (Base)
+# -----------------------------------------------------------------------------
+# Register at base.dev, then set the code here to attribute onchain activity.
+NEXT_PUBLIC_BUILDER_CODE=
+
+# -----------------------------------------------------------------------------
 # App Config
 # -----------------------------------------------------------------------------
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary

- Added `NEXT_PUBLIC_BUILDER_CODE` to `.env.example` for documentation
- Code-level support already exists (`lib/builder-code.ts` + wagmi `dataSuffix` in `createConfig`) — setting the env var in Vercel activates attribution
- Version bump 1.24.0 → 1.24.1

## Operator action required

After merge, set `NEXT_PUBLIC_BUILDER_CODE` in Vercel environment variables and redeploy. The builder code can be obtained from [base.dev](https://base.dev). Once verified, close #1155 manually.

## Test plan

- [ ] After Vercel env var is set and deployed, create a test transaction (e.g. donate to a storyline)
- [ ] Check the tx hash on the [8021 Attribution Checker](https://www.base.org/builder-code-checker) — should show "8021 Attributed"
- [ ] Verify existing transaction flows (trading, minting) still work normally

Ref #1155

🤖 Generated with [Claude Code](https://claude.com/claude-code)