### PR TITLE
[#1226] Remove 19+ toggle from NavBar, restore FilterBar checkbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.29.2",
+  "version": "1.29.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -322,6 +322,17 @@ export function FilterBar({ writer, genre, lang, contentType, tab, totalCount, s
               </select>
             </div>
 
+            {/* 19+ checkbox */}
+            <label className="flex cursor-pointer items-center gap-1.5 text-[12px] font-medium text-[var(--muted)] hover:text-[var(--fg)] transition-colors">
+              <input
+                type="checkbox"
+                checked={nsfw}
+                onChange={(e) => navigate({ tab, writer, genre, lang, contentType, nsfw: e.target.checked })}
+                className="h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--accent)]"
+              />
+              19+
+            </label>
+
             {/* Result count */}
             {totalCount !== undefined && (
               <span className="ml-1 text-[12px] tabular-nums text-[var(--muted)]">

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -2,30 +2,15 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { usePathname, useSearchParams, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { useAccount } from "wagmi";
 import Image from "next/image";
 import { ConnectWallet } from "./ConnectWallet";
-import { useNsfwPreference } from "../hooks/useNsfwPreference";
 
 export function NavBar() {
   const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const router = useRouter();
   const [mobileOpen, setMobileOpen] = useState(false);
   const { address, isConnected } = useAccount();
-
-  const [showNsfw, setNsfw] = useNsfwPreference();
-
-  const toggleNsfw = () => {
-    const next = !showNsfw;
-    setNsfw(next);
-    if (pathname === "/") {
-      const sp = new URLSearchParams(searchParams.toString());
-      if (next) sp.set("nsfw", "1"); else sp.delete("nsfw");
-      router.replace(`/?${sp.toString()}`);
-    }
-  };
 
   const dashboardHref = isConnected && address
     ? `/profile/${address}`
@@ -49,39 +34,22 @@ export function NavBar() {
   return (
     <nav className="fixed top-0 right-0 left-0 z-50 border-b border-[var(--border)] bg-[var(--bg)]/95 backdrop-blur-sm">
       <div className="mx-auto flex h-11 max-w-[var(--grid-max)] items-center justify-between px-4">
-        {/* Logo + 19+ toggle cluster */}
-        <div className="flex items-center">
-          <Link
-            href="/"
-            className="flex items-center gap-1.5 transition-opacity hover:opacity-80"
-          >
-            <Image
-              src="/plotlink-logo-symbol.svg"
-              alt=""
-              width={20}
-              height={24}
-              className="h-5 w-auto"
-            />
-            <span className="font-heading text-[20px] font-medium tracking-tight text-foreground">
-              Plot<span className="text-accent">Link</span>
-            </span>
-          </Link>
-
-          {/* 19+ NSFW toggle — round circle icon */}
-          <button
-            type="button"
-            onClick={toggleNsfw}
-            className={`ml-1.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[9px] font-bold leading-none transition-colors ${
-              showNsfw
-                ? "bg-red-600 text-white"
-                : "bg-neutral-700 text-neutral-400 hover:bg-neutral-600 hover:text-neutral-300"
-            }`}
-            title={showNsfw ? "Hide 19+ content" : "Show 19+ content"}
-            aria-pressed={showNsfw}
-          >
-            19
-          </button>
-        </div>
+        {/* Logo */}
+        <Link
+          href="/"
+          className="flex items-center gap-1.5 transition-opacity hover:opacity-80"
+        >
+          <Image
+            src="/plotlink-logo-symbol.svg"
+            alt=""
+            width={20}
+            height={24}
+            className="h-5 w-auto"
+          />
+          <span className="font-heading text-[20px] font-medium tracking-tight text-foreground">
+            Plot<span className="text-accent">Link</span>
+          </span>
+        </Link>
 
         {/* Desktop nav links */}
         <div className="hidden items-center gap-1 md:flex">


### PR DESCRIPTION
## Summary
- Removes the round 19+ icon from NavBar (and `useNsfwPreference` import) — NavBar is back to logo + nav links + wallet
- Adds a 19+ checkbox to FilterBar's desktop filter row, after the Language dropdown
- Mobile filter sheet already had the 19+ toggle — no changes needed there
- All other 19+ renames, NsfwBadge on story cards, and profile page filtering are preserved

## Test plan
- [ ] NavBar has no 19+ icon on desktop or mobile
- [ ] FilterBar desktop row shows 19+ checkbox after Language dropdown
- [ ] Checking the box adds `?nsfw=1` to the URL
- [ ] Unchecking removes it
- [ ] Mobile filter sheet still has "Show 19+ content" toggle
- [ ] Active chip "19+" appears on mobile when enabled
- [ ] NsfwBadge still renders on NSFW story cards

Fixes #1226

🤖 Generated with [Claude Code](https://claude.com/claude-code)