### PR TITLE
Add cookieStorage to fix Base App connection loss on refresh (#1160)

### DIFF
--- a/lib/wagmi.ts
+++ b/lib/wagmi.ts
@@ -1,4 +1,4 @@
-import { http, createConfig } from "wagmi";
+import { http, createConfig, createStorage, cookieStorage } from "wagmi";
 import { injected } from "wagmi/connectors";
 import { base, baseSepolia } from "wagmi/chains";
 import { farcasterMiniApp } from "@farcaster/miniapp-wagmi-connector";
@@ -56,6 +56,7 @@ export const config = createConfig({
     [base.id]: IS_MAINNET ? createFallbackTransport() : http(),
     [baseSepolia.id]: IS_MAINNET ? http() : createFallbackTransport(),
   },
+  storage: createStorage({ storage: cookieStorage }),
   ssr: true,
   ...(DATA_SUFFIX ? { dataSuffix: DATA_SUFFIX } : {}),
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -6,8 +6,6 @@ import { RainbowKitProvider, type Theme } from "@rainbow-me/rainbowkit";
 import { config } from "../../lib/wagmi";
 import { useState, Suspense } from "react";
 import { useReferralCapture } from "../hooks/useReferralCapture";
-import { usePlatformDetection } from "../hooks/usePlatformDetection";
-
 import "@rainbow-me/rainbowkit/styles.css";
 
 // PlotLink-themed RainbowKit theme using CSS vars
@@ -72,12 +70,6 @@ function ReferralCapture() {
   return null;
 }
 
-function PlatformGate({ children }: { children: React.ReactNode }) {
-  const { isLoading } = usePlatformDetection();
-  if (isLoading) return null;
-  return <>{children}</>;
-}
-
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
     () =>
@@ -114,7 +106,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
           <Suspense fallback={null}>
             <ReferralCapture />
           </Suspense>
-          <PlatformGate>{children}</PlatformGate>
+          {children}
         </RainbowKitProvider>
       </QueryClientProvider>
     </WagmiProvider>


### PR DESCRIPTION
## Summary

- Added `cookieStorage` to wagmi config so connection state persists via cookies instead of localStorage — wagmi reconnects before React hydrates, fixing connection loss on refresh in Base App's webview
- Removed `PlatformGate` from `providers.tsx` that was causing 1-3 second blank screen — no longer needed since cookieStorage handles SSR hydration correctly
- Version bump 1.24.2 → 1.24.3

## Test plan

- [ ] Open PlotLink in Base App — no blank screen on load
- [ ] Connect wallet in Base App → refresh → wallet stays connected
- [ ] Close and reopen Base App → reconnects automatically
- [ ] Open in Warpcast — Farcaster auto-connect works as before
- [ ] Open in desktop browser — RainbowKit modal works, no regressions

Closes #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)