### PR TITLE
[#1232] Add GET wrapper and pause check to airdrop-points cron

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.29.3",
+  "version": "1.29.4",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/api/cron/airdrop-points/route.ts
+++ b/src/app/api/cron/airdrop-points/route.ts
@@ -21,9 +21,13 @@ function verifyCron(req: Request): boolean {
   return authHeader === `Bearer ${secret}`;
 }
 
-export async function POST(req: Request) {
+async function handler(req: Request) {
   if (!verifyCron(req)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (process.env.NEXT_PUBLIC_AIRDROP_PAUSED === "1") {
+    return NextResponse.json({ paused: true });
   }
 
   const supabase = createServerClient();
@@ -170,4 +174,12 @@ export async function POST(req: Request) {
     message: "Points synced",
     processed: { buys: buyCount, referrals: referralCount },
   });
+}
+
+export async function GET(req: Request) {
+  return handler(req);
+}
+
+export async function POST(req: Request) {
+  return handler(req);
 }


### PR DESCRIPTION
## Summary
- Adds a `GET` export to `airdrop-points/route.ts` so Vercel cron (which calls GET) can invoke the handler — previously only `POST` was exported, so `pl_points action='buy'` rows were never populated.
- Adds `NEXT_PUBLIC_AIRDROP_PAUSED` env-based pause check **after** `CRON_SECRET` auth, **before** any DB reads/writes (RE1 r38/r39 ordering). Setting `NEXT_PUBLIC_AIRDROP_PAUSED=1` → cron returns `{paused: true}` with no DB writes.
- Existing `POST` handler preserved — both `GET` and `POST` delegate to the same internal `handler()`.

## Constraints followed
- **No `vercel.json` edits** — production cron registration is T1.4's job
- **Option C only** — no `vercel-staging.json`, no env-gated handler, no separate project
- Single-DB env acknowledged — manual curl will write to prod DB; cleanup is T1.2's responsibility

## Manual verification (smoke test)
```bash
curl -H "Authorization: Bearer $CRON_SECRET" \
     https://plotlink.xyz/api/cron/airdrop-points
```

## Version
1.29.3 → 1.29.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)