### PR TITLE
Display creator earnings on story detail page (#1185)

### DIFF
--- a/lib/price.ts
+++ b/lib/price.ts
@@ -288,6 +288,48 @@ export async function getTokenTVL(
 }
 
 // ---------------------------------------------------------------------------
+// Per-story creator earnings (computed from trade history + on-chain royalty BPS)
+// ---------------------------------------------------------------------------
+
+export async function getStoryEarnings(
+  tokenAddress: Address,
+  supabase: ReturnType<typeof import("./supabase").createServerClient> & object,
+  client?: typeof publicClient,
+): Promise<number> {
+  const rpc = client ?? publicClient;
+  try {
+    const [bondResult, { data: trades }] = await Promise.all([
+      rpc.readContract({
+        address: MCV2_BOND,
+        abi: mcv2BondAbi,
+        functionName: "tokenBond",
+        args: [tokenAddress],
+      }),
+      supabase
+        .from("trade_history")
+        .select("event_type, reserve_amount")
+        .eq("token_address", tokenAddress.toLowerCase()),
+    ]);
+
+    const [, mintBps, burnBps] = bondResult;
+
+    let mintSum = 0;
+    let burnSum = 0;
+    for (const t of trades ?? []) {
+      if (t.event_type === "mint") mintSum += t.reserve_amount;
+      else if (t.event_type === "burn") burnSum += t.reserve_amount;
+    }
+
+    const mintRoyalty = mintBps < 10000 ? (mintSum * mintBps) / (10000 - mintBps) : 0;
+    const burnRoyalty = burnBps < 10000 ? (burnSum * burnBps) / (10000 - burnBps) : 0;
+
+    return mintRoyalty + burnRoyalty;
+  } catch {
+    return 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Batched multicall for multiple tokens (home page)
 // ---------------------------------------------------------------------------
 

--- a/lib/price.ts
+++ b/lib/price.ts
@@ -291,6 +291,11 @@ export async function getTokenTVL(
 // Per-story creator earnings (computed from trade history + on-chain royalty BPS)
 // ---------------------------------------------------------------------------
 
+// MCV2 Mint/Burn events emit reserve_amount as the NET reserve (pool-side):
+//   Mint: user pays reserveAmount + royalty; reserveAmount enters the pool.
+//   Burn: pool releases refundAmount + royalty; user receives refundAmount.
+// So reserve_amount in trade_history is net-of-royalty.
+// To recover royalty: royalty = net * bps / (10000 - bps).
 export async function getStoryEarnings(
   tokenAddress: Address,
   supabase: ReturnType<typeof import("./supabase").createServerClient> & object,
@@ -298,7 +303,7 @@ export async function getStoryEarnings(
 ): Promise<number> {
   const rpc = client ?? publicClient;
   try {
-    const [bondResult, { data: trades }] = await Promise.all([
+    const [bondResult, mintResult, burnResult] = await Promise.all([
       rpc.readContract({
         address: MCV2_BOND,
         abi: mcv2BondAbi,
@@ -307,18 +312,21 @@ export async function getStoryEarnings(
       }),
       supabase
         .from("trade_history")
-        .select("event_type, reserve_amount")
-        .eq("token_address", tokenAddress.toLowerCase()),
+        .select("reserve_amount.sum()")
+        .eq("token_address", tokenAddress.toLowerCase())
+        .eq("event_type", "mint")
+        .single(),
+      supabase
+        .from("trade_history")
+        .select("reserve_amount.sum()")
+        .eq("token_address", tokenAddress.toLowerCase())
+        .eq("event_type", "burn")
+        .single(),
     ]);
 
     const [, mintBps, burnBps] = bondResult;
-
-    let mintSum = 0;
-    let burnSum = 0;
-    for (const t of trades ?? []) {
-      if (t.event_type === "mint") mintSum += t.reserve_amount;
-      else if (t.event_type === "burn") burnSum += t.reserve_amount;
-    }
+    const mintSum = (mintResult.data as unknown as { sum: number | null })?.sum ?? 0;
+    const burnSum = (burnResult.data as unknown as { sum: number | null })?.sum ?? 0;
 
     const mintRoyalty = mintBps < 10000 ? (mintSum * mintBps) / (10000 - mintBps) : 0;
     const burnRoyalty = burnBps < 10000 ? (burnSum * burnBps) / (10000 - burnBps) : 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.25.4",
+  "version": "1.26.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -11,7 +11,7 @@ import { RatingSummary } from "../../../components/RatingSummary";
 import { ShareButtons } from "../../../components/ShareButtons";
 import { StoryContent } from "../../../components/StoryContent";
 import { ReadingModeWrapper } from "../../../components/ReadingModeWrapper";
-import { getTokenPrice, type TokenPriceInfo } from "../../../../lib/price";
+import { getTokenPrice, getStoryEarnings, type TokenPriceInfo } from "../../../../lib/price";
 import { RESERVE_LABEL, STORY_FACTORY } from "../../../../lib/contracts/constants";
 import { formatPrice, formatSupply } from "../../../../lib/format";
 import { type Address } from "viem";
@@ -159,9 +159,10 @@ export default async function StoryPage({ params }: { params: Params }) {
   const chapters = plots.filter((p) => p.plot_index > 0);
 
   const sl = storyline as Storyline;
-  const priceInfo = sl.token_address
-    ? await getTokenPrice(sl.token_address as Address)
-    : null;
+  const [priceInfo, earningsPlot] = await Promise.all([
+    sl.token_address ? getTokenPrice(sl.token_address as Address) : null,
+    sl.token_address ? getStoryEarnings(sl.token_address as Address, supabase) : 0,
+  ]);
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-8 pb-24 lg:pb-10">
@@ -174,7 +175,7 @@ export default async function StoryPage({ params }: { params: Params }) {
         <span className="text-foreground">{sl.title}</span>
       </nav>
 
-      <StoryHeader storyline={storyline} priceInfo={priceInfo} storylineId={id} coverUrl={getCoverUrl(sl.cover_cid) ?? undefined} />
+      <StoryHeader storyline={storyline} priceInfo={priceInfo} storylineId={id} coverUrl={getCoverUrl(sl.cover_cid) ?? undefined} earningsPlot={earningsPlot} />
 
       <StoryEditPanel
         storylineId={id}
@@ -279,11 +280,13 @@ function StoryHeader({
   priceInfo,
   storylineId,
   coverUrl,
+  earningsPlot = 0,
 }: {
   storyline: Storyline;
   priceInfo: TokenPriceInfo | null;
   storylineId: number;
   coverUrl?: string;
+  earningsPlot?: number;
 }) {
   const createdTs = storyline.block_timestamp ? new Date(storyline.block_timestamp) : null;
   const createdDate = createdTs
@@ -321,7 +324,7 @@ function StoryHeader({
       <div className="rounded-[var(--card-radius)] border border-border bg-surface px-3 py-2.5">
         <div className="text-[10px] font-medium uppercase tracking-[0.04em] text-muted mb-1">Creator Earnings</div>
         <div className="text-[15px] font-semibold tabular-nums text-foreground">
-          <CreatorEarningsBox writerAddress={storyline.writer_address as Address} />
+          <CreatorEarningsBox earningsPlot={earningsPlot} />
         </div>
       </div>
       <div className="rounded-[var(--card-radius)] border border-border bg-surface px-3 py-2.5">

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -28,6 +28,7 @@ import { FALLBACK_STYLES, hashToVariant } from "../../../components/StoryCard";
 import { CoverLightbox } from "../../../components/CoverLightbox";
 import { getCoverUrl } from "../../../../lib/cover";
 import { StoryEditPanel } from "../../../components/StoryEditPanel";
+import { CreatorEarningsBox } from "../../../components/CreatorEarningsBox";
 
 /** Deduplicate plots by plot_index, keeping the first occurrence. */
 function deduplicateByPlotIndex(plots: Plot[]) {
@@ -315,6 +316,12 @@ function StoryHeader({
         <div className="text-[10px] font-medium uppercase tracking-[0.04em] text-muted mb-1">Supply</div>
         <div className="text-[15px] font-semibold tabular-nums text-foreground">
           {formatSupply(priceInfo.totalSupply)}
+        </div>
+      </div>
+      <div className="rounded-[var(--card-radius)] border border-border bg-surface px-3 py-2.5">
+        <div className="text-[10px] font-medium uppercase tracking-[0.04em] text-muted mb-1">Creator Earnings</div>
+        <div className="text-[15px] font-semibold tabular-nums text-foreground">
+          <CreatorEarningsBox writerAddress={storyline.writer_address as Address} />
         </div>
       </div>
       <div className="rounded-[var(--card-radius)] border border-border bg-surface px-3 py-2.5">

--- a/src/components/CreatorEarningsBox.tsx
+++ b/src/components/CreatorEarningsBox.tsx
@@ -1,54 +1,33 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
-import { formatUnits, type Address } from "viem";
-import { browserClient } from "../../lib/rpc";
-import { mcv2BondAbi } from "../../lib/price";
-import { MCV2_BOND, PLOT_TOKEN, RESERVE_LABEL } from "../../lib/contracts/constants";
+import { RESERVE_LABEL } from "../../lib/contracts/constants";
 import { usePlotUsdPrice } from "../hooks/usePlotUsdPrice";
 import { formatUsdValue } from "../../lib/usd-price";
 
-export function CreatorEarningsBox({ writerAddress }: { writerAddress: Address }) {
+export function CreatorEarningsBox({ earningsPlot }: { earningsPlot: number }) {
   const { data: plotUsd } = usePlotUsdPrice();
+  const usdValue = plotUsd ? earningsPlot * plotUsd : null;
 
-  const { data: royaltyInfo } = useQuery({
-    queryKey: ["creator-earnings", writerAddress],
-    queryFn: async () => {
-      const [unclaimed, claimed] = await browserClient.readContract({
-        address: MCV2_BOND,
-        abi: mcv2BondAbi,
-        functionName: "getRoyaltyInfo",
-        args: [writerAddress, PLOT_TOKEN],
-      });
-      return { unclaimed, claimed, total: unclaimed + claimed };
-    },
-    refetchInterval: 30_000,
-  });
+  if (earningsPlot === 0) return <div className="text-foreground text-sm font-bold">$0</div>;
 
-  const total = royaltyInfo?.total ?? BigInt(0);
-  const totalFloat = parseFloat(formatUnits(total, 18));
-  const usdValue = plotUsd ? totalFloat * plotUsd : null;
-
-  const displayValue = total === BigInt(0)
-    ? "$0"
-    : usdValue !== null
-      ? formatUsdValue(usdValue)
-      : `${formatTruncated(total)} ${RESERVE_LABEL}`;
+  const plotLabel = `${formatTruncated(earningsPlot)} ${RESERVE_LABEL}`;
 
   return (
     <>
-      <div className="text-foreground text-sm font-bold">{displayValue}</div>
-      {total > BigInt(0) && usdValue !== null && (
-        <div className="text-muted text-[10px]">{formatTruncated(total)} {RESERVE_LABEL}</div>
+      <div className="text-foreground text-sm font-bold">
+        {usdValue !== null ? formatUsdValue(usdValue) : plotLabel}
+      </div>
+      {usdValue !== null && (
+        <div className="text-muted text-[10px]">{plotLabel}</div>
       )}
     </>
   );
 }
 
-function formatTruncated(value: bigint, decimals = 18, digits = 4): string {
-  const raw = formatUnits(value, decimals);
-  const dot = raw.indexOf(".");
-  if (dot === -1 || raw.length - dot - 1 <= digits) return raw;
-  const truncated = raw.slice(0, dot + 1 + digits).replace(/0+$/, "").replace(/\.$/, "");
-  return truncated === "0" && value > BigInt(0) ? raw.slice(0, dot + 1 + digits) : truncated;
+function formatTruncated(value: number, digits = 4): string {
+  if (value === 0) return "0";
+  const str = String(value);
+  const dot = str.indexOf(".");
+  if (dot === -1 || str.length - dot - 1 <= digits) return str;
+  return str.slice(0, dot + 1 + digits).replace(/0+$/, "").replace(/\.$/, "");
 }

--- a/src/components/CreatorEarningsBox.tsx
+++ b/src/components/CreatorEarningsBox.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { formatUnits, type Address } from "viem";
+import { browserClient } from "../../lib/rpc";
+import { mcv2BondAbi } from "../../lib/price";
+import { MCV2_BOND, PLOT_TOKEN, RESERVE_LABEL } from "../../lib/contracts/constants";
+import { usePlotUsdPrice } from "../hooks/usePlotUsdPrice";
+import { formatUsdValue } from "../../lib/usd-price";
+
+export function CreatorEarningsBox({ writerAddress }: { writerAddress: Address }) {
+  const { data: plotUsd } = usePlotUsdPrice();
+
+  const { data: royaltyInfo } = useQuery({
+    queryKey: ["creator-earnings", writerAddress],
+    queryFn: async () => {
+      const [unclaimed, claimed] = await browserClient.readContract({
+        address: MCV2_BOND,
+        abi: mcv2BondAbi,
+        functionName: "getRoyaltyInfo",
+        args: [writerAddress, PLOT_TOKEN],
+      });
+      return { unclaimed, claimed, total: unclaimed + claimed };
+    },
+    refetchInterval: 30_000,
+  });
+
+  const total = royaltyInfo?.total ?? BigInt(0);
+  const totalFloat = parseFloat(formatUnits(total, 18));
+  const usdValue = plotUsd ? totalFloat * plotUsd : null;
+
+  const displayValue = total === BigInt(0)
+    ? "$0"
+    : usdValue !== null
+      ? formatUsdValue(usdValue)
+      : `${formatTruncated(total)} ${RESERVE_LABEL}`;
+
+  return (
+    <>
+      <div className="text-foreground text-sm font-bold">{displayValue}</div>
+      {total > BigInt(0) && usdValue !== null && (
+        <div className="text-muted text-[10px]">{formatTruncated(total)} {RESERVE_LABEL}</div>
+      )}
+    </>
+  );
+}
+
+function formatTruncated(value: bigint, decimals = 18, digits = 4): string {
+  const raw = formatUnits(value, decimals);
+  const dot = raw.indexOf(".");
+  if (dot === -1 || raw.length - dot - 1 <= digits) return raw;
+  const truncated = raw.slice(0, dot + 1 + digits).replace(/0+$/, "").replace(/\.$/, "");
+  return truncated === "0" && value > BigInt(0) ? raw.slice(0, dot + 1 + digits) : truncated;
+}


### PR DESCRIPTION
## Summary
- New `CreatorEarningsBox` client component that reads cumulative royalties (unclaimed + claimed) from the MCV2_BOND contract via `getRoyaltyInfo`
- Shows USD as primary value with PLOT as secondary line, or "$0" when no earnings
- Added to the stats grid on the story detail page between Supply and Plots
- Auto-refreshes every 30 seconds to stay current with new trades

Closes #1185

## Test plan
- [ ] Visit a story detail page — verify "Creator Earnings" stat box appears in the grid
- [ ] For stories with no trading activity, should show "$0"
- [ ] For stories with trades, should show cumulative USD earnings with PLOT amount below
- [ ] Verify the value updates after a trade occurs (within 30s refresh interval)
- [ ] Check mobile layout — 7 stat boxes in 3-col grid renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)