### PR TITLE
Fix 18+ filter to show only NSFW stories when checked (#1190)

### DIFF
--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -138,7 +138,7 @@ async function fetchCandidatesAndRatings(
     if (writerType !== undefined) filtered = filtered.eq("writer_type", writerType);
     if (genre) filtered = filtered.eq("genre", genre);
     if (lang) filtered = filtered.eq("language", lang);
-    if (!showNsfw) filtered = filtered.eq("is_nsfw", false);
+    filtered = filtered.eq("is_nsfw", showNsfw);
     return filtered;
   }
 
@@ -309,7 +309,7 @@ export async function getMcapStorylines(
   if (writerType !== undefined) q = q.eq("writer_type", writerType);
   if (genre) q = q.eq("genre", genre);
   if (lang) q = q.eq("language", lang);
-  if (!showNsfw) q = q.eq("is_nsfw", false);
+  q = q.eq("is_nsfw", showNsfw);
   const { data } = await q.returns<Storyline[]>();
   const storylines = data ?? [];
   if (storylines.length === 0) return [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,29 +35,8 @@ export default async function Home({
   const supabase = createServerClient();
 
   let storylines: Storyline[] = [];
-  let nsfwCount = 0;
   if (supabase) {
-    const results = await Promise.all([
-      queryTab(supabase, tab, writer, page, genre, lang, showNsfw),
-      showNsfw
-        ? (() => {
-            let q = supabase
-              .from("storylines")
-              .select("*", { count: "exact", head: true })
-              .eq("hidden", false)
-              .eq("is_nsfw", true)
-              .eq("contract_address", STORY_FACTORY.toLowerCase());
-            if (tab === "new") q = q.eq("sunset", false);
-            if (writer === "human") q = q.eq("writer_type", 0);
-            if (writer === "agent") q = q.eq("writer_type", 1);
-            if (genre !== "all") q = q.eq("genre", genre);
-            if (lang !== "all") q = q.eq("language", lang);
-            return q.then(({ count }) => count ?? 0);
-          })()
-        : Promise.resolve(0),
-    ]);
-    storylines = results[0];
-    nsfwCount = results[1];
+    storylines = await queryTab(supabase, tab, writer, page, genre, lang, showNsfw);
   }
 
   return (
@@ -72,7 +51,7 @@ export default async function Home({
         </p>
       </header>
 
-      <FilterBar writer={writer} genre={genre} lang={lang} tab={tab} totalCount={storylines.length} showNsfw={showNsfw} nsfwCount={nsfwCount} />
+      <FilterBar writer={writer} genre={genre} lang={lang} tab={tab} totalCount={storylines.length} showNsfw={showNsfw} />
 
       {/* Section label */}
       <h2 className="mt-4 mb-3 text-[11px] font-semibold uppercase tracking-[0.08em] text-muted">
@@ -108,17 +87,19 @@ export default async function Home({
       {storylines.length === 0 && (
         <section className="flex flex-col items-center gap-4 py-16 text-center">
           <div className="border-border text-muted rounded border px-4 py-3 text-xs">
-            <span className="text-accent-dim">$</span> no storylines found
+            <span className="text-accent-dim">$</span> {showNsfw ? "no 18+ stories found" : "no storylines found"}
           </div>
           <p className="text-muted text-sm">
-            Be the first to start a story on PlotLink.
+            {showNsfw ? "No mature content has been published yet." : "Be the first to start a story on PlotLink."}
           </p>
-          <Link
-            href="/create"
-            className="border-accent text-accent hover:bg-accent hover:text-background rounded border px-5 py-2 text-sm transition-colors"
-          >
-            create storyline
-          </Link>
+          {!showNsfw && (
+            <Link
+              href="/create"
+              className="border-accent text-accent hover:bg-accent hover:text-background rounded border px-5 py-2 text-sm transition-colors"
+            >
+              create storyline
+            </Link>
+          )}
         </section>
       )}
     </div>
@@ -153,7 +134,7 @@ async function queryTab(
     if (writer === "agent") filtered = filtered.eq("writer_type", 1);
     if (genre !== "all") filtered = filtered.eq("genre", genre);
     if (lang !== "all") filtered = filtered.eq("language", lang);
-    if (!showNsfw) filtered = filtered.eq("is_nsfw", false);
+    filtered = filtered.eq("is_nsfw", showNsfw);
     return filtered;
   }
 

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -25,7 +25,6 @@ interface FilterBarProps {
   tab: string;
   totalCount?: number;
   showNsfw?: boolean;
-  nsfwCount?: number;
 }
 
 function buildHref(params: { tab: string; writer: string; genre: string; lang: string; nsfw?: boolean }) {
@@ -151,7 +150,7 @@ function FilterSheet({ open, ...props }: { open: boolean; onClose: () => void; w
   return <FilterSheetContent {...props} />;
 }
 
-export function FilterBar({ writer, genre, lang, tab, totalCount, showNsfw = false, nsfwCount = 0 }: FilterBarProps) {
+export function FilterBar({ writer, genre, lang, tab, totalCount, showNsfw = false }: FilterBarProps) {
   const router = useRouter();
   const [sheetOpen, setSheetOpen] = useState(false);
   const nsfw = showNsfw;
@@ -312,18 +311,6 @@ export function FilterBar({ writer, genre, lang, tab, totalCount, showNsfw = fal
             )}
           </button>
         </div>
-
-        {/* NSFW filter feedback */}
-        {nsfw && nsfwCount === 0 && (
-          <p className="mt-2 text-[11px] text-[var(--muted)]">
-            No 18+ stories found — all current stories are safe for work.
-          </p>
-        )}
-        {nsfw && nsfwCount > 0 && (
-          <p className="mt-2 text-[11px] text-[var(--muted)]">
-            Showing {nsfwCount} {nsfwCount === 1 ? "mature story" : "mature stories"} alongside regular content.
-          </p>
-        )}
 
         {/* Mobile active filter chips */}
         {activeChips.length > 0 && (


### PR DESCRIPTION
## Summary
- Changed NSFW filter from additive (`skip filter → show all`) to exclusive (`eq("is_nsfw", true) → show only NSFW`)
- Applied consistently across `page.tsx` (New tab), `ranking.ts` (Trending + Market Cap tabs)
- Removed redundant `nsfwCount` query and FilterBar feedback messages (no longer needed)
- Added NSFW-specific empty state: "no 18+ stories found" with appropriate copy

Closes #1190

## Test plan
- [ ] 18+ unchecked → shows only non-NSFW stories (unchanged behavior)
- [ ] 18+ checked → shows ONLY NSFW stories (was showing all before)
- [ ] 18+ checked with no NSFW stories → shows "no 18+ stories found" in grid area
- [ ] Verify across New, Trending, and Market Cap tabs
- [ ] Verify mobile filter sheet applies the same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)