### PR TITLE
Fix Base App blank screen and connection loss on refresh (#1158)

### DIFF
--- a/lib/farcaster-detect.ts
+++ b/lib/farcaster-detect.ts
@@ -1,25 +1,8 @@
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
   return Promise.race([
     promise,
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("timeout")), ms),
-    ),
+    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), ms)),
   ]);
-}
-
-/**
- * Detect whether we are running inside a Farcaster Mini App context.
- * Safe to call on server (returns false) and outside Farcaster (returns false).
- */
-export async function isFarcasterMiniApp(): Promise<boolean> {
-  if (typeof window === "undefined") return false;
-  try {
-    const { sdk } = await import("@farcaster/miniapp-sdk");
-    const ctx = await withTimeout(sdk.context, 3000);
-    return !!ctx;
-  } catch {
-    return false;
-  }
 }
 
 function isMobileWithInjectedProvider(): boolean {
@@ -28,18 +11,43 @@ function isMobileWithInjectedProvider(): boolean {
   return /mobile|android/i.test(navigator.userAgent);
 }
 
-export async function detectPlatform(): Promise<"farcaster" | "base" | "web"> {
-  if (typeof window === "undefined") return "web";
+export async function isFarcasterMiniApp(): Promise<boolean> {
+  if (typeof window === "undefined") return false;
   try {
     const { sdk } = await import("@farcaster/miniapp-sdk");
-    const ctx = await withTimeout(sdk.context, 3000);
+    const ctx = await withTimeout(sdk.context, 3000, null);
+    return !!ctx;
+  } catch {
+    return false;
+  }
+}
+
+export async function detectPlatform(): Promise<"farcaster" | "base" | "web"> {
+  if (typeof window === "undefined") return "web";
+
+  // Fast path: mobile browser with injected provider is Base App
+  if (isMobileWithInjectedProvider()) {
+    try {
+      const { sdk } = await import("@farcaster/miniapp-sdk");
+      const ctx = await withTimeout(sdk.context, 1000, null);
+      if (ctx?.client) {
+        if (ctx.client.clientFid === 309857) return "base";
+        return "farcaster";
+      }
+    } catch {
+      // SDK failed — fall through to Base App detection
+    }
+    return "base";
+  }
+
+  // Standard path: desktop or non-injected mobile
+  try {
+    const { sdk } = await import("@farcaster/miniapp-sdk");
+    const ctx = await withTimeout(sdk.context, 3000, null);
     if (!ctx?.client) return "web";
     if (ctx.client.clientFid === 309857) return "base";
     return "farcaster";
   } catch {
-    // sdk.context timed out or failed — if we're in a mobile browser
-    // with an injected provider, this is likely Base App
-    if (isMobileWithInjectedProvider()) return "base";
     return "web";
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -6,6 +6,7 @@ import { RainbowKitProvider, type Theme } from "@rainbow-me/rainbowkit";
 import { config } from "../../lib/wagmi";
 import { useState, Suspense } from "react";
 import { useReferralCapture } from "../hooks/useReferralCapture";
+import { usePlatformDetection } from "../hooks/usePlatformDetection";
 
 import "@rainbow-me/rainbowkit/styles.css";
 
@@ -71,6 +72,12 @@ function ReferralCapture() {
   return null;
 }
 
+function PlatformGate({ children }: { children: React.ReactNode }) {
+  const { isLoading } = usePlatformDetection();
+  if (isLoading) return null;
+  return <>{children}</>;
+}
+
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
     () =>
@@ -107,7 +114,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
           <Suspense fallback={null}>
             <ReferralCapture />
           </Suspense>
-          {children}
+          <PlatformGate>{children}</PlatformGate>
         </RainbowKitProvider>
       </QueryClientProvider>
     </WagmiProvider>

--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -23,18 +23,24 @@ export function ConnectWallet({ onNavigate, compact }: ConnectWalletProps = {}) 
   const { profile } = useConnectedIdentity();
 
   // Auto-connect when inside a mini app (Farcaster or Base App)
+  // Base App: always re-attempt on mount (webview may not persist localStorage)
+  // Farcaster: only attempt once (wagmi reconnect handles persistence)
   useEffect(() => {
     if (platformLoading || platform === "web") return;
-    if (autoConnectAttempted.current || isConnected) return;
-    autoConnectAttempted.current = true;
+    if (isConnected) return;
 
-    if (platform === "base" && typeof window !== "undefined" && window.ethereum) {
-      const injectedConnector = connectors.find((c) => c.type === "injected");
-      if (injectedConnector) {
-        connect({ connector: injectedConnector });
-        return;
+    if (platform === "base") {
+      if (typeof window !== "undefined" && window.ethereum) {
+        const injectedConnector = connectors.find((c) => c.type === "injected");
+        if (injectedConnector) {
+          connect({ connector: injectedConnector });
+          return;
+        }
       }
     }
+
+    if (autoConnectAttempted.current) return;
+    autoConnectAttempted.current = true;
 
     const farcasterConnector = connectors.find((c) => c.type === "farcasterMiniApp");
     if (farcasterConnector) {

--- a/src/components/FarcasterMiniApp.tsx
+++ b/src/components/FarcasterMiniApp.tsx
@@ -26,7 +26,7 @@ export function FarcasterMiniApp() {
       if (cancelled) return;
 
       try {
-        sdk.actions.ready();
+        await sdk.actions.ready();
       } catch {
         // May fail in Base App where Farcaster host frame doesn't exist
       }

--- a/src/components/FarcasterMiniApp.tsx
+++ b/src/components/FarcasterMiniApp.tsx
@@ -25,8 +25,11 @@ export function FarcasterMiniApp() {
     import("@farcaster/miniapp-sdk").then(async ({ sdk }) => {
       if (cancelled) return;
 
-      // Dismiss splash screen
-      sdk.actions.ready();
+      try {
+        sdk.actions.ready();
+      } catch {
+        // May fail in Base App where Farcaster host frame doesn't exist
+      }
 
       // Check if user has already added the miniapp
       const context = await sdk.context;


### PR DESCRIPTION
## Summary

- **Safe timeout**: Use `resolve(fallback)` instead of `reject` in `withTimeout` to avoid unhandled promise rejections crashing Base App's webview
- **Fast-path detection**: Check mobile+injected provider immediately, use 1s SDK timeout (down from 3s) for Base App — auto-connect fires within ~1 second
- **Root-level loading gate**: Added `PlatformGate` in `providers.tsx` to block rendering until platform detection completes, preventing race conditions
- **sdk.actions.ready() guard**: Wrapped in try/catch for Base App where Farcaster host frame doesn't exist
- **Reconnect persistence**: Always re-attempt auto-connect in Base App on mount, don't rely on wagmi localStorage which may not persist in webview

## Test plan

- [ ] Open PlotLink in Base App — no blank screen, wallet auto-connects within ~1s
- [ ] Refresh page in Base App — connection persists (auto-reconnects)
- [ ] Open in Warpcast — Farcaster auto-connect works as before
- [ ] Open in desktop browser — RainbowKit modal appears on "connect wallet" click, no loading delay
- [ ] No console errors or unhandled promise rejections in any environment

Closes #1158

🤖 Generated with [Claude Code](https://claude.com/claude-code)