### PR TITLE
Skip Farcaster SDK import in Base App to prevent webview crash (#1162)

### DIFF
--- a/lib/farcaster-detect.ts
+++ b/lib/farcaster-detect.ts
@@ -13,6 +13,7 @@ function isMobileWithInjectedProvider(): boolean {
 
 export async function isFarcasterMiniApp(): Promise<boolean> {
   if (typeof window === "undefined") return false;
+  if (isMobileWithInjectedProvider()) return false;
   try {
     const { sdk } = await import("@farcaster/miniapp-sdk");
     const ctx = await withTimeout(sdk.context, 3000, null);
@@ -25,22 +26,13 @@ export async function isFarcasterMiniApp(): Promise<boolean> {
 export async function detectPlatform(): Promise<"farcaster" | "base" | "web"> {
   if (typeof window === "undefined") return "web";
 
-  // Fast path: mobile browser with injected provider is Base App
+  // Base App: mobile + injected provider → skip SDK import entirely
+  // Warpcast does NOT inject window.ethereum, so this is a safe distinguisher
   if (isMobileWithInjectedProvider()) {
-    try {
-      const { sdk } = await import("@farcaster/miniapp-sdk");
-      const ctx = await withTimeout(sdk.context, 1000, null);
-      if (ctx?.client) {
-        if (ctx.client.clientFid === 309857) return "base";
-        return "farcaster";
-      }
-    } catch {
-      // SDK failed — fall through to Base App detection
-    }
     return "base";
   }
 
-  // Standard path: desktop or non-injected mobile
+  // Only import SDK when NOT in Base App (desktop or Warpcast)
   try {
     const { sdk } = await import("@farcaster/miniapp-sdk");
     const ctx = await withTimeout(sdk.context, 3000, null);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.24.3",
+  "version": "1.24.4",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/FarcasterMiniApp.tsx
+++ b/src/components/FarcasterMiniApp.tsx
@@ -31,8 +31,10 @@ export function FarcasterMiniApp() {
         // May fail in Base App where Farcaster host frame doesn't exist
       }
 
-      // Check if user has already added the miniapp
-      const context = await sdk.context;
+      const context = await Promise.race([
+        sdk.context,
+        new Promise<null>((r) => setTimeout(() => r(null), 3000)),
+      ]);
       if (cancelled || !context?.client) return;
 
       // Save existing notification token if user already added

--- a/src/components/ShareToFarcaster.tsx
+++ b/src/components/ShareToFarcaster.tsx
@@ -17,16 +17,20 @@ export function ShareToFarcaster({
   const { platform, isLoading } = usePlatformDetection();
 
   const handleShare = useCallback(async () => {
-    const { sdk } = await import("@farcaster/miniapp-sdk");
+    try {
+      const { sdk } = await import("@farcaster/miniapp-sdk");
 
-    const appUrl =
-      process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
-    const storyUrl = `${appUrl}/story/${storylineId}`;
+      const appUrl =
+        process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+      const storyUrl = `${appUrl}/story/${storylineId}`;
 
-    await sdk.actions.composeCast({
-      text: `Check out "${title}" on PlotLink`,
-      embeds: [storyUrl],
-    });
+      await sdk.actions.composeCast({
+        text: `Check out "${title}" on PlotLink`,
+        embeds: [storyUrl],
+      });
+    } catch {
+      // SDK call failed — silently ignore
+    }
   }, [storylineId, title]);
 
   if (isLoading || platform !== "farcaster") return null;


### PR DESCRIPTION
## Summary

- **Root fix**: `detectPlatform()` now returns `"base"` immediately when mobile+injected provider is detected, **without importing `@farcaster/miniapp-sdk`** — the SDK's `postMessage` to a nonexistent Farcaster host frame was corrupting Base App's webview
- **`isFarcasterMiniApp()`**: Also skips SDK import for Base App (mobile+injected)
- **`FarcasterMiniApp.tsx`**: Added 3s timeout to `sdk.context` call that had no timeout
- **`ShareToFarcaster.tsx`**: Wrapped `composeCast()` in try/catch

### Farcaster preserved
All Farcaster functionality intact — SDK is only imported when `platform !== "base"` (i.e., in Warpcast or desktop). `sdk.actions.ready()`, `addMiniApp()`, `composeCast()`, and notification token saving all continue to work in Warpcast.

## Test plan

- [ ] Open PlotLink in Base App — loads reliably, no blank screen or crash
- [ ] Connect wallet in Base App → refresh → wallet stays connected
- [ ] Open in Warpcast — splash screen dismissed, addMiniApp works, share/compose works
- [ ] Open in Warpcast — auto-connect via farcasterMiniApp() connector works
- [ ] Share buttons work in Farcaster context
- [ ] Desktop browser — RainbowKit modal works, no regressions

Closes #1162

🤖 Generated with [Claude Code](https://claude.com/claude-code)