### PR TITLE
Fix AgentManageAll to show linked OWS agent for operator wallet (#1197)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.27.4",
+  "version": "1.27.5",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -189,7 +189,7 @@ function AgentsPageInner() {
             <p className="text-muted text-sm">Detecting agent status...</p>
           </div>
         ) : hasExistingAgent && !showRegisterForm ? (
-          <AgentManageAll onRegister={() => setShowRegisterForm(true)} />
+          <AgentManageAll onRegister={() => setShowRegisterForm(true)} linkedAgentWallet={linkedAgentWallet} />
         ) : (
           <AgentRegister />
         )

--- a/src/components/AgentManage.tsx
+++ b/src/components/AgentManage.tsx
@@ -651,7 +651,7 @@ export function AgentManage({ agentId, role, source }: AgentManageProps) {
 const ZERO_ADDR = "0x0000000000000000000000000000000000000000";
 
 /** Wrapper that enumerates all agents owned by the connected wallet */
-export function AgentManageAll({ onRegister }: { onRegister?: () => void } = {}) {
+export function AgentManageAll({ onRegister, linkedAgentWallet }: { onRegister?: () => void; linkedAgentWallet?: string | null } = {}) {
   const { address } = useAccount();
 
   const { data: balance, isLoading: balanceLoading } = useReadContract({
@@ -729,7 +729,18 @@ export function AgentManageAll({ onRegister }: { onRegister?: () => void } = {})
   const isSelfAgent = selfAgentId !== undefined && selfAgentId > BigInt(0);
   const selfInList = agents.some((a) => a.agentId === selfAgentId);
 
-  const isLoading = balanceLoading || tokensLoading || metaLoading;
+  // Look up agent ID for a linked OWS wallet (operator doesn't hold the NFT)
+  const { data: linkedAgentId, isLoading: linkedLoading } = useReadContract({
+    address: ERC8004_REGISTRY,
+    abi: erc8004Abi,
+    functionName: "agentIdByWallet",
+    args: linkedAgentWallet ? [linkedAgentWallet as Address] : undefined,
+    query: { enabled: !!linkedAgentWallet },
+  });
+  const hasLinkedAgent = linkedAgentId !== undefined && linkedAgentId > BigInt(0);
+  const linkedInList = agents.some((a) => a.agentId === linkedAgentId) || (isSelfAgent && selfAgentId === linkedAgentId);
+
+  const isLoading = balanceLoading || tokensLoading || metaLoading || linkedLoading;
 
   if (isLoading) {
     return (
@@ -739,7 +750,7 @@ export function AgentManageAll({ onRegister }: { onRegister?: () => void } = {})
     );
   }
 
-  const hasAgents = agents.length > 0 || (isSelfAgent && !selfInList);
+  const hasAgents = agents.length > 0 || (isSelfAgent && !selfInList) || (hasLinkedAgent && !linkedInList);
 
   if (!hasAgents) {
     return (
@@ -766,6 +777,9 @@ export function AgentManageAll({ onRegister }: { onRegister?: () => void } = {})
       ))}
       {isSelfAgent && !selfInList && (
         <AgentManage agentId={selfAgentId} role="agentWallet" source="direct" />
+      )}
+      {hasLinkedAgent && !linkedInList && (
+        <AgentManage agentId={linkedAgentId} role="owner" source="ows" />
       )}
     </div>
   );

--- a/src/components/AgentManage.tsx
+++ b/src/components/AgentManage.tsx
@@ -36,7 +36,7 @@ const SET_WALLET_TYPES = {
 
 interface AgentManageProps {
   agentId: bigint;
-  role: "owner" | "agentWallet";
+  role: "owner" | "agentWallet" | "linked";
   source?: "ows" | "direct";
 }
 
@@ -336,7 +336,7 @@ export function AgentManage({ agentId, role, source }: AgentManageProps) {
               )}
             </div>
             <p className="text-muted mt-0.5 text-xs">
-              {role === "owner" ? "You own this agent" : "Your wallet is bound to this agent"}
+              {role === "owner" ? "You own this agent" : role === "linked" ? "Linked OWS agent" : "Your wallet is bound to this agent"}
             </p>
           </div>
           {isOwner && !editing && (
@@ -779,7 +779,7 @@ export function AgentManageAll({ onRegister, linkedAgentWallet }: { onRegister?:
         <AgentManage agentId={selfAgentId} role="agentWallet" source="direct" />
       )}
       {hasLinkedAgent && !linkedInList && (
-        <AgentManage agentId={linkedAgentId} role="owner" source="ows" />
+        <AgentManage agentId={linkedAgentId} role="linked" source="ows" />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Pass `linkedAgentWallet` from agents page to `AgentManageAll` component
- Look up linked agent's ID via `agentIdByWallet(linkedAgentWallet)` on-chain
- Include the linked OWS agent in the agent list and `hasAgents` check
- Operator wallet now sees their linked OWS agent in the Manage tab instead of "You have no AI agents registered"

## Test plan
- [ ] Connect with operator wallet that has a linked OWS agent — Manage tab shows the agent
- [ ] Connect with agent wallet directly — still works correctly (agentWallet role)
- [ ] Connect with wallet that owns NFT directly — still works correctly (owner role)
- [ ] Connect with wallet that has no agents — shows empty state with register link
- [ ] No TypeScript or lint errors

Closes #1197

🤖 Generated with [Claude Code](https://claude.com/claude-code)