### PR TITLE
Redesign inline image upload as checkbox with instructions (#1192)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.27.2",
+  "version": "1.27.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -149,8 +149,6 @@ function CreatePage() {
   const [isNsfw, setIsNsfw] = useState(false);
   const [mobilePreviewOpen, setMobilePreviewOpen] = useState(false);
   const coverInputRef = useRef<HTMLInputElement>(null);
-  const newContentRef = useRef<HTMLTextAreaElement>(null);
-  const chainContentRef = useRef<HTMLTextAreaElement>(null);
   const hasDeadline = true;
 
   const handleCoverSelect = useCallback(async (file: File) => {
@@ -610,22 +608,12 @@ function CreatePage() {
               <p className="text-muted mb-2 text-[11px]">
                 The opening of your storyline — write a synopsis or introduction, or jump straight into the story. Markdown supported.
               </p>
-              <div className="flex items-center gap-2">
-                <WritePreviewToggle
-                  activeTab={newPreviewTab}
-                  onTabChange={setNewPreviewTab}
-                />
-                {newPreviewTab === "write" && (
-                  <PlotImageUpload
-                    textareaRef={newContentRef}
-                    disabled={newBusy}
-                    onInsert={(updater) => setNewContent(updater)}
-                  />
-                )}
-              </div>
+              <WritePreviewToggle
+                activeTab={newPreviewTab}
+                onTabChange={setNewPreviewTab}
+              />
               {newPreviewTab === "write" ? (
                 <textarea
-                  ref={newContentRef}
                   value={newContent}
                   onChange={(e) => setNewContent(e.target.value)}
                   disabled={newBusy}
@@ -642,6 +630,7 @@ function CreatePage() {
                   {MAX_CONTENT_LENGTH.toLocaleString()} chars
                 </span>
               </div>
+              <PlotImageUpload disabled={newBusy} />
             </div>
 
             <p className="text-muted text-xs">
@@ -795,22 +784,12 @@ function CreatePage() {
 
             <div>
               <label className="text-foreground mb-2 block text-sm">Next Chapter</label>
-              <div className="flex items-center gap-2">
-                <WritePreviewToggle
-                  activeTab={chainPreviewTab}
-                  onTabChange={setChainPreviewTab}
-                />
-                {chainPreviewTab === "write" && (
-                  <PlotImageUpload
-                    textareaRef={chainContentRef}
-                    disabled={chainBusy || noStoryline}
-                    onInsert={(updater) => setChainContent(updater)}
-                  />
-                )}
-              </div>
+              <WritePreviewToggle
+                activeTab={chainPreviewTab}
+                onTabChange={setChainPreviewTab}
+              />
               {chainPreviewTab === "write" ? (
                 <textarea
-                  ref={chainContentRef}
                   value={chainContent}
                   onChange={(e) => setChainContent(e.target.value)}
                   disabled={chainBusy || noStoryline}
@@ -827,6 +806,7 @@ function CreatePage() {
                   {MAX_CONTENT_LENGTH.toLocaleString()} chars
                 </span>
               </div>
+              <PlotImageUpload disabled={chainBusy || noStoryline} />
             </div>
 
             {chainState === "error" && (

--- a/src/components/PlotImageUpload.tsx
+++ b/src/components/PlotImageUpload.tsx
@@ -1,22 +1,29 @@
 "use client";
 
-import { useRef, useState, type RefObject } from "react";
+import { useRef, useState, useCallback } from "react";
 import { useAccount, useSignMessage } from "wagmi";
 
+interface UploadedImage {
+  cid: string;
+  url: string;
+  alt: string;
+}
+
 interface PlotImageUploadProps {
-  textareaRef: RefObject<HTMLTextAreaElement | null>;
-  onInsert: (updater: (prev: string) => string) => void;
   disabled?: boolean;
 }
 
-export function PlotImageUpload({ textareaRef, onInsert, disabled }: PlotImageUploadProps) {
+export function PlotImageUpload({ disabled }: PlotImageUploadProps) {
   const { isConnected } = useAccount();
   const { signMessageAsync } = useSignMessage();
+  const [open, setOpen] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [images, setImages] = useState<UploadedImage[]>([]);
+  const [copied, setCopied] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  async function handleFile(file: File) {
+  const handleFile = useCallback(async (file: File) => {
     setError(null);
     if (!isConnected) {
       setError("Connect wallet to upload.");
@@ -31,8 +38,6 @@ export function PlotImageUpload({ textareaRef, onInsert, disabled }: PlotImageUp
       setError("Max 500KB.");
       return;
     }
-
-    const cursorPos = textareaRef.current?.selectionStart ?? -1;
 
     setUploading(true);
     try {
@@ -50,48 +55,117 @@ export function PlotImageUpload({ textareaRef, onInsert, disabled }: PlotImageUp
       if (!res.ok) throw new Error(data.error || "Upload failed");
 
       const alt = file.name.replace(/\.[^.]+$/, "").replace(/[-_]/g, " ");
-      const md = `\n![${alt}](${data.url})\n`;
-
-      onInsert((prev) => {
-        if (cursorPos >= 0 && cursorPos <= prev.length) {
-          return prev.slice(0, cursorPos) + md + prev.slice(cursorPos);
-        }
-        return prev + md;
-      });
+      setImages((prev) => [...prev, { cid: data.cid, url: data.url, alt }]);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Upload failed");
     } finally {
       setUploading(false);
       if (inputRef.current) inputRef.current.value = "";
     }
+  }, [isConnected, signMessageAsync]);
+
+  function copyMarkdown(img: UploadedImage) {
+    const md = `![${img.alt}](${img.url})`;
+    navigator.clipboard.writeText(md);
+    setCopied(img.cid);
+    setTimeout(() => setCopied(null), 2000);
+  }
+
+  function removeImage(cid: string) {
+    setImages((prev) => prev.filter((i) => i.cid !== cid));
   }
 
   return (
-    <div className="inline-flex items-center gap-2">
-      <input
-        ref={inputRef}
-        type="file"
-        accept="image/webp,image/jpeg"
-        className="hidden"
-        onChange={(e) => {
-          const file = e.target.files?.[0];
-          if (file) handleFile(file);
-        }}
-      />
-      <button
-        type="button"
-        onClick={() => inputRef.current?.click()}
-        disabled={disabled || uploading || !isConnected}
-        className="flex items-center gap-1 rounded border border-border px-2 py-1 text-[11px] font-medium text-muted transition-colors hover:border-accent hover:text-accent disabled:opacity-40"
-      >
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-          <circle cx="8.5" cy="8.5" r="1.5" />
-          <polyline points="21 15 16 10 5 21" />
-        </svg>
-        {uploading ? "Uploading…" : "Image"}
-      </button>
-      {error && <span className="text-[10px] text-error">{error}</span>}
+    <div className="mt-2">
+      <label className="flex cursor-pointer items-center gap-2">
+        <input
+          type="checkbox"
+          checked={open}
+          onChange={(e) => setOpen(e.target.checked)}
+          disabled={disabled}
+          className="h-3.5 w-3.5 rounded border-border accent-accent"
+        />
+        <span className="text-foreground text-xs">Add illustrations in the plot</span>
+      </label>
+
+      {open && (
+        <div className="mt-2 space-y-2">
+          <input
+            ref={inputRef}
+            type="file"
+            accept="image/webp,image/jpeg"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) handleFile(file);
+            }}
+          />
+
+          <div
+            onClick={() => !disabled && !uploading && isConnected && inputRef.current?.click()}
+            onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); }}
+            onDrop={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              const file = e.dataTransfer.files[0];
+              if (file && !disabled && !uploading) handleFile(file);
+            }}
+            className={`flex cursor-pointer flex-col items-center justify-center gap-1.5 rounded border border-dashed border-border px-4 py-4 transition-colors hover:border-accent ${
+              disabled || uploading ? "pointer-events-none opacity-50" : ""
+            }`}
+          >
+            {uploading ? (
+              <span className="text-muted text-xs">Uploading...</span>
+            ) : !isConnected ? (
+              <span className="text-muted text-xs">Connect wallet to upload</span>
+            ) : (
+              <span className="text-muted text-xs">Drop image here or click to browse</span>
+            )}
+          </div>
+          <p className="text-muted text-[10px]">WebP or JPEG, max 500KB</p>
+
+          {error && <p className="text-[11px] text-error">{error}</p>}
+
+          {images.map((img) => {
+            const md = `![${img.alt}](${img.url})`;
+            return (
+              <div key={img.cid} className="rounded border border-border bg-surface px-3 py-2.5">
+                <div className="flex items-start gap-3">
+                  <img
+                    src={img.url}
+                    alt={img.alt}
+                    className="h-[60px] w-[60px] shrink-0 rounded border border-border object-cover"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="text-muted mb-1 text-[10px]">
+                      Copy the markdown below and paste it where you want the illustration to appear:
+                    </p>
+                    <div className="flex items-center gap-1.5">
+                      <code className="block min-w-0 flex-1 truncate rounded bg-[var(--bg)] px-2 py-1 font-mono text-[10px] text-foreground">
+                        {md}
+                      </code>
+                      <button
+                        type="button"
+                        onClick={() => copyMarkdown(img)}
+                        className="shrink-0 rounded border border-border px-2 py-1 text-[10px] font-medium text-muted transition-colors hover:border-accent hover:text-accent"
+                      >
+                        {copied === img.cid ? "Copied!" : "Copy"}
+                      </button>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => removeImage(img.cid)}
+                    className="text-error hover:text-error/80 shrink-0 text-[11px] transition-colors"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaced toolbar image button with "Add illustrations in the plot" checkbox below character count
- When checked, expands to show drag-and-drop upload area (matching cover image style)
- After upload, shows image preview with copyable markdown and paste instructions
- Supports multiple image uploads with individual copy/remove controls
- Applied to both genesis and chain plot editors

Closes #1192

## Test plan
- [ ] Checkbox "Add illustrations in the plot" appears below char count on both editors
- [ ] Checking it reveals dashed-border upload area
- [ ] Upload a WebP/JPEG — preview appears with copyable markdown
- [ ] Click "Copy" — markdown is copied to clipboard
- [ ] Paste markdown into textarea — image renders in preview
- [ ] Upload multiple images — all show with individual controls
- [ ] Click "Remove" — image card is removed
- [ ] Uncheck checkbox — upload area collapses
- [ ] Verify on mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)