### PR TITLE
Support inline images in plot content (#1186)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/api/upload-plot-image/route.ts
+++ b/src/app/api/upload-plot-image/route.ts
@@ -1,0 +1,141 @@
+import { NextRequest, NextResponse } from "next/server";
+import { recoverMessageAddress } from "viem";
+import { uploadBinaryWithRetry } from "../../../../lib/filebase";
+
+const MAX_FILE_SIZE = 500 * 1024;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 5;
+const SIGNATURE_MAX_AGE_MS = 5 * 60 * 1000;
+
+const ALLOWED_MIME_TYPES = new Set(["image/webp", "image/jpeg"]);
+
+const walletRequestLog = new Map<string, number[]>();
+
+function checkRateLimit(wallet: string): boolean {
+  const now = Date.now();
+  const timestamps = walletRequestLog.get(wallet) ?? [];
+  const recent = timestamps.filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
+  if (recent.length >= RATE_LIMIT_MAX) return false;
+  recent.push(now);
+  walletRequestLog.set(wallet, recent);
+  return true;
+}
+
+function validateMagicBytes(buffer: Uint8Array, mimeType: string): boolean {
+  if (mimeType === "image/jpeg") {
+    return buffer.length >= 3 &&
+      buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff;
+  }
+  if (mimeType === "image/webp") {
+    return buffer.length >= 12 &&
+      buffer[0] === 0x52 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x46 &&
+      buffer[8] === 0x57 && buffer[9] === 0x45 && buffer[10] === 0x42 && buffer[11] === 0x50;
+  }
+  return false;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const formData = await req.formData();
+
+    const rawMessage = formData.get("message");
+    const signature = formData.get("signature");
+
+    if (typeof rawMessage !== "string" || typeof signature !== "string") {
+      return NextResponse.json(
+        { error: "Missing wallet signature. Please connect your wallet and try again." },
+        { status: 401 }
+      );
+    }
+
+    const message = rawMessage.replace(/\r\n/g, "\n");
+
+    const timestampMatch = message.match(/Timestamp:\s*(\d+)/);
+    if (!timestampMatch) {
+      return NextResponse.json(
+        { error: "Invalid message format." },
+        { status: 401 }
+      );
+    }
+
+    const timestamp = Number(timestampMatch[1]);
+    const expectedMessage = `PlotLink: Upload plot image\nTimestamp: ${timestamp}`;
+    if (message !== expectedMessage) {
+      return NextResponse.json(
+        { error: "Invalid message format." },
+        { status: 401 }
+      );
+    }
+
+    const age = Date.now() - timestamp;
+    if (age > SIGNATURE_MAX_AGE_MS || age < -30_000) {
+      return NextResponse.json(
+        { error: "Signature expired. Please try again." },
+        { status: 401 }
+      );
+    }
+
+    const signer = await recoverMessageAddress({
+      message,
+      signature: signature as `0x${string}`,
+    });
+    const walletKey = signer.toLowerCase();
+
+    if (!checkRateLimit(walletKey)) {
+      return NextResponse.json(
+        { error: "Rate limit exceeded. Max 5 uploads per minute." },
+        { status: 429 }
+      );
+    }
+
+    const file = formData.get("file");
+
+    if (!file || !(file instanceof File)) {
+      return NextResponse.json(
+        { error: "Missing file in request" },
+        { status: 400 }
+      );
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json(
+        { error: `File too large. Maximum size is ${MAX_FILE_SIZE / 1024}KB.` },
+        { status: 400 }
+      );
+    }
+
+    const declaredType = file.type;
+    if (!ALLOWED_MIME_TYPES.has(declaredType)) {
+      return NextResponse.json(
+        { error: "Invalid file type. Only WebP and JPEG are accepted." },
+        { status: 400 }
+      );
+    }
+
+    const arrayBuffer = await file.arrayBuffer();
+    const bytes = new Uint8Array(arrayBuffer);
+
+    if (!validateMagicBytes(bytes, declaredType)) {
+      return NextResponse.json(
+        { error: "File content does not match declared type." },
+        { status: 400 }
+      );
+    }
+
+    const key = `plotlink/plot-images/${Date.now()}-${Math.random().toString(36).slice(2, 8)}${declaredType === "image/webp" ? ".webp" : ".jpg"}`;
+
+    const cid = await uploadBinaryWithRetry(
+      Buffer.from(arrayBuffer),
+      key,
+      declaredType
+    );
+
+    return NextResponse.json({
+      cid,
+      url: `https://ipfs.filebase.io/ipfs/${cid}`,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Upload failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -149,6 +149,8 @@ function CreatePage() {
   const [isNsfw, setIsNsfw] = useState(false);
   const [mobilePreviewOpen, setMobilePreviewOpen] = useState(false);
   const coverInputRef = useRef<HTMLInputElement>(null);
+  const newContentRef = useRef<HTMLTextAreaElement>(null);
+  const chainContentRef = useRef<HTMLTextAreaElement>(null);
   const hasDeadline = true;
 
   const handleCoverSelect = useCallback(async (file: File) => {
@@ -615,13 +617,15 @@ function CreatePage() {
                 />
                 {newPreviewTab === "write" && (
                   <PlotImageUpload
+                    textareaRef={newContentRef}
                     disabled={newBusy}
-                    onInsert={(md) => setNewContent((prev) => prev + md)}
+                    onInsert={(updater) => setNewContent(updater)}
                   />
                 )}
               </div>
               {newPreviewTab === "write" ? (
                 <textarea
+                  ref={newContentRef}
                   value={newContent}
                   onChange={(e) => setNewContent(e.target.value)}
                   disabled={newBusy}
@@ -798,13 +802,15 @@ function CreatePage() {
                 />
                 {chainPreviewTab === "write" && (
                   <PlotImageUpload
+                    textareaRef={chainContentRef}
                     disabled={chainBusy || noStoryline}
-                    onInsert={(md) => setChainContent((prev) => prev + md)}
+                    onInsert={(updater) => setChainContent(updater)}
                   />
                 )}
               </div>
               {chainPreviewTab === "write" ? (
                 <textarea
+                  ref={chainContentRef}
                   value={chainContent}
                   onChange={(e) => setChainContent(e.target.value)}
                   disabled={chainBusy || noStoryline}

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -26,6 +26,7 @@ import { DropdownSelect } from "../../components/DropdownSelect";
 import { Select } from "../../components/Select";
 import { GENRES, LANGUAGES } from "../../../lib/genres";
 import { WritePreviewToggle, ContentPreview } from "../../components/StoryContent";
+import { PlotImageUpload } from "../../components/PlotImageUpload";
 import { FALLBACK_STYLES } from "../../components/StoryCard";
 import { getCoverUrl } from "../../../lib/cover";
 
@@ -607,10 +608,18 @@ function CreatePage() {
               <p className="text-muted mb-2 text-[11px]">
                 The opening of your storyline — write a synopsis or introduction, or jump straight into the story. Markdown supported.
               </p>
-              <WritePreviewToggle
-                activeTab={newPreviewTab}
-                onTabChange={setNewPreviewTab}
-              />
+              <div className="flex items-center gap-2">
+                <WritePreviewToggle
+                  activeTab={newPreviewTab}
+                  onTabChange={setNewPreviewTab}
+                />
+                {newPreviewTab === "write" && (
+                  <PlotImageUpload
+                    disabled={newBusy}
+                    onInsert={(md) => setNewContent((prev) => prev + md)}
+                  />
+                )}
+              </div>
               {newPreviewTab === "write" ? (
                 <textarea
                   value={newContent}
@@ -782,10 +791,18 @@ function CreatePage() {
 
             <div>
               <label className="text-foreground mb-2 block text-sm">Next Chapter</label>
-              <WritePreviewToggle
-                activeTab={chainPreviewTab}
-                onTabChange={setChainPreviewTab}
-              />
+              <div className="flex items-center gap-2">
+                <WritePreviewToggle
+                  activeTab={chainPreviewTab}
+                  onTabChange={setChainPreviewTab}
+                />
+                {chainPreviewTab === "write" && (
+                  <PlotImageUpload
+                    disabled={chainBusy || noStoryline}
+                    onInsert={(md) => setChainContent((prev) => prev + md)}
+                  />
+                )}
+              </div>
               {chainPreviewTab === "write" ? (
                 <textarea
                   value={chainContent}

--- a/src/components/PlotImageUpload.tsx
+++ b/src/components/PlotImageUpload.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useRef, useState, type RefObject } from "react";
 import { useAccount, useSignMessage } from "wagmi";
 
 interface PlotImageUploadProps {
-  onInsert: (markdown: string) => void;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  onInsert: (updater: (prev: string) => string) => void;
   disabled?: boolean;
 }
 
-export function PlotImageUpload({ onInsert, disabled }: PlotImageUploadProps) {
+export function PlotImageUpload({ textareaRef, onInsert, disabled }: PlotImageUploadProps) {
   const { isConnected } = useAccount();
   const { signMessageAsync } = useSignMessage();
   const [uploading, setUploading] = useState(false);
@@ -31,6 +32,8 @@ export function PlotImageUpload({ onInsert, disabled }: PlotImageUploadProps) {
       return;
     }
 
+    const cursorPos = textareaRef.current?.selectionStart ?? -1;
+
     setUploading(true);
     try {
       const timestamp = Date.now();
@@ -47,7 +50,14 @@ export function PlotImageUpload({ onInsert, disabled }: PlotImageUploadProps) {
       if (!res.ok) throw new Error(data.error || "Upload failed");
 
       const alt = file.name.replace(/\.[^.]+$/, "").replace(/[-_]/g, " ");
-      onInsert(`\n![${alt}](${data.url})\n`);
+      const md = `\n![${alt}](${data.url})\n`;
+
+      onInsert((prev) => {
+        if (cursorPos >= 0 && cursorPos <= prev.length) {
+          return prev.slice(0, cursorPos) + md + prev.slice(cursorPos);
+        }
+        return prev + md;
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Upload failed");
     } finally {

--- a/src/components/PlotImageUpload.tsx
+++ b/src/components/PlotImageUpload.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useAccount, useSignMessage } from "wagmi";
+
+interface PlotImageUploadProps {
+  onInsert: (markdown: string) => void;
+  disabled?: boolean;
+}
+
+export function PlotImageUpload({ onInsert, disabled }: PlotImageUploadProps) {
+  const { isConnected } = useAccount();
+  const { signMessageAsync } = useSignMessage();
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  async function handleFile(file: File) {
+    setError(null);
+    if (!isConnected) {
+      setError("Connect wallet to upload.");
+      return;
+    }
+    const allowed = ["image/webp", "image/jpeg"];
+    if (!allowed.includes(file.type)) {
+      setError("Only WebP and JPEG accepted.");
+      return;
+    }
+    if (file.size > 500 * 1024) {
+      setError("Max 500KB.");
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const timestamp = Date.now();
+      const message = `PlotLink: Upload plot image\nTimestamp: ${timestamp}`;
+      const signature = await signMessageAsync({ message });
+
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("message", message);
+      formData.append("signature", signature);
+
+      const res = await fetch("/api/upload-plot-image", { method: "POST", body: formData });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Upload failed");
+
+      const alt = file.name.replace(/\.[^.]+$/, "").replace(/[-_]/g, " ");
+      onInsert(`\n![${alt}](${data.url})\n`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Upload failed");
+    } finally {
+      setUploading(false);
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  }
+
+  return (
+    <div className="inline-flex items-center gap-2">
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/webp,image/jpeg"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) handleFile(file);
+        }}
+      />
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        disabled={disabled || uploading || !isConnected}
+        className="flex items-center gap-1 rounded border border-border px-2 py-1 text-[11px] font-medium text-muted transition-colors hover:border-accent hover:text-accent disabled:opacity-40"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+          <circle cx="8.5" cy="8.5" r="1.5" />
+          <polyline points="21 15 16 10 5 21" />
+        </svg>
+        {uploading ? "Uploading…" : "Image"}
+      </button>
+      {error && <span className="text-[10px] text-error">{error}</span>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/api/upload-plot-image` endpoint with wallet signature auth, WebP/JPEG magic byte validation, 500KB max, rate limiting (5/min per wallet), and Filebase IPFS upload
- New `PlotImageUpload` component with file picker, wallet signing, upload progress, and auto-insert of markdown image syntax
- Wired into both genesis and chain plot editors on the create page alongside the Write/Preview toggle
- Image rendering already works — `img` is in the rehype-sanitize allowlist with existing CSS styling

Closes #1186

## Test plan
- [ ] Upload a WebP image via the Image button on genesis editor — verify markdown is inserted and preview renders it
- [ ] Upload a JPEG image via the Image button on chain plot editor — same checks
- [ ] Try uploading a non-image file — should get "Only WebP and JPEG accepted" error
- [ ] Try uploading a file > 500KB — should get size error
- [ ] Try uploading without wallet connected — should get "Connect wallet" error
- [ ] Upload 6 images quickly — 6th should hit rate limit
- [ ] Verify images display correctly in reading mode on story detail page
- [ ] Check mobile layout — Image button fits alongside Write/Preview toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)