### PR TITLE
[#1239] Add Farcaster follow verification (verifyFc)

### DIFF
--- a/lib/airdrop/activation-verify.test.ts
+++ b/lib/airdrop/activation-verify.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+beforeEach(() => {
+  vi.stubEnv("NEYNAR_API_KEY", "test-neynar-key");
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+function mockFetch(status: number, body?: unknown) {
+  return vi.mocked(fetch).mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+const PLOTLINK_FID = 12345;
+
+describe("verifyFc", () => {
+  it("returns ok with fid when user exists and follows plotlink", async () => {
+    const { verifyFc } = await import("./activation-verify");
+
+    mockFetch(200, { user: { fid: 999 } });
+    mockFetch(200, {
+      users: [{ fid: PLOTLINK_FID, viewer_context: { following: true } }],
+    });
+
+    const result = await verifyFc("testuser", PLOTLINK_FID);
+    expect(result).toEqual({ ok: true, fid: 999 });
+  });
+
+  it("returns user_not_found when username returns 404", async () => {
+    const { verifyFc } = await import("./activation-verify");
+    mockFetch(404);
+
+    const result = await verifyFc("nonexistent", PLOTLINK_FID);
+    expect(result).toEqual({ ok: false, error: "user_not_found" });
+  });
+
+  it("returns user_not_found when username returns 400", async () => {
+    const { verifyFc } = await import("./activation-verify");
+    mockFetch(400);
+
+    const result = await verifyFc("bad!", PLOTLINK_FID);
+    expect(result).toEqual({ ok: false, error: "user_not_found" });
+  });
+
+  it("returns user_not_found when response has no fid", async () => {
+    const { verifyFc } = await import("./activation-verify");
+    mockFetch(200, { user: {} });
+
+    const result = await verifyFc("nofid", PLOTLINK_FID);
+    expect(result).toEqual({ ok: false, error: "user_not_found" });
+  });
+
+  it("returns not_following when user exists but doesn't follow", async () => {
+    const { verifyFc } = await import("./activation-verify");
+
+    mockFetch(200, { user: { fid: 999 } });
+    mockFetch(200, {
+      users: [{ fid: PLOTLINK_FID, viewer_context: { following: false } }],
+    });
+
+    const result = await verifyFc("testuser", PLOTLINK_FID);
+    expect(result).toEqual({ ok: false, error: "not_following" });
+  });
+
+  it("returns neynar_error on 5xx from username lookup", async () => {
+    const { verifyFc } = await import("./activation-verify");
+    mockFetch(500);
+
+    const result = await verifyFc("testuser", PLOTLINK_FID);
+    expect(result).toEqual({ ok: false, error: "neynar_error" });
+  });
+
+  it("returns neynar_error on 5xx from follow check", async () => {
+    const { verifyFc } = await import("./activation-verify");
+    mockFetch(200, { user: { fid: 999 } });
+    mockFetch(500);
+
+    const result = await verifyFc("testuser", PLOTLINK_FID);
+    expect(result).toEqual({ ok: false, error: "neynar_error" });
+  });
+
+  it("returns neynar_error on network failure", async () => {
+    const { verifyFc } = await import("./activation-verify");
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("network error"));
+
+    const result = await verifyFc("testuser", PLOTLINK_FID);
+    expect(result).toEqual({ ok: false, error: "neynar_error" });
+  });
+
+  it("returns neynar_error when NEYNAR_API_KEY is not set", async () => {
+    vi.stubEnv("NEYNAR_API_KEY", "");
+    const { verifyFc } = await import("./activation-verify");
+
+    const result = await verifyFc("testuser", PLOTLINK_FID);
+    expect(result).toEqual({ ok: false, error: "neynar_error" });
+  });
+});

--- a/lib/airdrop/activation-verify.ts
+++ b/lib/airdrop/activation-verify.ts
@@ -1,0 +1,58 @@
+const NEYNAR_BASE = "https://api.neynar.com/v2/farcaster";
+
+type VerifyFcResult =
+  | { ok: true; fid: number }
+  | { ok: false; error: "user_not_found" | "not_following" | "neynar_error" };
+
+export async function verifyFc(
+  username: string,
+  plotlinkFid: number,
+): Promise<VerifyFcResult> {
+  const apiKey = process.env.NEYNAR_API_KEY;
+  if (!apiKey) return { ok: false, error: "neynar_error" };
+
+  let fid: number;
+  try {
+    const res = await fetch(
+      `${NEYNAR_BASE}/user/by_username?username=${encodeURIComponent(username)}`,
+      { headers: { accept: "application/json", "x-api-key": apiKey } },
+    );
+
+    if (res.status === 404 || res.status === 400) {
+      return { ok: false, error: "user_not_found" };
+    }
+    if (!res.ok) {
+      return { ok: false, error: "neynar_error" };
+    }
+
+    const data = await res.json();
+    fid = data?.user?.fid;
+    if (!fid) return { ok: false, error: "user_not_found" };
+  } catch {
+    return { ok: false, error: "neynar_error" };
+  }
+
+  try {
+    const res = await fetch(
+      `${NEYNAR_BASE}/user/bulk?fids=${plotlinkFid}&viewer_fid=${fid}`,
+      { headers: { accept: "application/json", "x-api-key": apiKey } },
+    );
+
+    if (!res.ok) {
+      return { ok: false, error: "neynar_error" };
+    }
+
+    const data = await res.json();
+    const target = data?.users?.[0];
+    if (!target) return { ok: false, error: "neynar_error" };
+
+    const isFollowing = target?.viewer_context?.following ?? false;
+    if (!isFollowing) {
+      return { ok: false, error: "not_following" };
+    }
+
+    return { ok: true, fid };
+  } catch {
+    return { ok: false, error: "neynar_error" };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.30.3",
+  "version": "1.30.4",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary
- Creates `lib/airdrop/activation-verify.ts` with `verifyFc(username, plotlinkFid)`
- Two Neynar API calls: (1) `GET /user/by_username` → FID, (2) `GET /user/bulk?viewer_fid` → follow check
- Returns `{ ok: true, fid }` on success, or `{ ok: false, error }` with `user_not_found` / `not_following` / `neynar_error`
- No DB writes — caller endpoint handles persistence
- 9 unit tests: success, 404, 400, no-fid, not-following, 5xx on both calls, network failure, missing API key

## Version
1.30.3 → 1.30.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)