### PR TITLE
Simplify icon config and remove manifest link for Base App toolbar (#1176)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.25.4",
+  "version": "1.25.5",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,13 +35,9 @@ export const metadata: Metadata = {
   title: appName,
   description: appDescription,
   icons: {
-    icon: [
-      { url: "/favicon.png" },
-      { url: "/plotlink-logo-symbol.svg", type: "image/svg+xml" },
-    ],
-    apple: { url: "/icon.png", sizes: "180x180" },
+    icon: "/favicon.png",
+    apple: "/icon.png",
   },
-  manifest: "/manifest.json",
   openGraph: {
     title: appName,
     description: appDescription,


### PR DESCRIPTION
## Summary
- Removes `manifest: "/manifest.json"` from metadata — manifest link tag interfered with Base App's icon resolution
- Simplifies icon config to single `favicon.png` + `apple: icon.png`, matching DropCast's working pattern
- Removes SVG icon reference that added competing icon sources
- Version bump 1.25.4 → 1.25.5

## Changes
- `src/app/layout.tsx` — Simplified icons config, removed manifest link
- `package.json` — Version bump

Closes #1176

## Test plan
- [ ] Icon visible in Base App toolbar
- [ ] Favicon works in desktop browsers
- [ ] No manifest link tag in rendered HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)