### PR TITLE
Call sdk.actions.ready() fire-and-forget for all mini app contexts (#1174)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.25.3",
+  "version": "1.25.4",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/FarcasterMiniApp.tsx
+++ b/src/components/FarcasterMiniApp.tsx
@@ -18,18 +18,15 @@ export function FarcasterMiniApp() {
   const { platform, isLoading } = usePlatformDetection();
 
   useEffect(() => {
-    if (isLoading || platform !== "farcaster") return;
-
+    if (isLoading) return;
     let cancelled = false;
 
     import("@farcaster/miniapp-sdk").then(async ({ sdk }) => {
       if (cancelled) return;
 
-      try {
-        await sdk.actions.ready();
-      } catch {
-        // May fail in Base App where Farcaster host frame doesn't exist
-      }
+      sdk.actions.ready().catch(() => {});
+
+      if (platform !== "farcaster") return;
 
       const context = await Promise.race([
         sdk.context,
@@ -37,7 +34,6 @@ export function FarcasterMiniApp() {
       ]);
       if (cancelled || !context?.client) return;
 
-      // Save existing notification token if user already added
       if (context.client.added && context.client.notificationDetails) {
         saveTokenClientSide(
           context.user?.fid,
@@ -46,19 +42,14 @@ export function FarcasterMiniApp() {
       }
 
       if (!context.client.added) {
-        // Trigger native add/notification modal
         try {
           const result = await sdk.actions.addMiniApp();
           if (result?.notificationDetails) {
             saveTokenClientSide(context.user?.fid, result.notificationDetails);
           }
-        } catch {
-          // User dismissed or SDK error — no action needed
-        }
+        } catch {}
       }
-    }).catch(() => {
-      // Not in a Farcaster context — silently ignore
-    });
+    }).catch(() => {});
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
## Summary
- Moves `sdk.actions.ready()` call before the `platform !== "farcaster"` guard in `FarcasterMiniApp.tsx` so it fires in Base App too
- `ready()` is NOT awaited — fire-and-forget, so a hung host ack can't freeze rendering
- `addMiniApp()` remains Farcaster-only (unchanged)
- No changes to FrameProvider, detectPlatform, ConnectWallet, or wagmi
- Version bump 1.25.3 → 1.25.4

## Changes
- `src/components/FarcasterMiniApp.tsx` — Move `ready()` before platform guard, make fire-and-forget
- `package.json` — Version bump

Closes #1174

## Test plan
- [ ] Base App: splash screen dismisses via ready() call
- [ ] Farcaster: no freeze, addMiniApp works, notifications work
- [ ] Desktop browser: no wallet popup on refresh, unchanged behavior
- [ ] Mobile Safari/Chrome: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)