### PR TITLE
Add FrameProvider initialization gate and global-error boundary (#1170)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.25.2",
+  "version": "1.25.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+export default function GlobalError({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="en">
+      <body
+        style={{
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#faf8f5",
+          fontFamily: "system-ui, sans-serif",
+          color: "#333",
+          textAlign: "center",
+          padding: "24px",
+        }}
+      >
+        <div>
+          <h2 style={{ fontSize: "16px", marginBottom: "8px" }}>
+            Something went wrong
+          </h2>
+          <button
+            onClick={reset}
+            style={{
+              background: "#333",
+              color: "#fff",
+              border: "none",
+              borderRadius: "4px",
+              padding: "8px 16px",
+              fontSize: "13px",
+              cursor: "pointer",
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -14,9 +14,9 @@ export default function GlobalError({
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          background: "#faf8f5",
+          background: "#0a0a0a",
           fontFamily: "system-ui, sans-serif",
-          color: "#333",
+          color: "#999999",
           textAlign: "center",
           padding: "24px",
         }}
@@ -28,8 +28,8 @@ export default function GlobalError({
           <button
             onClick={reset}
             style={{
-              background: "#333",
-              color: "#fff",
+              background: "#00ff88",
+              color: "#0a0a0a",
               border: "none",
               borderRadius: "4px",
               padding: "8px 16px",

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -6,6 +6,7 @@ import { RainbowKitProvider, type Theme } from "@rainbow-me/rainbowkit";
 import { config } from "../../lib/wagmi";
 import { useState, Suspense } from "react";
 import { useReferralCapture } from "../hooks/useReferralCapture";
+import { FrameProvider } from "../components/FrameProvider";
 import "@rainbow-me/rainbowkit/styles.css";
 
 // PlotLink-themed RainbowKit theme using CSS vars
@@ -103,10 +104,12 @@ export function Providers({ children }: { children: React.ReactNode }) {
             ),
           }}
         >
-          <Suspense fallback={null}>
-            <ReferralCapture />
-          </Suspense>
-          {children}
+          <FrameProvider>
+            <Suspense fallback={null}>
+              <ReferralCapture />
+            </Suspense>
+            {children}
+          </FrameProvider>
         </RainbowKitProvider>
       </QueryClientProvider>
     </WagmiProvider>

--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { useAccount, useConnect, useDisconnect } from "wagmi";
+import { useAccount, useDisconnect } from "wagmi";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import Link from "next/link";
 import { truncateAddress } from "../../lib/utils";
 import { useConnectedIdentity } from "../hooks/useConnectedIdentity";
-import { usePlatformDetection } from "../hooks/usePlatformDetection";
 
 interface ConnectWalletProps {
   onNavigate?: () => void;
@@ -16,37 +14,8 @@ interface ConnectWalletProps {
 
 export function ConnectWallet({ onNavigate, compact }: ConnectWalletProps = {}) {
   const { address, isConnected } = useAccount();
-  const { connect, connectors } = useConnect();
   const { disconnect } = useDisconnect();
-  const autoConnectAttempted = useRef(false);
-  const { platform, isLoading: platformLoading } = usePlatformDetection();
   const { profile } = useConnectedIdentity();
-
-  // Auto-connect when inside a mini app (Farcaster or Base App)
-  // Base App: always re-attempt on mount (webview may not persist localStorage)
-  // Farcaster: only attempt once (wagmi reconnect handles persistence)
-  useEffect(() => {
-    if (platformLoading || platform === "web") return;
-    if (isConnected) return;
-
-    if (platform === "base") {
-      if (typeof window !== "undefined" && window.ethereum) {
-        const injectedConnector = connectors.find((c) => c.type === "injected");
-        if (injectedConnector) {
-          connect({ connector: injectedConnector });
-          return;
-        }
-      }
-    }
-
-    if (autoConnectAttempted.current) return;
-    autoConnectAttempted.current = true;
-
-    const farcasterConnector = connectors.find((c) => c.type === "farcasterMiniApp");
-    if (farcasterConnector) {
-      connect({ connector: farcasterConnector });
-    }
-  }, [platform, platformLoading, connectors, connect, isConnected]);
 
   // Connected state
   if (isConnected && address) {

--- a/src/components/FrameProvider.tsx
+++ b/src/components/FrameProvider.tsx
@@ -17,6 +17,10 @@ export function FrameProvider({ children }: FrameProviderProps) {
   const connectAttempted = useRef(false);
 
   useEffect(() => {
+    if (typeof window !== "undefined" && !window.ethereum && window.self === window.top) {
+      setIsReady(true);
+      return;
+    }
     detectPlatform().then((p) => {
       setPlatform(p);
       setIsReady(true);

--- a/src/components/FrameProvider.tsx
+++ b/src/components/FrameProvider.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useConnect } from "wagmi";
+import { detectPlatform } from "../../lib/farcaster-detect";
+import type { Platform } from "../hooks/usePlatformDetection";
+
+interface FrameProviderProps {
+  children: React.ReactNode;
+}
+
+export function FrameProvider({ children }: FrameProviderProps) {
+  const [isReady, setIsReady] = useState(false);
+  const [platform, setPlatform] = useState<Platform>("web");
+  const { connect, connectors } = useConnect();
+
+  useEffect(() => {
+    detectPlatform().then((p) => {
+      setPlatform(p);
+      setIsReady(true);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!isReady || platform === "web") return;
+
+    if (platform === "base") {
+      const injectedConnector = connectors.find((c) => c.type === "injected");
+      if (injectedConnector) {
+        connect({ connector: injectedConnector });
+      }
+      return;
+    }
+
+    if (platform === "farcaster") {
+      const farcasterConnector = connectors.find((c) => c.type === "farcasterMiniApp");
+      if (farcasterConnector) {
+        connect({ connector: farcasterConnector });
+      }
+    }
+  }, [isReady, platform, connectors, connect]);
+
+  if (!isReady) {
+    return (
+      <div
+        style={{
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#faf8f5",
+          fontFamily: "system-ui, sans-serif",
+          color: "#666",
+          fontSize: "14px",
+        }}
+      >
+        Loading PlotLink...
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/FrameProvider.tsx
+++ b/src/components/FrameProvider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useConnect } from "wagmi";
+import { useState, useEffect, useRef } from "react";
+import { useAccount, useConnect } from "wagmi";
 import { detectPlatform } from "../../lib/farcaster-detect";
 import type { Platform } from "../hooks/usePlatformDetection";
 
@@ -13,6 +13,8 @@ export function FrameProvider({ children }: FrameProviderProps) {
   const [isReady, setIsReady] = useState(false);
   const [platform, setPlatform] = useState<Platform>("web");
   const { connect, connectors } = useConnect();
+  const { isConnected } = useAccount();
+  const connectAttempted = useRef(false);
 
   useEffect(() => {
     detectPlatform().then((p) => {
@@ -22,7 +24,8 @@ export function FrameProvider({ children }: FrameProviderProps) {
   }, []);
 
   useEffect(() => {
-    if (!isReady || platform === "web") return;
+    if (!isReady || platform === "web" || isConnected || connectAttempted.current) return;
+    connectAttempted.current = true;
 
     if (platform === "base") {
       const injectedConnector = connectors.find((c) => c.type === "injected");
@@ -38,7 +41,7 @@ export function FrameProvider({ children }: FrameProviderProps) {
         connect({ connector: farcasterConnector });
       }
     }
-  }, [isReady, platform, connectors, connect]);
+  }, [isReady, platform, isConnected, connectors, connect]);
 
   if (!isReady) {
     return (
@@ -48,9 +51,9 @@ export function FrameProvider({ children }: FrameProviderProps) {
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          background: "#faf8f5",
+          background: "#0a0a0a",
           fontFamily: "system-ui, sans-serif",
-          color: "#666",
+          color: "#666666",
           fontSize: "14px",
         }}
       >

--- a/src/components/FrameProvider.tsx
+++ b/src/components/FrameProvider.tsx
@@ -17,11 +17,10 @@ export function FrameProvider({ children }: FrameProviderProps) {
   const connectAttempted = useRef(false);
 
   useEffect(() => {
-    if (typeof window !== "undefined" && !window.ethereum && window.self === window.top) {
-      setIsReady(true);
-      return;
-    }
-    detectPlatform().then((p) => {
+    const isClearlyDesktop =
+      typeof window !== "undefined" && !window.ethereum && window.self === window.top;
+
+    (isClearlyDesktop ? Promise.resolve("web" as Platform) : detectPlatform()).then((p) => {
       setPlatform(p);
       setIsReady(true);
     });


### PR DESCRIPTION
## Summary
- Adds `FrameProvider` component that gates child rendering until platform detection completes, preventing race conditions that caused black screens in Base App
- Shows inline-styled loading state (no CSS variable dependency) during initialization
- Moves auto-connect logic from `ConnectWallet` into `FrameProvider` for proper sequencing — wallet connects only after platform is known
- Adds `global-error.tsx` as safety net to catch uncaught errors with a recovery UI instead of permanent black screen

## Changes
- `src/components/FrameProvider.tsx` — New initialization gate component
- `src/app/global-error.tsx` — New global error boundary
- `src/app/providers.tsx` — Wraps children with FrameProvider inside RainbowKitProvider
- `src/components/ConnectWallet.tsx` — Removes auto-connect logic (now in FrameProvider)
- `package.json` — Version bump 1.25.2 → 1.25.3

Closes #1170

## Test plan
- [ ] Base App: no black screen, loading indicator shown briefly, then app renders
- [ ] Base App: wallet auto-connects after initialization
- [ ] Farcaster: sdk.actions.ready(), addMiniApp, composeCast all work
- [ ] Desktop browser: RainbowKit connect modal works, no loading flash
- [ ] Force an error in a component — global-error.tsx shows recovery UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)