### PR TITLE
Remove cookieStorage to fix hydration crash in Base App (#1166)

### DIFF
--- a/lib/wagmi.ts
+++ b/lib/wagmi.ts
@@ -1,4 +1,4 @@
-import { http, createConfig, createStorage, cookieStorage } from "wagmi";
+import { http, createConfig } from "wagmi";
 import { injected } from "wagmi/connectors";
 import { base, baseSepolia } from "wagmi/chains";
 import { farcasterMiniApp } from "@farcaster/miniapp-wagmi-connector";
@@ -56,7 +56,6 @@ export const config = createConfig({
     [base.id]: IS_MAINNET ? createFallbackTransport() : http(),
     [baseSepolia.id]: IS_MAINNET ? http() : createFallbackTransport(),
   },
-  storage: createStorage({ storage: cookieStorage }),
   ssr: true,
   ...(DATA_SUFFIX ? { dataSuffix: DATA_SUFFIX } : {}),
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary
- Removes `cookieStorage` from wagmi config (`lib/wagmi.ts`) which caused SSR/client hydration mismatch in Base App
- Without `cookieToInitialState` on `WagmiProvider`, stored connection state diverged between server and client renders, causing ~75% blank screen crashes
- Auto-connect via `injected()` connector already handles Base App wallet persistence on every mount

## Changes
- `lib/wagmi.ts`: Remove `createStorage`, `cookieStorage` imports and `storage: createStorage({ storage: cookieStorage })` line
- `package.json`: Bump version 1.25.0 → 1.25.1

Closes #1166

## Test plan
- [ ] Open PlotLink in Base App — no blank screen on first load
- [ ] Connect wallet in Base App, close and reopen — app loads reliably, wallet auto-connects
- [ ] Open in Farcaster — wallet auto-connects via farcasterMiniApp connector (unchanged)
- [ ] Open on desktop web — RainbowKit connect modal works (unchanged)
- [ ] Verify no hydration warnings in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)