### PR TITLE
Keep 6-box stats grid and show unclaimed earnings (#1191)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.27.1",
+  "version": "1.27.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -324,12 +324,8 @@ function StoryHeader({
       <div className="rounded-[var(--card-radius)] border border-border bg-surface px-3 py-2.5">
         <div className="text-[10px] font-medium uppercase tracking-[0.04em] text-muted mb-1">Creator Earnings</div>
         <div className="text-[15px] font-semibold tabular-nums text-foreground">
-          <CreatorEarningsBox earningsPlot={earningsPlot} />
+          <CreatorEarningsBox earningsPlot={earningsPlot} writerAddress={storyline.writer_address as Address} />
         </div>
-      </div>
-      <div className="rounded-[var(--card-radius)] border border-border bg-surface px-3 py-2.5">
-        <div className="text-[10px] font-medium uppercase tracking-[0.04em] text-muted mb-1">Plots</div>
-        <div className="text-[15px] font-semibold tabular-nums text-foreground">{storyline.plot_count}</div>
       </div>
       <div className="rounded-[var(--card-radius)] border border-border bg-surface px-3 py-2.5">
         <div className="text-[10px] font-medium uppercase tracking-[0.04em] text-muted mb-1">Deadline</div>

--- a/src/components/CreatorEarningsBox.tsx
+++ b/src/components/CreatorEarningsBox.tsx
@@ -1,12 +1,38 @@
 "use client";
 
-import { RESERVE_LABEL } from "../../lib/contracts/constants";
+import { useQuery } from "@tanstack/react-query";
+import { formatUnits, type Address } from "viem";
+import { browserClient } from "../../lib/rpc";
+import { mcv2BondAbi } from "../../lib/price";
+import { MCV2_BOND, PLOT_TOKEN, RESERVE_LABEL } from "../../lib/contracts/constants";
 import { usePlotUsdPrice } from "../hooks/usePlotUsdPrice";
 import { formatUsdValue } from "../../lib/usd-price";
 
-export function CreatorEarningsBox({ earningsPlot }: { earningsPlot: number }) {
+interface CreatorEarningsBoxProps {
+  earningsPlot: number;
+  writerAddress: Address;
+}
+
+export function CreatorEarningsBox({ earningsPlot, writerAddress }: CreatorEarningsBoxProps) {
   const { data: plotUsd } = usePlotUsdPrice();
   const usdValue = plotUsd ? earningsPlot * plotUsd : null;
+
+  const { data: unclaimed } = useQuery({
+    queryKey: ["unclaimed-royalties", writerAddress],
+    queryFn: async () => {
+      const [balance] = await browserClient.readContract({
+        address: MCV2_BOND,
+        abi: mcv2BondAbi,
+        functionName: "getRoyaltyInfo",
+        args: [writerAddress, PLOT_TOKEN],
+      });
+      return balance;
+    },
+    refetchInterval: 30_000,
+  });
+
+  const unclaimedFloat = unclaimed ? parseFloat(formatUnits(unclaimed, 18)) : 0;
+  const unclaimedUsd = plotUsd && unclaimedFloat > 0 ? formatUsdValue(unclaimedFloat * plotUsd) : null;
 
   if (earningsPlot === 0) return <div className="text-foreground text-sm font-bold">$0</div>;
 
@@ -19,6 +45,11 @@ export function CreatorEarningsBox({ earningsPlot }: { earningsPlot: number }) {
       </div>
       {usdValue !== null && (
         <div className="text-muted text-[10px]">{plotLabel}</div>
+      )}
+      {unclaimedFloat > 0 && (
+        <div className="text-muted text-[10px]">
+          {unclaimedUsd ?? `${formatTruncated(unclaimedFloat)} ${RESERVE_LABEL}`} unclaimed
+        </div>
       )}
     </>
   );

--- a/src/components/CreatorEarningsBox.tsx
+++ b/src/components/CreatorEarningsBox.tsx
@@ -17,6 +17,7 @@ export function CreatorEarningsBox({ earningsPlot, writerAddress }: CreatorEarni
   const { data: plotUsd } = usePlotUsdPrice();
   const usdValue = plotUsd ? earningsPlot * plotUsd : null;
 
+  // Wallet-wide unclaimed (contract doesn't expose per-story unclaimed)
   const { data: unclaimed } = useQuery({
     queryKey: ["unclaimed-royalties", writerAddress],
     queryFn: async () => {
@@ -34,21 +35,19 @@ export function CreatorEarningsBox({ earningsPlot, writerAddress }: CreatorEarni
   const unclaimedFloat = unclaimed ? parseFloat(formatUnits(unclaimed, 18)) : 0;
   const unclaimedUsd = plotUsd && unclaimedFloat > 0 ? formatUsdValue(unclaimedFloat * plotUsd) : null;
 
-  if (earningsPlot === 0) return <div className="text-foreground text-sm font-bold">$0</div>;
-
-  const plotLabel = `${formatTruncated(earningsPlot)} ${RESERVE_LABEL}`;
+  const plotLabel = earningsPlot > 0 ? `${formatTruncated(earningsPlot)} ${RESERVE_LABEL}` : null;
 
   return (
     <>
       <div className="text-foreground text-sm font-bold">
-        {usdValue !== null ? formatUsdValue(usdValue) : plotLabel}
+        {earningsPlot === 0 ? "$0" : usdValue !== null ? formatUsdValue(usdValue) : plotLabel}
       </div>
-      {usdValue !== null && (
+      {earningsPlot > 0 && usdValue !== null && (
         <div className="text-muted text-[10px]">{plotLabel}</div>
       )}
       {unclaimedFloat > 0 && (
         <div className="text-muted text-[10px]">
-          {unclaimedUsd ?? `${formatTruncated(unclaimedFloat)} ${RESERVE_LABEL}`} unclaimed
+          {unclaimedUsd ?? `${formatTruncated(unclaimedFloat)} ${RESERVE_LABEL}`} unclaimed (all stories)
         </div>
       )}
     </>


### PR DESCRIPTION
## Summary
- Removed "Plots" box from stats grid to maintain clean 3x2 layout (plot count already visible in story navigation below)
- Updated `CreatorEarningsBox` to fetch unclaimed royalties client-side via `getRoyaltyInfo` and display as secondary line ("$X.XX unclaimed")
- Grid now: Market Cap | Price | Supply | Creator Earnings | Deadline | Created

Closes #1191

## Test plan
- [ ] Stats grid shows exactly 6 boxes in 3x2 layout (no orphan)
- [ ] Creator Earnings shows total USD + PLOT as before
- [ ] If unclaimed earnings > 0, shows "X unclaimed" line below total
- [ ] Plot count still visible elsewhere on the page
- [ ] Check mobile layout renders 6 boxes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)