### PR TITLE
Restore manifest.json link to fix Base App black screen (#1181)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.25.5",
+  "version": "1.25.6",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,6 +38,7 @@ export const metadata: Metadata = {
     icon: "/favicon.png",
     apple: "/icon.png",
   },
+  manifest: "/manifest.json",
   openGraph: {
     title: appName,
     description: appDescription,


### PR DESCRIPTION
## Summary
- Restores `manifest: "/manifest.json"` in layout.tsx metadata — removed in PR #1178 alongside icon simplification
- Base App uses manifest.json for `display`, `background_color`, and `theme_color` webview configuration
- Simplified icon config (from #1176) is preserved
- Version bump 1.25.5 → 1.25.6

## Changes
- `src/app/layout.tsx` — Restored manifest link
- `package.json` — Version bump

Closes #1181

## Test plan
- [ ] `<link rel="manifest" href="/manifest.json"/>` present in rendered HTML
- [ ] No black screen in Base App
- [ ] Favicon still works in desktop browsers
- [ ] Farcaster and desktop unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)