### PR TITLE
Increase image upload limit from 500KB to 1MB (#1202)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.27.7",
+  "version": "1.28.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/api/upload-cover/route.ts
+++ b/src/app/api/upload-cover/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { recoverMessageAddress } from "viem";
 import { uploadBinaryWithRetry } from "../../../../lib/filebase";
 
-const MAX_FILE_SIZE = 500 * 1024; // 500KB
+const MAX_FILE_SIZE = 1024 * 1024; // 1MB
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 5;
 const SIGNATURE_MAX_AGE_MS = 5 * 60 * 1000;
@@ -100,7 +100,7 @@ export async function POST(req: NextRequest) {
 
     if (file.size > MAX_FILE_SIZE) {
       return NextResponse.json(
-        { error: `File too large. Maximum size is ${MAX_FILE_SIZE / 1024}KB.` },
+        { error: "File too large. Maximum size is 1MB." },
         { status: 400 }
       );
     }

--- a/src/app/api/upload-plot-image/route.ts
+++ b/src/app/api/upload-plot-image/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { recoverMessageAddress } from "viem";
 import { uploadBinaryWithRetry } from "../../../../lib/filebase";
 
-const MAX_FILE_SIZE = 500 * 1024;
+const MAX_FILE_SIZE = 1024 * 1024; // 1MB
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 5;
 const SIGNATURE_MAX_AGE_MS = 5 * 60 * 1000;
@@ -99,7 +99,7 @@ export async function POST(req: NextRequest) {
 
     if (file.size > MAX_FILE_SIZE) {
       return NextResponse.json(
-        { error: `File too large. Maximum size is ${MAX_FILE_SIZE / 1024}KB.` },
+        { error: "File too large. Maximum size is 1MB." },
         { status: 400 }
       );
     }

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -162,8 +162,8 @@ function CreatePage() {
       setCoverError("Only WebP and JPEG files are accepted.");
       return;
     }
-    if (file.size > 500 * 1024) {
-      setCoverError("File too large. Maximum size is 500KB.");
+    if (file.size > 1024 * 1024) {
+      setCoverError("File too large. Maximum size is 1MB.");
       return;
     }
     setCoverUploading(true);
@@ -497,7 +497,7 @@ function CreatePage() {
             <div>
               <label className="text-foreground mb-1 block text-sm">Cover Image</label>
               <p className="text-muted mb-1 text-[11px]">
-                Optional. WebP or JPEG, max 500KB. Recommended: 600×900px (2:3 portrait).
+                Optional. WebP or JPEG, max 1MB. Recommended: 600×900px (2:3 portrait).
               </p>
               <p className="text-muted mb-2 text-[10px]">
                 PlotLink may replace or remove cover images that violate our Terms or do not meet quality guidelines.

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -61,7 +61,7 @@ export default function TermsPage() {
         <h2>8. Cover Image Policy</h2>
         <p>Authors may upload book cover images for their stories. Cover images are subject to the following policies:</p>
         <ul>
-          <li>Accepted formats are WebP and JPEG, with a maximum file size of 500KB</li>
+          <li>Accepted formats are WebP and JPEG, with a maximum file size of 1MB</li>
           <li>Cover images are stored on IPFS via Filebase and are publicly accessible once uploaded</li>
           <li>Authors are responsible for ensuring cover images do not infringe any third-party copyright or intellectual property rights</li>
           <li>PlotLink reserves the right to replace cover images that are deemed low quality, misleading, or inappropriate, without prior notice to the author</li>

--- a/src/components/PlotImageUpload.tsx
+++ b/src/components/PlotImageUpload.tsx
@@ -34,8 +34,8 @@ export function PlotImageUpload({ disabled }: PlotImageUploadProps) {
       setError("Only WebP and JPEG accepted.");
       return;
     }
-    if (file.size > 500 * 1024) {
-      setError("Max 500KB.");
+    if (file.size > 1024 * 1024) {
+      setError("Max 1MB.");
       return;
     }
 
@@ -122,7 +122,7 @@ export function PlotImageUpload({ disabled }: PlotImageUploadProps) {
               <span className="text-muted text-xs">Drop image here or click to browse</span>
             )}
           </div>
-          <p className="text-muted text-[10px]">WebP or JPEG, max 500KB</p>
+          <p className="text-muted text-[10px]">WebP or JPEG, max 1MB</p>
 
           {error && <p className="text-[11px] text-error">{error}</p>}
 

--- a/src/components/StoryEditPanel.tsx
+++ b/src/components/StoryEditPanel.tsx
@@ -56,8 +56,8 @@ export function StoryEditPanel({
       setCoverError("Only WebP and JPEG files are accepted.");
       return;
     }
-    if (file.size > 500 * 1024) {
-      setCoverError("File too large. Maximum size is 500KB.");
+    if (file.size > 1024 * 1024) {
+      setCoverError("File too large. Maximum size is 1MB.");
       return;
     }
     setCoverUploading(true);
@@ -159,7 +159,7 @@ export function StoryEditPanel({
       {/* Cover Image */}
       <div>
         <label className="text-foreground mb-1 block text-xs font-medium">Cover Image</label>
-        <p className="text-muted mb-1 text-[10px]">WebP or JPEG, max 500KB. Recommended: 600×900px (2:3 portrait).</p>
+        <p className="text-muted mb-1 text-[10px]">WebP or JPEG, max 1MB. Recommended: 600×900px (2:3 portrait).</p>
         <p className="text-muted mb-2 text-[9px]">
           PlotLink may replace or remove cover images that violate our Terms or do not meet quality guidelines.
         </p>


### PR DESCRIPTION
## Summary
- Increase max file size from 500KB to 1MB for both cover images and plot illustrations
- Updated API endpoints: `upload-cover` and `upload-plot-image`
- Updated client-side validation: `create/page.tsx`, `StoryEditPanel.tsx`, `PlotImageUpload.tsx`
- Updated all user-facing text to say "max 1MB"
- Updated terms page to reflect new limit
- Magic byte validation (WebP/JPEG only) and rate limiting (5/min) unchanged

## Test plan
- [ ] Upload a 600KB cover image — accepted
- [ ] Upload a 1.1MB image — rejected with "1MB" error message
- [ ] Guidance text on create page, edit panel, and plot upload all say "max 1MB"
- [ ] Terms page reflects new 1MB limit
- [ ] No TypeScript or lint errors

Closes #1202

🤖 Generated with [Claude Code](https://claude.com/claude-code)