### PR TITLE
Call sdk.actions.ready() for all mini apps and add inline background (#1172)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.25.3",
+  "version": "1.25.4",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -14,9 +14,9 @@ export default function GlobalError({
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          background: "#0a0a0a",
+          background: "#faf8f5",
           fontFamily: "system-ui, sans-serif",
-          color: "#999999",
+          color: "#666666",
           textAlign: "center",
           padding: "24px",
         }}
@@ -28,8 +28,8 @@ export default function GlobalError({
           <button
             onClick={reset}
             style={{
-              background: "#00ff88",
-              color: "#0a0a0a",
+              background: "#333333",
+              color: "#ffffff",
               border: "none",
               borderRadius: "4px",
               padding: "8px 16px",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,6 @@ import { Newsreader, Geist_Mono } from "next/font/google";
 import { Providers } from "./providers";
 import { NavBar } from "../components/NavBar";
 import { Footer } from "../components/Footer";
-import { FarcasterMiniApp } from "../components/FarcasterMiniApp";
 import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 
@@ -28,6 +27,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
+  themeColor: "#faf8f5",
 };
 
 export const metadata: Metadata = {
@@ -68,7 +68,6 @@ export const metadata: Metadata = {
     statusBarStyle: "default",
     title: appName,
   },
-  themeColor,
   other: {
     "base:app_id": "69c257e93c2c56b9bbd2f62a",
     "fc:miniapp": JSON.stringify({
@@ -94,10 +93,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className={`${newsreader.variable} ${geistMono.variable} antialiased`}>
+    <html lang="en" style={{ backgroundColor: "#faf8f5", colorScheme: "light" }}>
+      <body
+        style={{ backgroundColor: "#faf8f5" }}
+        className={`${newsreader.variable} ${geistMono.variable} antialiased`}
+      >
         <Providers>
-          <FarcasterMiniApp />
           <NavBar />
           <div className="pt-11 min-h-screen">{children}</div>
           <Footer />

--- a/src/components/FrameProvider.tsx
+++ b/src/components/FrameProvider.tsx
@@ -2,8 +2,14 @@
 
 import { useState, useEffect, useRef } from "react";
 import { useAccount, useConnect } from "wagmi";
-import { detectPlatform } from "../../lib/farcaster-detect";
 import type { Platform } from "../hooks/usePlatformDetection";
+
+function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), ms)),
+  ]);
+}
 
 interface FrameProviderProps {
   children: React.ReactNode;
@@ -20,8 +26,47 @@ export function FrameProvider({ children }: FrameProviderProps) {
     const isClearlyDesktop =
       typeof window !== "undefined" && !window.ethereum && window.self === window.top;
 
-    (isClearlyDesktop ? Promise.resolve("web" as Platform) : detectPlatform()).then((p) => {
-      setPlatform(p);
+    if (isClearlyDesktop) {
+      Promise.resolve().then(() => setIsReady(true));
+      return;
+    }
+
+    import("@farcaster/miniapp-sdk").then(async ({ sdk }) => {
+      try { await sdk.actions.ready(); } catch {}
+
+      const ctx = await withTimeout(sdk.context, 3000, null);
+
+      if (!ctx?.client) {
+        if (typeof window !== "undefined" && window.ethereum && /mobile|android/i.test(navigator.userAgent)) {
+          setPlatform("base");
+        }
+        setIsReady(true);
+        return;
+      }
+
+      if (ctx.client.clientFid === 309857) {
+        setPlatform("base");
+        setIsReady(true);
+        return;
+      }
+
+      setPlatform("farcaster");
+      setIsReady(true);
+
+      if (!ctx.client.added) {
+        try {
+          const result = await sdk.actions.addMiniApp();
+          if (result?.notificationDetails && ctx.user?.fid) {
+            saveTokenClientSide(ctx.user.fid, result.notificationDetails);
+          }
+        } catch {}
+      } else if (ctx.client.notificationDetails && ctx.user?.fid) {
+        saveTokenClientSide(ctx.user.fid, ctx.client.notificationDetails);
+      }
+    }).catch(() => {
+      if (typeof window !== "undefined" && window.ethereum && /mobile|android/i.test(navigator.userAgent)) {
+        setPlatform("base");
+      }
       setIsReady(true);
     });
   }, []);
@@ -54,9 +99,9 @@ export function FrameProvider({ children }: FrameProviderProps) {
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          background: "#0a0a0a",
+          background: "#faf8f5",
           fontFamily: "system-ui, sans-serif",
-          color: "#666666",
+          color: "#999999",
           fontSize: "14px",
         }}
       >
@@ -66,4 +111,16 @@ export function FrameProvider({ children }: FrameProviderProps) {
   }
 
   return <>{children}</>;
+}
+
+function saveTokenClientSide(
+  fid: number,
+  details: { token: string; url: string },
+) {
+  if (!details.token || !details.url) return;
+  fetch("/api/notifications/save-token", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ fid, token: details.token, url: details.url }),
+  }).catch(() => {});
 }


### PR DESCRIPTION
## Summary
- **Root cause fix**: `sdk.actions.ready()` is now called for ALL mini app contexts (Farcaster AND Base App) to dismiss the splash screen — previously Base App was skipped, causing permanent black screen
- FrameProvider now handles the full SDK lifecycle: `ready()` → platform detection → `addMiniApp()` (Farcaster only) → notification token save
- Merged `FarcasterMiniApp` logic into `FrameProvider` (removed from layout.tsx)
- Added inline `style={{ backgroundColor: '#faf8f5', colorScheme: 'light' }}` on `<html>` and `<body>` so the webview never shows a black canvas even before CSS loads
- Moved `themeColor` from metadata to viewport export (fixes Next.js deprecation warning)
- Version bump 1.25.3 → 1.25.4

## Changes
- `src/components/FrameProvider.tsx` — Rewrote to import SDK, call `ready()`, detect platform, handle `addMiniApp` + notifications
- `src/app/layout.tsx` — Removed FarcasterMiniApp import, added inline styles, moved themeColor to viewport
- `src/app/global-error.tsx` — Updated to beige background matching app theme
- `package.json` — Version bump

Closes #1172

## Test plan
- [ ] Base App: splash screen dismisses, beige background shown, no black screen
- [ ] Base App: wallet auto-connects via injected provider
- [ ] Farcaster: sdk.actions.ready(), addMiniApp(), notification tokens all work
- [ ] Desktop browser: no loading flash, unchanged behavior
- [ ] CSS not loaded scenario: body shows beige (inline style), not black

🤖 Generated with [Claude Code](https://claude.com/claude-code)