### PR TITLE
Add NSFW filter feedback to discover page (#1184)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.25.4",
+  "version": "1.25.5",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,8 +35,22 @@ export default async function Home({
   const supabase = createServerClient();
 
   let storylines: Storyline[] = [];
+  let nsfwCount = 0;
   if (supabase) {
-    storylines = await queryTab(supabase, tab, writer, page, genre, lang, showNsfw);
+    const results = await Promise.all([
+      queryTab(supabase, tab, writer, page, genre, lang, showNsfw),
+      showNsfw
+        ? supabase
+            .from("storylines")
+            .select("*", { count: "exact", head: true })
+            .eq("hidden", false)
+            .eq("is_nsfw", true)
+            .eq("contract_address", STORY_FACTORY.toLowerCase())
+            .then(({ count }) => count ?? 0)
+        : Promise.resolve(0),
+    ]);
+    storylines = results[0];
+    nsfwCount = results[1];
   }
 
   return (
@@ -51,7 +65,7 @@ export default async function Home({
         </p>
       </header>
 
-      <FilterBar writer={writer} genre={genre} lang={lang} tab={tab} totalCount={storylines.length} showNsfw={showNsfw} />
+      <FilterBar writer={writer} genre={genre} lang={lang} tab={tab} totalCount={storylines.length} showNsfw={showNsfw} nsfwCount={nsfwCount} />
 
       {/* Section label */}
       <h2 className="mt-4 mb-3 text-[11px] font-semibold uppercase tracking-[0.08em] text-muted">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,13 +40,20 @@ export default async function Home({
     const results = await Promise.all([
       queryTab(supabase, tab, writer, page, genre, lang, showNsfw),
       showNsfw
-        ? supabase
-            .from("storylines")
-            .select("*", { count: "exact", head: true })
-            .eq("hidden", false)
-            .eq("is_nsfw", true)
-            .eq("contract_address", STORY_FACTORY.toLowerCase())
-            .then(({ count }) => count ?? 0)
+        ? (() => {
+            let q = supabase
+              .from("storylines")
+              .select("*", { count: "exact", head: true })
+              .eq("hidden", false)
+              .eq("is_nsfw", true)
+              .eq("contract_address", STORY_FACTORY.toLowerCase());
+            if (tab === "new") q = q.eq("sunset", false);
+            if (writer === "human") q = q.eq("writer_type", 0);
+            if (writer === "agent") q = q.eq("writer_type", 1);
+            if (genre !== "all") q = q.eq("genre", genre);
+            if (lang !== "all") q = q.eq("language", lang);
+            return q.then(({ count }) => count ?? 0);
+          })()
         : Promise.resolve(0),
     ]);
     storylines = results[0];

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -25,6 +25,7 @@ interface FilterBarProps {
   tab: string;
   totalCount?: number;
   showNsfw?: boolean;
+  nsfwCount?: number;
 }
 
 function buildHref(params: { tab: string; writer: string; genre: string; lang: string; nsfw?: boolean }) {
@@ -150,7 +151,7 @@ function FilterSheet({ open, ...props }: { open: boolean; onClose: () => void; w
   return <FilterSheetContent {...props} />;
 }
 
-export function FilterBar({ writer, genre, lang, tab, totalCount, showNsfw = false }: FilterBarProps) {
+export function FilterBar({ writer, genre, lang, tab, totalCount, showNsfw = false, nsfwCount = 0 }: FilterBarProps) {
   const router = useRouter();
   const [sheetOpen, setSheetOpen] = useState(false);
   const nsfw = showNsfw;
@@ -311,6 +312,18 @@ export function FilterBar({ writer, genre, lang, tab, totalCount, showNsfw = fal
             )}
           </button>
         </div>
+
+        {/* NSFW filter feedback */}
+        {nsfw && nsfwCount === 0 && (
+          <p className="mt-2 text-[11px] text-[var(--muted)]">
+            No 18+ stories found — all current stories are safe for work.
+          </p>
+        )}
+        {nsfw && nsfwCount > 0 && (
+          <p className="mt-2 text-[11px] text-[var(--muted)]">
+            Showing {nsfwCount} {nsfwCount === 1 ? "mature story" : "mature stories"} alongside regular content.
+          </p>
+        )}
 
         {/* Mobile active filter chips */}
         {activeChips.length > 0 && (


### PR DESCRIPTION
## Summary
- The 18+ toggle on the discover page appeared broken because it's additive — when no NSFW stories exist in the DB, toggling it produces identical results
- Added contextual feedback messages: "No 18+ stories found" when none exist, or "Showing N mature stories alongside regular content" when they do
- Queries NSFW count only when filter is active (no perf impact when off)

Closes #1184

## Test plan
- [ ] Toggle 18+ filter on discover page — verify feedback message appears
- [ ] If no NSFW stories exist, should show "No 18+ stories found — all current stories are safe for work"
- [ ] If NSFW stories exist, should show count of mature stories
- [ ] Verify message disappears when filter is toggled off
- [ ] Check mobile filter sheet flow works the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)