### PR TITLE
Display content type filter and cartoon indicator (#1221)

### DIFF
--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -128,6 +128,7 @@ async function fetchCandidatesAndRatings(
   writerType?: number,
   genre?: string,
   lang?: string,
+  contentType?: string,
   showNsfw = false,
 ) {
   function applyBase(q: ReturnType<typeof supabase.from>) {
@@ -138,6 +139,7 @@ async function fetchCandidatesAndRatings(
     if (writerType !== undefined) filtered = filtered.eq("writer_type", writerType);
     if (genre) filtered = filtered.eq("genre", genre);
     if (lang) filtered = filtered.eq("language", lang);
+    if (contentType) filtered = filtered.eq("content_type", contentType);
     filtered = filtered.eq("is_nsfw", showNsfw);
     return filtered;
   }
@@ -249,9 +251,10 @@ export async function getTrendingStorylines(
   offset = 0,
   genre?: string,
   lang?: string,
+  contentType?: string,
   showNsfw = false,
 ): Promise<RankedStoryline[]> {
-  const { storylines, ratingMap, userMap } = await fetchCandidatesAndRatings(supabase, writerType, genre, lang, showNsfw);
+  const { storylines, ratingMap, userMap } = await fetchCandidatesAndRatings(supabase, writerType, genre, lang, contentType, showNsfw);
   if (storylines.length === 0) return [];
 
   const enriched = await Promise.all(
@@ -297,6 +300,7 @@ export async function getMcapStorylines(
   offset = 0,
   genre?: string,
   lang?: string,
+  contentType?: string,
   showNsfw = false,
 ): Promise<Storyline[]> {
   // Fetch all eligible stories — MCap needs the full set, not a recency-biased subset
@@ -309,6 +313,7 @@ export async function getMcapStorylines(
   if (writerType !== undefined) q = q.eq("writer_type", writerType);
   if (genre) q = q.eq("genre", genre);
   if (lang) q = q.eq("language", lang);
+  if (contentType) q = q.eq("content_type", contentType);
   q = q.eq("is_nsfw", showNsfw);
   const { data } = await q.returns<Storyline[]>();
   const storylines = data ?? [];

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,8 @@ import { createServerClient, type Storyline } from "../../lib/supabase";
 import { STORY_FACTORY } from "../../lib/contracts/constants";
 import { getTrendingStorylines, getMcapStorylines } from "../../lib/ranking";
 import { StoryGrid } from "../components/StoryGrid";
-import { FilterBar, type WriterFilterValue } from "../components/FilterBar";
-import { GENRES, LANGUAGES } from "../../lib/genres";
+import { FilterBar, type WriterFilterValue, type ContentTypeFilterValue } from "../components/FilterBar";
+import { GENRES, LANGUAGES, CONTENT_TYPES } from "../../lib/genres";
 import Link from "next/link";
 
 const TABS = ["new", "trending", "mcap"] as const;
@@ -13,14 +13,14 @@ const WRITER_VALUES: WriterFilterValue[] = ["all", "human", "agent"];
 
 const PAGE_SIZE = 24;
 
-type SearchParams = Promise<{ tab?: string; writer?: string; page?: string; genre?: string; lang?: string; nsfw?: string }>;
+type SearchParams = Promise<{ tab?: string; writer?: string; page?: string; genre?: string; lang?: string; type?: string; nsfw?: string }>;
 
 export default async function Home({
   searchParams,
 }: {
   searchParams: SearchParams;
 }) {
-  const { tab: rawTab, writer: rawWriter, page: rawPage, genre: rawGenre, lang: rawLang, nsfw: rawNsfw } = await searchParams;
+  const { tab: rawTab, writer: rawWriter, page: rawPage, genre: rawGenre, lang: rawLang, type: rawType, nsfw: rawNsfw } = await searchParams;
   const tab: Tab = TABS.includes(rawTab as Tab) ? (rawTab as Tab) : "trending";
   const writer: WriterFilterValue = WRITER_VALUES.includes(
     rawWriter as WriterFilterValue,
@@ -30,13 +30,14 @@ export default async function Home({
   const page = Math.max(1, parseInt(rawPage ?? "1", 10) || 1);
   const genre = rawGenre && (GENRES as readonly string[]).includes(rawGenre) ? rawGenre : "all";
   const lang = rawLang && (LANGUAGES as readonly string[]).includes(rawLang) ? rawLang : "all";
+  const contentType: ContentTypeFilterValue = rawType && (CONTENT_TYPES as readonly string[]).includes(rawType) ? (rawType as ContentTypeFilterValue) : "all";
   const showNsfw = rawNsfw === "1";
 
   const supabase = createServerClient();
 
   let storylines: Storyline[] = [];
   if (supabase) {
-    storylines = await queryTab(supabase, tab, writer, page, genre, lang, showNsfw);
+    storylines = await queryTab(supabase, tab, writer, page, genre, lang, contentType, showNsfw);
   }
 
   return (
@@ -51,7 +52,7 @@ export default async function Home({
         </p>
       </header>
 
-      <FilterBar writer={writer} genre={genre} lang={lang} tab={tab} totalCount={storylines.length} showNsfw={showNsfw} />
+      <FilterBar writer={writer} genre={genre} lang={lang} contentType={contentType} tab={tab} totalCount={storylines.length} showNsfw={showNsfw} />
 
       {/* Section label */}
       <h2 className="mt-4 mb-3 text-[11px] font-semibold uppercase tracking-[0.08em] text-muted">
@@ -66,7 +67,7 @@ export default async function Home({
         <div className="mt-8 flex items-center justify-center gap-4">
           {page > 1 && (
             <Link
-              href={buildPageHref(tab, writer, page - 1, genre, lang, showNsfw)}
+              href={buildPageHref(tab, writer, page - 1, genre, lang, contentType, showNsfw)}
               className="border-border text-muted hover:text-foreground rounded border px-4 py-2 text-xs transition-colors"
             >
               &larr; Previous
@@ -75,7 +76,7 @@ export default async function Home({
           <span className="text-muted text-xs">Page {page}</span>
           {storylines.length === PAGE_SIZE && (
             <Link
-              href={buildPageHref(tab, writer, page + 1, genre, lang, showNsfw)}
+              href={buildPageHref(tab, writer, page + 1, genre, lang, contentType, showNsfw)}
               className="border-border text-muted hover:text-foreground rounded border px-4 py-2 text-xs transition-colors"
             >
               Next &rarr;
@@ -106,11 +107,12 @@ export default async function Home({
   );
 }
 
-function buildPageHref(tab: string, writer: string, page: number, genre: string, lang: string, showNsfw?: boolean): string {
+function buildPageHref(tab: string, writer: string, page: number, genre: string, lang: string, contentType: string, showNsfw?: boolean): string {
   const params = new URLSearchParams({ tab });
   if (writer !== "all") params.set("writer", writer);
   if (genre !== "all") params.set("genre", genre);
   if (lang !== "all") params.set("lang", lang);
+  if (contentType !== "all") params.set("type", contentType);
   if (showNsfw) params.set("nsfw", "1");
   if (page > 1) params.set("page", String(page));
   return `/?${params.toString()}`;
@@ -123,6 +125,7 @@ async function queryTab(
   page: number,
   genre: string,
   lang: string,
+  contentType: string,
   showNsfw: boolean,
 ): Promise<Storyline[]> {
   const from = (page - 1) * PAGE_SIZE;
@@ -134,6 +137,7 @@ async function queryTab(
     if (writer === "agent") filtered = filtered.eq("writer_type", 1);
     if (genre !== "all") filtered = filtered.eq("genre", genre);
     if (lang !== "all") filtered = filtered.eq("language", lang);
+    if (contentType !== "all") filtered = filtered.eq("content_type", contentType);
     filtered = filtered.eq("is_nsfw", showNsfw);
     return filtered;
   }
@@ -158,14 +162,16 @@ async function queryTab(
       const wt = writer === "human" ? 0 : writer === "agent" ? 1 : undefined;
       const g = genre !== "all" ? genre : undefined;
       const l = lang !== "all" ? lang : undefined;
-      return getTrendingStorylines(supabase, PAGE_SIZE, wt, from, g, l, showNsfw);
+      const ct = contentType !== "all" ? contentType : undefined;
+      return getTrendingStorylines(supabase, PAGE_SIZE, wt, from, g, l, ct, showNsfw);
     }
 
     case "mcap": {
       const wt = writer === "human" ? 0 : writer === "agent" ? 1 : undefined;
       const g = genre !== "all" ? genre : undefined;
       const l = lang !== "all" ? lang : undefined;
-      return getMcapStorylines(supabase, PAGE_SIZE, wt, from, g, l, showNsfw);
+      const ct = contentType !== "all" ? contentType : undefined;
+      return getMcapStorylines(supabase, PAGE_SIZE, wt, from, g, l, ct, showNsfw);
     }
   }
 }

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { GENRES, LANGUAGES } from "../../lib/genres";
+import { GENRES, LANGUAGES, CONTENT_TYPES } from "../../lib/genres";
 
 const SORT_OPTIONS = [
   { value: "new", label: "New" },
@@ -18,20 +18,30 @@ const WRITER_OPTIONS = [
 
 export type WriterFilterValue = "all" | "human" | "agent";
 
+const CONTENT_TYPE_OPTIONS = [
+  { value: "all", label: "All" },
+  { value: "fiction", label: "Fiction" },
+  { value: "cartoon", label: "Cartoon" },
+] as const;
+
+export type ContentTypeFilterValue = "all" | "fiction" | "cartoon";
+
 interface FilterBarProps {
   writer: string;
   genre: string;
   lang: string;
+  contentType: string;
   tab: string;
   totalCount?: number;
   showNsfw?: boolean;
 }
 
-function buildHref(params: { tab: string; writer: string; genre: string; lang: string; nsfw?: boolean }) {
+function buildHref(params: { tab: string; writer: string; genre: string; lang: string; contentType: string; nsfw?: boolean }) {
   const sp = new URLSearchParams({ tab: params.tab });
   if (params.writer !== "all") sp.set("writer", params.writer);
   if (params.genre !== "all") sp.set("genre", params.genre);
   if (params.lang !== "all") sp.set("lang", params.lang);
+  if (params.contentType !== "all") sp.set("type", params.contentType);
   if (params.nsfw) sp.set("nsfw", "1");
   return `/?${sp.toString()}`;
 }
@@ -41,6 +51,7 @@ function FilterSheetContent({
   writer,
   genre,
   lang,
+  contentType,
   nsfw,
   onApply,
 }: {
@@ -48,12 +59,14 @@ function FilterSheetContent({
   writer: string;
   genre: string;
   lang: string;
+  contentType: string;
   nsfw: boolean;
-  onApply: (w: string, g: string, l: string, nsfw: boolean) => void;
+  onApply: (w: string, g: string, l: string, ct: string, nsfw: boolean) => void;
 }) {
   const [localWriter, setLocalWriter] = useState(writer);
   const [localGenre, setLocalGenre] = useState(genre);
   const [localLang, setLocalLang] = useState(lang);
+  const [localContentType, setLocalContentType] = useState(contentType);
   const [localNsfw, setLocalNsfw] = useState(nsfw);
 
   useEffect(() => {
@@ -79,6 +92,26 @@ function FilterSheetContent({
                   onClick={() => setLocalWriter(value)}
                   className={`rounded-full border px-3.5 py-1.5 text-xs font-medium transition-colors ${
                     localWriter === value
+                      ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-bg)]"
+                      : "border-[var(--border)] text-[var(--muted)]"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Content Type */}
+          <div>
+            <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.06em] text-[var(--muted)]">Type</div>
+            <div className="flex gap-1.5">
+              {CONTENT_TYPE_OPTIONS.map(({ value, label }) => (
+                <button
+                  key={value}
+                  onClick={() => setLocalContentType(value)}
+                  className={`rounded-full border px-3.5 py-1.5 text-xs font-medium transition-colors ${
+                    localContentType === value
                       ? "border-[var(--accent)] text-[var(--accent)] bg-[var(--accent-bg)]"
                       : "border-[var(--border)] text-[var(--muted)]"
                   }`}
@@ -134,7 +167,7 @@ function FilterSheetContent({
 
           {/* Apply */}
           <button
-            onClick={() => { onApply(localWriter, localGenre, localLang, localNsfw); onClose(); }}
+            onClick={() => { onApply(localWriter, localGenre, localLang, localContentType, localNsfw); onClose(); }}
             className="w-full rounded-lg bg-[var(--accent)] py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90"
           >
             Apply Filters
@@ -145,12 +178,12 @@ function FilterSheetContent({
   );
 }
 
-function FilterSheet({ open, ...props }: { open: boolean; onClose: () => void; writer: string; genre: string; lang: string; nsfw: boolean; onApply: (w: string, g: string, l: string, nsfw: boolean) => void }) {
+function FilterSheet({ open, ...props }: { open: boolean; onClose: () => void; writer: string; genre: string; lang: string; contentType: string; nsfw: boolean; onApply: (w: string, g: string, l: string, ct: string, nsfw: boolean) => void }) {
   if (!open) return null;
   return <FilterSheetContent {...props} />;
 }
 
-export function FilterBar({ writer, genre, lang, tab, totalCount, showNsfw = false }: FilterBarProps) {
+export function FilterBar({ writer, genre, lang, contentType, tab, totalCount, showNsfw = false }: FilterBarProps) {
   const router = useRouter();
   const [sheetOpen, setSheetOpen] = useState(false);
   const nsfw = showNsfw;
@@ -160,31 +193,34 @@ export function FilterBar({ writer, genre, lang, tab, totalCount, showNsfw = fal
     if (urlParams.has("lang") || urlParams.has("nsfw")) return;
     try {
       const savedLang = localStorage.getItem("plotlink_lang");
+      const savedContentType = localStorage.getItem("plotlink_content_type") || "all";
       const savedNsfw = localStorage.getItem("plotlink_nsfw") === "1";
-      if ((savedLang && savedLang !== "all" && (LANGUAGES as readonly string[]).includes(savedLang)) || savedNsfw) {
-        router.replace(buildHref({ tab, writer, genre, lang: savedLang && savedLang !== "all" ? savedLang : lang, nsfw: savedNsfw }));
+      if ((savedLang && savedLang !== "all" && (LANGUAGES as readonly string[]).includes(savedLang)) || savedNsfw || (savedContentType !== "all" && (CONTENT_TYPES as readonly string[]).includes(savedContentType))) {
+        router.replace(buildHref({ tab, writer, genre, lang: savedLang && savedLang !== "all" ? savedLang : lang, contentType: savedContentType !== "all" ? savedContentType : contentType, nsfw: savedNsfw }));
       }
     } catch {}
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  function navigate(params: { tab: string; writer: string; genre: string; lang: string; nsfw?: boolean }) {
+  function navigate(params: { tab: string; writer: string; genre: string; lang: string; contentType: string; nsfw?: boolean }) {
     try {
       localStorage.setItem("plotlink_lang", params.lang);
+      localStorage.setItem("plotlink_content_type", params.contentType);
       localStorage.setItem("plotlink_nsfw", params.nsfw ? "1" : "0");
     } catch {}
     router.push(buildHref(params));
   }
 
-  const handleApplyFilters = useCallback((w: string, g: string, l: string, n: boolean) => {
-    navigate({ tab, writer: w, genre: g, lang: l, nsfw: n });
+  const handleApplyFilters = useCallback((w: string, g: string, l: string, ct: string, n: boolean) => {
+    navigate({ tab, writer: w, genre: g, lang: l, contentType: ct, nsfw: n });
   }, [tab]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const activeFilterCount = [writer !== "all", genre !== "all", lang !== "all", nsfw].filter(Boolean).length;
+  const activeFilterCount = [writer !== "all", genre !== "all", lang !== "all", contentType !== "all", nsfw].filter(Boolean).length;
   const activeChips: { label: string; clear: () => void }[] = [];
-  if (writer !== "all") activeChips.push({ label: `Writer: ${writer}`, clear: () => navigate({ tab, writer: "all", genre, lang, nsfw }) });
-  if (genre !== "all") activeChips.push({ label: genre, clear: () => navigate({ tab, writer, genre: "all", lang, nsfw }) });
-  if (lang !== "all") activeChips.push({ label: lang, clear: () => navigate({ tab, writer, genre, lang: "all", nsfw }) });
-  if (nsfw) activeChips.push({ label: "19+", clear: () => navigate({ tab, writer, genre, lang, nsfw: false }) });
+  if (writer !== "all") activeChips.push({ label: `Writer: ${writer}`, clear: () => navigate({ tab, writer: "all", genre, lang, contentType, nsfw }) });
+  if (contentType !== "all") activeChips.push({ label: contentType === "cartoon" ? "Cartoon" : "Fiction", clear: () => navigate({ tab, writer, genre, lang, contentType: "all", nsfw }) });
+  if (genre !== "all") activeChips.push({ label: genre, clear: () => navigate({ tab, writer, genre: "all", lang, contentType, nsfw }) });
+  if (lang !== "all") activeChips.push({ label: lang, clear: () => navigate({ tab, writer, genre, lang: "all", contentType, nsfw }) });
+  if (nsfw) activeChips.push({ label: "19+", clear: () => navigate({ tab, writer, genre, lang, contentType, nsfw: false }) });
 
   return (
     <>
@@ -195,7 +231,7 @@ export function FilterBar({ writer, genre, lang, tab, totalCount, showNsfw = fal
             {SORT_OPTIONS.map(({ value, label }) => (
               <button
                 key={value}
-                onClick={() => navigate({ tab: value, writer, genre, lang, nsfw })}
+                onClick={() => navigate({ tab: value, writer, genre, lang, contentType, nsfw })}
                 className={`relative px-3 py-2 text-[13px] font-medium transition-colors sm:text-sm ${
                   tab === value
                     ? "font-semibold text-[var(--fg)]"
@@ -224,9 +260,26 @@ export function FilterBar({ writer, genre, lang, tab, totalCount, showNsfw = fal
               {WRITER_OPTIONS.map(({ value, label }) => (
                 <button
                   key={value}
-                  onClick={() => navigate({ tab, writer: value, genre, lang, nsfw })}
+                  onClick={() => navigate({ tab, writer: value, genre, lang, contentType, nsfw })}
                   className={`rounded-full px-2.5 py-1 text-[12px] font-medium transition-colors ${
                     writer === value
+                      ? "bg-[var(--accent)] text-white"
+                      : "text-[var(--muted)] hover:text-[var(--fg)]"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+
+            {/* Content type pills */}
+            <div className="flex items-center rounded-full border border-[var(--border)] p-0.5">
+              {CONTENT_TYPE_OPTIONS.map(({ value, label }) => (
+                <button
+                  key={value}
+                  onClick={() => navigate({ tab, writer, genre, lang, contentType: value, nsfw })}
+                  className={`rounded-full px-2.5 py-1 text-[12px] font-medium transition-colors ${
+                    contentType === value
                       ? "bg-[var(--accent)] text-white"
                       : "text-[var(--muted)] hover:text-[var(--fg)]"
                   }`}
@@ -240,7 +293,7 @@ export function FilterBar({ writer, genre, lang, tab, totalCount, showNsfw = fal
             <div className="relative">
               <select
                 value={genre}
-                onChange={(e) => navigate({ tab, writer, genre: e.target.value, lang, nsfw })}
+                onChange={(e) => navigate({ tab, writer, genre: e.target.value, lang, contentType, nsfw })}
                 className={`rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors focus:border-[var(--accent)] focus:outline-none ${
                   genre !== "all"
                     ? "border-[var(--accent)] bg-[var(--accent-bg)] text-[var(--accent)]"
@@ -256,7 +309,7 @@ export function FilterBar({ writer, genre, lang, tab, totalCount, showNsfw = fal
             <div className="relative">
               <select
                 value={lang}
-                onChange={(e) => navigate({ tab, writer, genre, lang: e.target.value, nsfw })}
+                onChange={(e) => navigate({ tab, writer, genre, lang: e.target.value, contentType, nsfw })}
                 className={`rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors focus:border-[var(--accent)] focus:outline-none ${
                   lang !== "all"
                     ? "border-[var(--accent)] bg-[var(--accent-bg)] text-[var(--accent)]"
@@ -322,6 +375,7 @@ export function FilterBar({ writer, genre, lang, tab, totalCount, showNsfw = fal
         writer={writer}
         genre={genre}
         lang={lang}
+        contentType={contentType}
         nsfw={nsfw}
         onApply={handleApplyFilters}
       />

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -190,13 +190,14 @@ export function FilterBar({ writer, genre, lang, contentType, tab, totalCount, s
 
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.has("lang") || urlParams.has("nsfw")) return;
+    if (urlParams.has("lang") || urlParams.has("nsfw") || urlParams.has("type")) return;
     try {
       const savedLang = localStorage.getItem("plotlink_lang");
       const savedContentType = localStorage.getItem("plotlink_content_type") || "all";
+      const validContentType = savedContentType !== "all" && (CONTENT_TYPES as readonly string[]).includes(savedContentType) ? savedContentType : "all";
       const savedNsfw = localStorage.getItem("plotlink_nsfw") === "1";
-      if ((savedLang && savedLang !== "all" && (LANGUAGES as readonly string[]).includes(savedLang)) || savedNsfw || (savedContentType !== "all" && (CONTENT_TYPES as readonly string[]).includes(savedContentType))) {
-        router.replace(buildHref({ tab, writer, genre, lang: savedLang && savedLang !== "all" ? savedLang : lang, contentType: savedContentType !== "all" ? savedContentType : contentType, nsfw: savedNsfw }));
+      if ((savedLang && savedLang !== "all" && (LANGUAGES as readonly string[]).includes(savedLang)) || savedNsfw || validContentType !== "all") {
+        router.replace(buildHref({ tab, writer, genre, lang: savedLang && savedLang !== "all" ? savedLang : lang, contentType: validContentType !== "all" ? validContentType : contentType, nsfw: savedNsfw }));
       }
     } catch {}
   }, []); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -19,7 +19,7 @@ export const FALLBACK_STYLES: Record<FallbackVariant, React.CSSProperties> = {
   D: { background: "linear-gradient(175deg, oklch(94% 0.015 50) 0%, oklch(90% 0.02 40) 100%)" },
 };
 
-function Badges({ genre, writerType, status, contentType }: { genre?: string | null; writerType: number | null; status: string; contentType?: string }) {
+function Badges({ genre, writerType, status }: { genre?: string | null; writerType: number | null; status: string }) {
   const isActive = status === "active";
   return (
     <div className="absolute top-2 left-2 z-[2] flex flex-wrap items-center gap-1">
@@ -43,11 +43,19 @@ function Badges({ genre, writerType, status, contentType }: { genre?: string | n
           Ongoing
         </span>
       )}
-      {contentType === "cartoon" && (
-        <span className="rounded-[3px] bg-[oklch(50%_0.15_60_/_0.65)] px-[7px] py-[2px] text-[10px] font-medium uppercase tracking-wider leading-[1.4] text-white/90 backdrop-blur-[2px]">
-          Cartoon
-        </span>
-      )}
+    </div>
+  );
+}
+
+function CartoonIndicator({ contentType }: { contentType?: string }) {
+  if (contentType !== "cartoon") return null;
+  return (
+    <div className="absolute bottom-2 left-2 z-[2] flex h-5 w-5 items-center justify-center rounded bg-[oklch(0%_0_0_/_0.5)] backdrop-blur-[2px]" title="Cartoon">
+      <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="1" y="1" width="14" height="14" rx="1.5" />
+        <line x1="8" y1="1" x2="8" y2="15" />
+        <line x1="1" y1="8" x2="8" y2="8" />
+      </svg>
     </div>
   );
 }
@@ -86,8 +94,9 @@ export function StoryCard({
         />
         <div className="absolute inset-0 bg-[linear-gradient(to_bottom,transparent_40%,oklch(0%_0_0_/_0.15)_60%,oklch(0%_0_0_/_0.55)_80%,oklch(0%_0_0_/_0.78)_100%)]" />
 
-        <Badges genre={displayGenre} writerType={storyline.writer_type} status={status} contentType={storyline.content_type} />
+        <Badges genre={displayGenre} writerType={storyline.writer_type} status={status} />
         <NsfwBadge isNsfw={storyline.is_nsfw} />
+        <CartoonIndicator contentType={storyline.content_type} />
 
         <div className="absolute right-0 bottom-0 left-0 z-[2] px-2.5 pt-3 pb-2.5">
           <h3 className="font-heading text-[13px] font-semibold leading-[1.25] text-white drop-shadow-[0_1px_2px_oklch(0%_0_0_/_0.6)] line-clamp-2 sm:text-[15px]">
@@ -112,8 +121,9 @@ export function StoryCard({
     <Link href={`/story/${storyline.storyline_id}`} className={cardClass}>
       <div className="absolute inset-0" style={FALLBACK_STYLES[variant]} />
 
-      <Badges genre={displayGenre} writerType={storyline.writer_type} status={status} contentType={storyline.content_type} />
-        <NsfwBadge isNsfw={storyline.is_nsfw} />
+      <Badges genre={displayGenre} writerType={storyline.writer_type} status={status} />
+      <NsfwBadge isNsfw={storyline.is_nsfw} />
+      <CartoonIndicator contentType={storyline.content_type} />
 
       {/* Centered title with accent line */}
       <div className="absolute inset-0 z-[1] flex flex-col items-center justify-center px-4 text-center">

--- a/src/components/__tests__/FilterBar.test.tsx
+++ b/src/components/__tests__/FilterBar.test.tsx
@@ -14,6 +14,7 @@ const defaultProps = {
   writer: "all",
   genre: "all",
   lang: "all",
+  contentType: "all",
   tab: "new",
 };
 
@@ -31,7 +32,7 @@ describe("FilterBar", () => {
 
   it("renders writer pill buttons", () => {
     render(<FilterBar {...defaultProps} />);
-    expect(screen.getByText("All")).toBeInTheDocument();
+    expect(screen.getAllByText("All").length).toBeGreaterThan(0);
     expect(screen.getByText("Human")).toBeInTheDocument();
     expect(screen.getByText("Agent")).toBeInTheDocument();
   });

--- a/src/components/__tests__/StoryCard.test.tsx
+++ b/src/components/__tests__/StoryCard.test.tsx
@@ -91,13 +91,13 @@ describe("StoryCard", () => {
     expect(screen.getByText("AI Writer")).toBeInTheDocument();
   });
 
-  it("shows Cartoon badge when content_type is cartoon", () => {
+  it("shows Cartoon indicator when content_type is cartoon", () => {
     render(<StoryCard storyline={makeStoryline({ content_type: "cartoon" })} />);
-    expect(screen.getAllByText("Cartoon").length).toBeGreaterThan(0);
+    expect(screen.getAllByTitle("Cartoon").length).toBeGreaterThan(0);
   });
 
-  it("does not show Cartoon badge for fiction stories", () => {
+  it("does not show Cartoon indicator for fiction stories", () => {
     render(<StoryCard storyline={makeStoryline({ content_type: "fiction" })} />);
-    expect(screen.queryByText("Cartoon")).not.toBeInTheDocument();
+    expect(screen.queryByTitle("Cartoon")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Adds All/Fiction/Cartoon segmented content type filter on discover page (both desktop pills and mobile filter sheet)
- Persists content type preference in localStorage, consistent with existing lang/nsfw prefs
- Filters pass through to all query paths: new (Supabase), trending, and mcap (ranking lib)
- Replaces crowded text "Cartoon" badge on story cards with a compact comic-panel SVG icon (bottom-left)
- Fiction stories show no indicator (per spec)
- Story detail page CARTOON tag already present from #1212

## Test plan
- [x] All 62 tests pass (updated for new prop + icon indicator)
- [x] Typecheck clean
- [x] Lint: 0 errors
- [ ] Visual check: content type pills render on desktop filter bar
- [ ] Visual check: mobile filter sheet shows Type selector
- [ ] Visual check: filtering by Cartoon shows only cartoon stories
- [ ] Visual check: comic-panel icon visible on cartoon story cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)