### PR TITLE
[#1241] Add shared SQL helper v_weighted_spend (option A)

### DIFF
--- a/lib/airdrop/sql.test.ts
+++ b/lib/airdrop/sql.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
-import { weightedSpendQuery } from "./sql";
+import { describe, expect, it } from "vitest";
+import { weightedSpendQuery, computeWeightedSpend } from "./sql";
 import type { AirdropConfig } from "./config";
+import type { Activation, BuyPoint, Referral } from "./sql";
 
 function buildConfig(overrides: Partial<AirdropConfig> = {}): AirdropConfig {
   return {
@@ -33,87 +34,210 @@ function buildConfig(overrides: Partial<AirdropConfig> = {}): AirdropConfig {
 }
 
 describe("weightedSpendQuery", () => {
-  it("returns sql and params with correct campaign window", () => {
+  it("returns parameterized sql with campaign window and config values", () => {
     const config = buildConfig();
     const { sql, params } = weightedSpendQuery(config);
 
-    expect(params[0]).toBe("2026-07-01T00:00:00.000Z");
-    expect(params[1]).toBe("2026-10-01T00:00:00.000Z");
-    expect(params[2]).toBe(50);
-    expect(params[3]).toBe(0.2);
-    expect(params[4]).toBe(3.0);
+    expect(params).toEqual([
+      "2026-07-01T00:00:00.000Z",
+      "2026-10-01T00:00:00.000Z",
+      50, 0.2, 3.0,
+    ]);
     expect(sql).toContain("pl_activations");
-    expect(sql).toContain("pl_points");
-    expect(sql).toContain("pl_referrals");
-  });
-
-  it("includes eligibility filter for activated + not blacklisted", () => {
-    const { sql } = weightedSpendQuery(buildConfig());
-    expect(sql).toContain("a.activated_at IS NOT NULL");
-    expect(sql).toContain("a.is_blacklisted = FALSE");
-  });
-
-  it("filters buy points within campaign window using params", () => {
-    const { sql } = weightedSpendQuery(buildConfig());
-    expect(sql).toContain("p.created_at >= $1");
-    expect(sql).toContain("p.created_at <= $2");
-  });
-
-  it("qualified_refs uses MIN_REFERRAL_THRESHOLD param", () => {
-    const { sql } = weightedSpendQuery(buildConfig());
-    expect(sql).toContain("eb.buy_volume >= $3");
-  });
-
-  it("qualified_refs joins against eligible_buys (same eligibility filter)", () => {
-    const { sql } = weightedSpendQuery(buildConfig());
-    expect(sql).toContain("JOIN eligible_buys eb ON r.referred_address = eb.address");
-  });
-
-  it("multiplier uses REFERRAL_MULTIPLIER_PER_REF and CAP params", () => {
-    const { sql } = weightedSpendQuery(buildConfig());
-    expect(sql).toContain("$4");
-    expect(sql).toContain("$5");
-    expect(sql).toContain("LEAST");
-  });
-
-  it("includes community_total as window function", () => {
-    const { sql } = weightedSpendQuery(buildConfig());
+    expect(sql).toContain("activated_at IS NOT NULL");
+    expect(sql).toContain("is_blacklisted = FALSE");
     expect(sql).toContain("SUM(w.weighted_spend) OVER ()");
   });
 
-  it("produces different params for TEST vs PROD config", () => {
-    const prodConfig = buildConfig();
-    const testConfig = buildConfig({
+  it("same SQL structure for TEST vs PROD, different params", () => {
+    const prod = weightedSpendQuery(buildConfig());
+    const test = weightedSpendQuery(buildConfig({
       CAMPAIGN_START: new Date("2026-06-01T12:00:00Z"),
       CAMPAIGN_END: new Date("2026-06-01T12:05:00Z"),
       MIN_REFERRAL_THRESHOLD: 1,
-    });
-
-    const prod = weightedSpendQuery(prodConfig);
-    const test = weightedSpendQuery(testConfig);
-
-    expect(prod.params[0]).not.toBe(test.params[0]);
-    expect(prod.params[1]).not.toBe(test.params[1]);
-    expect(prod.params[2]).not.toBe(test.params[2]);
+    }));
     expect(prod.sql).toBe(test.sql);
+    expect(prod.params).not.toEqual(test.params);
+  });
+});
+
+describe("computeWeightedSpend", () => {
+  const config = buildConfig();
+  const inCampaign = "2026-08-01T00:00:00Z";
+
+  it("100 PLOT + 2 qualified refs + FC bonus → multiplier 1.6, weighted 160", () => {
+    const activations: Activation[] = [
+      { address: "alice", activated_at: "2026-07-01", is_blacklisted: false, fid: 123 },
+      { address: "ref1", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
+      { address: "ref2", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
+    ];
+    const buys: BuyPoint[] = [
+      { address: "alice", action: "buy", points: 100, created_at: inCampaign },
+      { address: "ref1", action: "buy", points: 60, created_at: inCampaign },
+      { address: "ref2", action: "buy", points: 80, created_at: inCampaign },
+    ];
+    const refs: Referral[] = [
+      { referrer_address: "alice", referred_address: "ref1" },
+      { referrer_address: "alice", referred_address: "ref2" },
+    ];
+
+    const rows = computeWeightedSpend(config, activations, buys, refs);
+    const alice = rows.find(r => r.address === "alice")!;
+
+    expect(alice.buy_volume).toBe(100);
+    expect(alice.qualified_refs).toBe(2);
+    expect(alice.has_fc_bonus).toBe(1);
+    expect(alice.multiplier).toBe(1.6);
+    expect(alice.weighted_spend).toBe(160);
   });
 
-  it("multiplier example: 2 refs + FC bonus + 0.2 per ref → 1.6", () => {
-    const config = buildConfig();
-    const refCount = 2;
-    const fcBonus = 1;
-    const expected = 1 + (refCount + fcBonus) * config.REFERRAL_MULTIPLIER_PER_REF;
-    expect(expected).toBe(1.6);
-    expect(expected).toBeLessThanOrEqual(config.REFERRAL_MULTIPLIER_CAP);
+  it("excludes blacklisted wallets from results", () => {
+    const activations: Activation[] = [
+      { address: "good", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
+      { address: "bad", activated_at: "2026-07-01", is_blacklisted: true, fid: null },
+    ];
+    const buys: BuyPoint[] = [
+      { address: "good", action: "buy", points: 100, created_at: inCampaign },
+      { address: "bad", action: "buy", points: 100, created_at: inCampaign },
+    ];
+
+    const rows = computeWeightedSpend(config, activations, buys, []);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].address).toBe("good");
+  });
+
+  it("excludes non-activated wallets from results", () => {
+    const activations: Activation[] = [
+      { address: "active", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
+      { address: "pending", activated_at: null, is_blacklisted: false, fid: null },
+    ];
+    const buys: BuyPoint[] = [
+      { address: "active", action: "buy", points: 100, created_at: inCampaign },
+      { address: "pending", action: "buy", points: 100, created_at: inCampaign },
+    ];
+
+    const rows = computeWeightedSpend(config, activations, buys, []);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].address).toBe("active");
+  });
+
+  it("qualified_refs excludes non-activated referees", () => {
+    const activations: Activation[] = [
+      { address: "alice", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
+      { address: "bob", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
+      { address: "charlie", activated_at: null, is_blacklisted: false, fid: null },
+    ];
+    const buys: BuyPoint[] = [
+      { address: "alice", action: "buy", points: 100, created_at: inCampaign },
+      { address: "bob", action: "buy", points: 60, created_at: inCampaign },
+      { address: "charlie", action: "buy", points: 60, created_at: inCampaign },
+    ];
+    const refs: Referral[] = [
+      { referrer_address: "alice", referred_address: "bob" },
+      { referrer_address: "alice", referred_address: "charlie" },
+    ];
+
+    const rows = computeWeightedSpend(config, activations, buys, refs);
+    const alice = rows.find(r => r.address === "alice")!;
+    expect(alice.qualified_refs).toBe(1);
+  });
+
+  it("qualified_refs excludes blacklisted referees", () => {
+    const activations: Activation[] = [
+      { address: "alice", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
+      { address: "dave", activated_at: "2026-07-01", is_blacklisted: true, fid: null },
+    ];
+    const buys: BuyPoint[] = [
+      { address: "alice", action: "buy", points: 100, created_at: inCampaign },
+      { address: "dave", action: "buy", points: 60, created_at: inCampaign },
+    ];
+    const refs: Referral[] = [
+      { referrer_address: "alice", referred_address: "dave" },
+    ];
+
+    const rows = computeWeightedSpend(config, activations, buys, refs);
+    const alice = rows.find(r => r.address === "alice")!;
+    expect(alice.qualified_refs).toBe(0);
+  });
+
+  it("qualified_refs excludes under-threshold referees (49 < 50)", () => {
+    const activations: Activation[] = [
+      { address: "alice", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
+      { address: "low", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
+      { address: "high", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
+    ];
+    const buys: BuyPoint[] = [
+      { address: "alice", action: "buy", points: 100, created_at: inCampaign },
+      { address: "low", action: "buy", points: 49, created_at: inCampaign },
+      { address: "high", action: "buy", points: 50, created_at: inCampaign },
+    ];
+    const refs: Referral[] = [
+      { referrer_address: "alice", referred_address: "low" },
+      { referrer_address: "alice", referred_address: "high" },
+    ];
+
+    const rows = computeWeightedSpend(config, activations, buys, refs);
+    const alice = rows.find(r => r.address === "alice")!;
+    expect(alice.qualified_refs).toBe(1);
+  });
+
+  it("TEST vs PROD campaign windows produce different buy_volume", () => {
+    const prodConfig = buildConfig();
+    const testConfig = buildConfig({
+      CAMPAIGN_START: new Date("2026-06-01T00:00:00Z"),
+      CAMPAIGN_END: new Date("2026-06-01T00:05:00Z"),
+    });
+
+    const activations: Activation[] = [
+      { address: "alice", activated_at: "2026-06-01", is_blacklisted: false, fid: null },
+    ];
+    const buys: BuyPoint[] = [
+      { address: "alice", action: "buy", points: 50, created_at: "2026-06-01T00:02:00Z" },
+      { address: "alice", action: "buy", points: 75, created_at: "2026-08-01T00:00:00Z" },
+    ];
+
+    const testRows = computeWeightedSpend(testConfig, activations, buys, []);
+    const prodRows = computeWeightedSpend(prodConfig, activations, buys, []);
+
+    expect(testRows[0].buy_volume).toBe(50);
+    expect(prodRows[0].buy_volume).toBe(75);
+  });
+
+  it("community_total sums all weighted_spend", () => {
+    const activations: Activation[] = [
+      { address: "a", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
+      { address: "b", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
+    ];
+    const buys: BuyPoint[] = [
+      { address: "a", action: "buy", points: 100, created_at: inCampaign },
+      { address: "b", action: "buy", points: 200, created_at: inCampaign },
+    ];
+
+    const rows = computeWeightedSpend(config, activations, buys, []);
+    expect(rows[0].community_total).toBe(300);
+    expect(rows[1].community_total).toBe(300);
   });
 
   it("multiplier is capped at REFERRAL_MULTIPLIER_CAP", () => {
-    const config = buildConfig();
-    const refCount = 20;
-    const fcBonus = 1;
-    const uncapped = 1 + (refCount + fcBonus) * config.REFERRAL_MULTIPLIER_PER_REF;
-    const capped = Math.min(uncapped, config.REFERRAL_MULTIPLIER_CAP);
-    expect(uncapped).toBeGreaterThan(config.REFERRAL_MULTIPLIER_CAP);
-    expect(capped).toBe(3.0);
+    const activations: Activation[] = [
+      { address: "whale", activated_at: "2026-07-01", is_blacklisted: false, fid: 1 },
+      ...Array.from({ length: 20 }, (_, i) => ({
+        address: `ref${i}`, activated_at: "2026-07-01" as string | null, is_blacklisted: false, fid: null,
+      })),
+    ];
+    const buys: BuyPoint[] = [
+      { address: "whale", action: "buy", points: 100, created_at: inCampaign },
+      ...Array.from({ length: 20 }, (_, i) => ({
+        address: `ref${i}`, action: "buy", points: 60, created_at: inCampaign,
+      })),
+    ];
+    const refs: Referral[] = Array.from({ length: 20 }, (_, i) => ({
+      referrer_address: "whale", referred_address: `ref${i}`,
+    }));
+
+    const rows = computeWeightedSpend(config, activations, buys, refs);
+    const whale = rows.find(r => r.address === "whale")!;
+    expect(whale.multiplier).toBe(3.0);
+    expect(whale.weighted_spend).toBe(300);
   });
 });

--- a/lib/airdrop/sql.test.ts
+++ b/lib/airdrop/sql.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { weightedSpendQuery, computeWeightedSpend } from "./sql";
+// @vitest-environment node
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { PGlite } from "@electric-sql/pglite";
+import { weightedSpendQuery } from "./sql";
 import type { AirdropConfig } from "./config";
-import type { Activation, BuyPoint, Referral } from "./sql";
+
+let db: PGlite;
 
 function buildConfig(overrides: Partial<AirdropConfig> = {}): AirdropConfig {
   return {
@@ -33,211 +36,235 @@ function buildConfig(overrides: Partial<AirdropConfig> = {}): AirdropConfig {
   };
 }
 
-describe("weightedSpendQuery", () => {
-  it("returns parameterized sql with campaign window and config values", () => {
-    const config = buildConfig();
-    const { sql, params } = weightedSpendQuery(config);
-
-    expect(params).toEqual([
-      "2026-07-01T00:00:00.000Z",
-      "2026-10-01T00:00:00.000Z",
-      50, 0.2, 3.0,
-    ]);
-    expect(sql).toContain("pl_activations");
-    expect(sql).toContain("activated_at IS NOT NULL");
-    expect(sql).toContain("is_blacklisted = FALSE");
-    expect(sql).toContain("SUM(w.weighted_spend) OVER ()");
-  });
-
-  it("same SQL structure for TEST vs PROD, different params", () => {
-    const prod = weightedSpendQuery(buildConfig());
-    const test = weightedSpendQuery(buildConfig({
-      CAMPAIGN_START: new Date("2026-06-01T12:00:00Z"),
-      CAMPAIGN_END: new Date("2026-06-01T12:05:00Z"),
-      MIN_REFERRAL_THRESHOLD: 1,
-    }));
-    expect(prod.sql).toBe(test.sql);
-    expect(prod.params).not.toEqual(test.params);
-  });
+beforeAll(async () => {
+  db = new PGlite();
+  await db.exec(`
+    CREATE TABLE pl_activations (
+      address TEXT PRIMARY KEY,
+      fid BIGINT,
+      activated_at TIMESTAMPTZ,
+      is_blacklisted BOOLEAN NOT NULL DEFAULT FALSE
+    );
+    CREATE TABLE pl_points (
+      id SERIAL PRIMARY KEY,
+      address TEXT NOT NULL,
+      action TEXT NOT NULL,
+      points NUMERIC NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    );
+    CREATE TABLE pl_referrals (
+      id SERIAL PRIMARY KEY,
+      referrer_address TEXT NOT NULL,
+      referred_address TEXT NOT NULL
+    );
+  `);
 });
 
-describe("computeWeightedSpend", () => {
-  const config = buildConfig();
-  const inCampaign = "2026-08-01T00:00:00Z";
+afterAll(async () => {
+  await db.close();
+});
 
-  it("100 PLOT + 2 qualified refs + FC bonus → multiplier 1.6, weighted 160", () => {
-    const activations: Activation[] = [
-      { address: "alice", activated_at: "2026-07-01", is_blacklisted: false, fid: 123 },
-      { address: "ref1", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
-      { address: "ref2", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
-    ];
-    const buys: BuyPoint[] = [
-      { address: "alice", action: "buy", points: 100, created_at: inCampaign },
-      { address: "ref1", action: "buy", points: 60, created_at: inCampaign },
-      { address: "ref2", action: "buy", points: 80, created_at: inCampaign },
-    ];
-    const refs: Referral[] = [
-      { referrer_address: "alice", referred_address: "ref1" },
-      { referrer_address: "alice", referred_address: "ref2" },
-    ];
+async function resetFixtures() {
+  await db.exec("DELETE FROM pl_referrals; DELETE FROM pl_points; DELETE FROM pl_activations;");
+}
 
-    const rows = computeWeightedSpend(config, activations, buys, refs);
+async function runQuery(config: AirdropConfig) {
+  const { sql, params } = weightedSpendQuery(config);
+  const result = await db.query(sql, params);
+  return result.rows as Array<{
+    address: string;
+    buy_volume: number;
+    qualified_refs: number;
+    has_fc_bonus: number;
+    multiplier: number;
+    weighted_spend: number;
+    community_total: number;
+  }>;
+}
+
+const IN_CAMPAIGN = "2026-08-01T00:00:00Z";
+const config = buildConfig();
+
+describe("weightedSpendQuery against PGlite", () => {
+  it("100 PLOT + 2 qualified refs + FC bonus → multiplier 1.6, weighted 160", async () => {
+    await resetFixtures();
+    await db.exec(`
+      INSERT INTO pl_activations (address, fid, activated_at) VALUES
+        ('alice', 123, '2026-07-01'),
+        ('ref1', NULL, '2026-07-01'),
+        ('ref2', NULL, '2026-07-01');
+      INSERT INTO pl_points (address, action, points, created_at) VALUES
+        ('alice', 'buy', 100, '${IN_CAMPAIGN}'),
+        ('ref1', 'buy', 60, '${IN_CAMPAIGN}'),
+        ('ref2', 'buy', 80, '${IN_CAMPAIGN}');
+      INSERT INTO pl_referrals (referrer_address, referred_address) VALUES
+        ('alice', 'ref1'),
+        ('alice', 'ref2');
+    `);
+
+    const rows = await runQuery(config);
     const alice = rows.find(r => r.address === "alice")!;
 
-    expect(alice.buy_volume).toBe(100);
-    expect(alice.qualified_refs).toBe(2);
-    expect(alice.has_fc_bonus).toBe(1);
-    expect(alice.multiplier).toBe(1.6);
-    expect(alice.weighted_spend).toBe(160);
+    expect(Number(alice.buy_volume)).toBe(100);
+    expect(Number(alice.qualified_refs)).toBe(2);
+    expect(Number(alice.has_fc_bonus)).toBe(1);
+    expect(Number(alice.multiplier)).toBeCloseTo(1.6);
+    expect(Number(alice.weighted_spend)).toBeCloseTo(160);
   });
 
-  it("excludes blacklisted wallets from results", () => {
-    const activations: Activation[] = [
-      { address: "good", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
-      { address: "bad", activated_at: "2026-07-01", is_blacklisted: true, fid: null },
-    ];
-    const buys: BuyPoint[] = [
-      { address: "good", action: "buy", points: 100, created_at: inCampaign },
-      { address: "bad", action: "buy", points: 100, created_at: inCampaign },
-    ];
+  it("excludes blacklisted wallets from results", async () => {
+    await resetFixtures();
+    await db.exec(`
+      INSERT INTO pl_activations (address, activated_at, is_blacklisted) VALUES
+        ('good', '2026-07-01', FALSE),
+        ('bad', '2026-07-01', TRUE);
+      INSERT INTO pl_points (address, action, points, created_at) VALUES
+        ('good', 'buy', 100, '${IN_CAMPAIGN}'),
+        ('bad', 'buy', 100, '${IN_CAMPAIGN}');
+    `);
 
-    const rows = computeWeightedSpend(config, activations, buys, []);
+    const rows = await runQuery(config);
     expect(rows).toHaveLength(1);
     expect(rows[0].address).toBe("good");
   });
 
-  it("excludes non-activated wallets from results", () => {
-    const activations: Activation[] = [
-      { address: "active", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
-      { address: "pending", activated_at: null, is_blacklisted: false, fid: null },
-    ];
-    const buys: BuyPoint[] = [
-      { address: "active", action: "buy", points: 100, created_at: inCampaign },
-      { address: "pending", action: "buy", points: 100, created_at: inCampaign },
-    ];
+  it("excludes non-activated wallets from results", async () => {
+    await resetFixtures();
+    await db.exec(`
+      INSERT INTO pl_activations (address, activated_at) VALUES
+        ('active', '2026-07-01'),
+        ('pending', NULL);
+      INSERT INTO pl_points (address, action, points, created_at) VALUES
+        ('active', 'buy', 100, '${IN_CAMPAIGN}'),
+        ('pending', 'buy', 100, '${IN_CAMPAIGN}');
+    `);
 
-    const rows = computeWeightedSpend(config, activations, buys, []);
+    const rows = await runQuery(config);
     expect(rows).toHaveLength(1);
     expect(rows[0].address).toBe("active");
   });
 
-  it("qualified_refs excludes non-activated referees", () => {
-    const activations: Activation[] = [
-      { address: "alice", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
-      { address: "bob", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
-      { address: "charlie", activated_at: null, is_blacklisted: false, fid: null },
-    ];
-    const buys: BuyPoint[] = [
-      { address: "alice", action: "buy", points: 100, created_at: inCampaign },
-      { address: "bob", action: "buy", points: 60, created_at: inCampaign },
-      { address: "charlie", action: "buy", points: 60, created_at: inCampaign },
-    ];
-    const refs: Referral[] = [
-      { referrer_address: "alice", referred_address: "bob" },
-      { referrer_address: "alice", referred_address: "charlie" },
-    ];
+  it("qualified_refs excludes non-activated referees", async () => {
+    await resetFixtures();
+    await db.exec(`
+      INSERT INTO pl_activations (address, activated_at) VALUES
+        ('alice', '2026-07-01'),
+        ('bob', '2026-07-01'),
+        ('charlie', NULL);
+      INSERT INTO pl_points (address, action, points, created_at) VALUES
+        ('alice', 'buy', 100, '${IN_CAMPAIGN}'),
+        ('bob', 'buy', 60, '${IN_CAMPAIGN}'),
+        ('charlie', 'buy', 60, '${IN_CAMPAIGN}');
+      INSERT INTO pl_referrals (referrer_address, referred_address) VALUES
+        ('alice', 'bob'),
+        ('alice', 'charlie');
+    `);
 
-    const rows = computeWeightedSpend(config, activations, buys, refs);
+    const rows = await runQuery(config);
     const alice = rows.find(r => r.address === "alice")!;
-    expect(alice.qualified_refs).toBe(1);
+    expect(Number(alice.qualified_refs)).toBe(1);
   });
 
-  it("qualified_refs excludes blacklisted referees", () => {
-    const activations: Activation[] = [
-      { address: "alice", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
-      { address: "dave", activated_at: "2026-07-01", is_blacklisted: true, fid: null },
-    ];
-    const buys: BuyPoint[] = [
-      { address: "alice", action: "buy", points: 100, created_at: inCampaign },
-      { address: "dave", action: "buy", points: 60, created_at: inCampaign },
-    ];
-    const refs: Referral[] = [
-      { referrer_address: "alice", referred_address: "dave" },
-    ];
+  it("qualified_refs excludes blacklisted referees", async () => {
+    await resetFixtures();
+    await db.exec(`
+      INSERT INTO pl_activations (address, activated_at, is_blacklisted) VALUES
+        ('alice', '2026-07-01', FALSE),
+        ('dave', '2026-07-01', TRUE);
+      INSERT INTO pl_points (address, action, points, created_at) VALUES
+        ('alice', 'buy', 100, '${IN_CAMPAIGN}'),
+        ('dave', 'buy', 60, '${IN_CAMPAIGN}');
+      INSERT INTO pl_referrals (referrer_address, referred_address) VALUES
+        ('alice', 'dave');
+    `);
 
-    const rows = computeWeightedSpend(config, activations, buys, refs);
+    const rows = await runQuery(config);
     const alice = rows.find(r => r.address === "alice")!;
-    expect(alice.qualified_refs).toBe(0);
+    expect(Number(alice.qualified_refs)).toBe(0);
   });
 
-  it("qualified_refs excludes under-threshold referees (49 < 50)", () => {
-    const activations: Activation[] = [
-      { address: "alice", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
-      { address: "low", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
-      { address: "high", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
-    ];
-    const buys: BuyPoint[] = [
-      { address: "alice", action: "buy", points: 100, created_at: inCampaign },
-      { address: "low", action: "buy", points: 49, created_at: inCampaign },
-      { address: "high", action: "buy", points: 50, created_at: inCampaign },
-    ];
-    const refs: Referral[] = [
-      { referrer_address: "alice", referred_address: "low" },
-      { referrer_address: "alice", referred_address: "high" },
-    ];
+  it("qualified_refs excludes under-threshold referees (49 < 50)", async () => {
+    await resetFixtures();
+    await db.exec(`
+      INSERT INTO pl_activations (address, activated_at) VALUES
+        ('alice', '2026-07-01'),
+        ('low', '2026-07-01'),
+        ('high', '2026-07-01');
+      INSERT INTO pl_points (address, action, points, created_at) VALUES
+        ('alice', 'buy', 100, '${IN_CAMPAIGN}'),
+        ('low', 'buy', 49, '${IN_CAMPAIGN}'),
+        ('high', 'buy', 50, '${IN_CAMPAIGN}');
+      INSERT INTO pl_referrals (referrer_address, referred_address) VALUES
+        ('alice', 'low'),
+        ('alice', 'high');
+    `);
 
-    const rows = computeWeightedSpend(config, activations, buys, refs);
+    const rows = await runQuery(config);
     const alice = rows.find(r => r.address === "alice")!;
-    expect(alice.qualified_refs).toBe(1);
+    expect(Number(alice.qualified_refs)).toBe(1);
   });
 
-  it("TEST vs PROD campaign windows produce different buy_volume", () => {
-    const prodConfig = buildConfig();
+  it("TEST vs PROD campaign windows produce different buy_volume", async () => {
+    await resetFixtures();
+    await db.exec(`
+      INSERT INTO pl_activations (address, activated_at) VALUES ('alice', '2026-06-01');
+      INSERT INTO pl_points (address, action, points, created_at) VALUES
+        ('alice', 'buy', 50, '2026-06-01T00:02:00Z'),
+        ('alice', 'buy', 75, '${IN_CAMPAIGN}');
+    `);
+
     const testConfig = buildConfig({
       CAMPAIGN_START: new Date("2026-06-01T00:00:00Z"),
       CAMPAIGN_END: new Date("2026-06-01T00:05:00Z"),
     });
 
-    const activations: Activation[] = [
-      { address: "alice", activated_at: "2026-06-01", is_blacklisted: false, fid: null },
-    ];
-    const buys: BuyPoint[] = [
-      { address: "alice", action: "buy", points: 50, created_at: "2026-06-01T00:02:00Z" },
-      { address: "alice", action: "buy", points: 75, created_at: "2026-08-01T00:00:00Z" },
-    ];
+    const testRows = await runQuery(testConfig);
+    const prodRows = await runQuery(config);
 
-    const testRows = computeWeightedSpend(testConfig, activations, buys, []);
-    const prodRows = computeWeightedSpend(prodConfig, activations, buys, []);
-
-    expect(testRows[0].buy_volume).toBe(50);
-    expect(prodRows[0].buy_volume).toBe(75);
+    expect(Number(testRows[0].buy_volume)).toBe(50);
+    expect(Number(prodRows[0].buy_volume)).toBe(75);
   });
 
-  it("community_total sums all weighted_spend", () => {
-    const activations: Activation[] = [
-      { address: "a", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
-      { address: "b", activated_at: "2026-07-01", is_blacklisted: false, fid: null },
-    ];
-    const buys: BuyPoint[] = [
-      { address: "a", action: "buy", points: 100, created_at: inCampaign },
-      { address: "b", action: "buy", points: 200, created_at: inCampaign },
-    ];
+  it("community_total sums all weighted_spend across rows", async () => {
+    await resetFixtures();
+    await db.exec(`
+      INSERT INTO pl_activations (address, activated_at) VALUES
+        ('a', '2026-07-01'),
+        ('b', '2026-07-01');
+      INSERT INTO pl_points (address, action, points, created_at) VALUES
+        ('a', 'buy', 100, '${IN_CAMPAIGN}'),
+        ('b', 'buy', 200, '${IN_CAMPAIGN}');
+    `);
 
-    const rows = computeWeightedSpend(config, activations, buys, []);
-    expect(rows[0].community_total).toBe(300);
-    expect(rows[1].community_total).toBe(300);
+    const rows = await runQuery(config);
+    expect(Number(rows[0].community_total)).toBe(300);
+    expect(Number(rows[1].community_total)).toBe(300);
   });
 
-  it("multiplier is capped at REFERRAL_MULTIPLIER_CAP", () => {
-    const activations: Activation[] = [
-      { address: "whale", activated_at: "2026-07-01", is_blacklisted: false, fid: 1 },
-      ...Array.from({ length: 20 }, (_, i) => ({
-        address: `ref${i}`, activated_at: "2026-07-01" as string | null, is_blacklisted: false, fid: null,
-      })),
-    ];
-    const buys: BuyPoint[] = [
-      { address: "whale", action: "buy", points: 100, created_at: inCampaign },
-      ...Array.from({ length: 20 }, (_, i) => ({
-        address: `ref${i}`, action: "buy", points: 60, created_at: inCampaign,
-      })),
-    ];
-    const refs: Referral[] = Array.from({ length: 20 }, (_, i) => ({
-      referrer_address: "whale", referred_address: `ref${i}`,
-    }));
+  it("multiplier is capped at REFERRAL_MULTIPLIER_CAP", async () => {
+    await resetFixtures();
+    const refInserts = Array.from({ length: 20 }, (_, i) =>
+      `('ref${i}', '2026-07-01')`
+    ).join(",");
+    const buyInserts = Array.from({ length: 20 }, (_, i) =>
+      `('ref${i}', 'buy', 60, '${IN_CAMPAIGN}')`
+    ).join(",");
+    const relInserts = Array.from({ length: 20 }, (_, i) =>
+      `('whale', 'ref${i}')`
+    ).join(",");
 
-    const rows = computeWeightedSpend(config, activations, buys, refs);
+    await db.exec(`
+      INSERT INTO pl_activations (address, activated_at) VALUES
+        ('whale', '2026-07-01'), ${refInserts};
+      UPDATE pl_activations SET fid = 1 WHERE address = 'whale';
+      INSERT INTO pl_points (address, action, points, created_at) VALUES
+        ('whale', 'buy', 100, '${IN_CAMPAIGN}'), ${buyInserts};
+      INSERT INTO pl_referrals (referrer_address, referred_address) VALUES ${relInserts};
+    `);
+
+    const rows = await runQuery(config);
     const whale = rows.find(r => r.address === "whale")!;
-    expect(whale.multiplier).toBe(3.0);
-    expect(whale.weighted_spend).toBe(300);
+    expect(Number(whale.multiplier)).toBe(3.0);
+    expect(Number(whale.weighted_spend)).toBeCloseTo(300);
   });
 });

--- a/lib/airdrop/sql.test.ts
+++ b/lib/airdrop/sql.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { weightedSpendQuery } from "./sql";
+import type { AirdropConfig } from "./config";
+
+function buildConfig(overrides: Partial<AirdropConfig> = {}): AirdropConfig {
+  return {
+    CAMPAIGN_START: new Date("2026-07-01T00:00:00Z"),
+    CAMPAIGN_END: new Date("2026-10-01T00:00:00Z"),
+    POOL_AMOUNT: 200_000,
+    MILESTONES: {
+      BRONZE: { mcap: 100_000, pct: 10 },
+      SILVER: { mcap: 1_000_000, pct: 30 },
+      GOLD: { mcap: 5_000_000, pct: 50 },
+      DIAMOND: { mcap: 10_000_000, pct: 100 },
+    },
+    LOCKER_TX: null,
+    POINTS: { BUY_PER_PLOT: 1, REFERRAL_PCT: 20, WRITE_FLAT: 50, RATE_FLAT: 5, RATE_DAILY_CAP: 10 },
+    STREAK_BOOSTS: {},
+    STREAK_MIN_GAP_MINUTES: 30,
+    MIN_REFERRAL_THRESHOLD: 50,
+    REFERRAL_MULTIPLIER_PER_REF: 0.2,
+    REFERRAL_MULTIPLIER_CAP: 3.0,
+    SIGNATURE_FRESHNESS_MIN: 10,
+    SIWE_DOMAIN: "plotlink.xyz",
+    SIWE_URI: "https://plotlink.xyz/airdrop",
+    SIWE_STATEMENT: "PlotLink Buy-Back Sprint activation",
+    SIWE_CHAIN_ID: 8453,
+    PLOTLINK_X_HANDLE: "plotlinkxyz",
+    PLOTLINK_FC_FID: 0,
+    CLAIM_WINDOW_DAYS: 30,
+    ...overrides,
+  };
+}
+
+describe("weightedSpendQuery", () => {
+  it("returns sql and params with correct campaign window", () => {
+    const config = buildConfig();
+    const { sql, params } = weightedSpendQuery(config);
+
+    expect(params[0]).toBe("2026-07-01T00:00:00.000Z");
+    expect(params[1]).toBe("2026-10-01T00:00:00.000Z");
+    expect(params[2]).toBe(50);
+    expect(params[3]).toBe(0.2);
+    expect(params[4]).toBe(3.0);
+    expect(sql).toContain("pl_activations");
+    expect(sql).toContain("pl_points");
+    expect(sql).toContain("pl_referrals");
+  });
+
+  it("includes eligibility filter for activated + not blacklisted", () => {
+    const { sql } = weightedSpendQuery(buildConfig());
+    expect(sql).toContain("a.activated_at IS NOT NULL");
+    expect(sql).toContain("a.is_blacklisted = FALSE");
+  });
+
+  it("filters buy points within campaign window using params", () => {
+    const { sql } = weightedSpendQuery(buildConfig());
+    expect(sql).toContain("p.created_at >= $1");
+    expect(sql).toContain("p.created_at <= $2");
+  });
+
+  it("qualified_refs uses MIN_REFERRAL_THRESHOLD param", () => {
+    const { sql } = weightedSpendQuery(buildConfig());
+    expect(sql).toContain("eb.buy_volume >= $3");
+  });
+
+  it("qualified_refs joins against eligible_buys (same eligibility filter)", () => {
+    const { sql } = weightedSpendQuery(buildConfig());
+    expect(sql).toContain("JOIN eligible_buys eb ON r.referred_address = eb.address");
+  });
+
+  it("multiplier uses REFERRAL_MULTIPLIER_PER_REF and CAP params", () => {
+    const { sql } = weightedSpendQuery(buildConfig());
+    expect(sql).toContain("$4");
+    expect(sql).toContain("$5");
+    expect(sql).toContain("LEAST");
+  });
+
+  it("includes community_total as window function", () => {
+    const { sql } = weightedSpendQuery(buildConfig());
+    expect(sql).toContain("SUM(w.weighted_spend) OVER ()");
+  });
+
+  it("produces different params for TEST vs PROD config", () => {
+    const prodConfig = buildConfig();
+    const testConfig = buildConfig({
+      CAMPAIGN_START: new Date("2026-06-01T12:00:00Z"),
+      CAMPAIGN_END: new Date("2026-06-01T12:05:00Z"),
+      MIN_REFERRAL_THRESHOLD: 1,
+    });
+
+    const prod = weightedSpendQuery(prodConfig);
+    const test = weightedSpendQuery(testConfig);
+
+    expect(prod.params[0]).not.toBe(test.params[0]);
+    expect(prod.params[1]).not.toBe(test.params[1]);
+    expect(prod.params[2]).not.toBe(test.params[2]);
+    expect(prod.sql).toBe(test.sql);
+  });
+
+  it("multiplier example: 2 refs + FC bonus + 0.2 per ref → 1.6", () => {
+    const config = buildConfig();
+    const refCount = 2;
+    const fcBonus = 1;
+    const expected = 1 + (refCount + fcBonus) * config.REFERRAL_MULTIPLIER_PER_REF;
+    expect(expected).toBe(1.6);
+    expect(expected).toBeLessThanOrEqual(config.REFERRAL_MULTIPLIER_CAP);
+  });
+
+  it("multiplier is capped at REFERRAL_MULTIPLIER_CAP", () => {
+    const config = buildConfig();
+    const refCount = 20;
+    const fcBonus = 1;
+    const uncapped = 1 + (refCount + fcBonus) * config.REFERRAL_MULTIPLIER_PER_REF;
+    const capped = Math.min(uncapped, config.REFERRAL_MULTIPLIER_CAP);
+    expect(uncapped).toBeGreaterThan(config.REFERRAL_MULTIPLIER_CAP);
+    expect(capped).toBe(3.0);
+  });
+});

--- a/lib/airdrop/sql.ts
+++ b/lib/airdrop/sql.ts
@@ -15,70 +15,6 @@ export interface WeightedSpendRow {
   community_total: number;
 }
 
-export interface Activation { address: string; activated_at: string | null; is_blacklisted: boolean; fid: number | null }
-export interface BuyPoint { address: string; action: string; points: number; created_at: string }
-export interface Referral { referrer_address: string; referred_address: string }
-
-export function computeWeightedSpend(
-  config: AirdropConfig,
-  activations: Activation[],
-  buyPoints: BuyPoint[],
-  referrals: Referral[],
-): WeightedSpendRow[] {
-  const eligible = activations
-    .filter(a => a.activated_at !== null && !a.is_blacklisted)
-    .map(a => ({ address: a.address, has_fc_bonus: a.fid !== null ? 1 : 0 }));
-
-  const eligibleSet = new Set(eligible.map(e => e.address));
-
-  const campStart = config.CAMPAIGN_START.getTime();
-  const campEnd = config.CAMPAIGN_END.getTime();
-
-  const buyMap = new Map<string, number>();
-  for (const p of buyPoints) {
-    if (p.action !== "buy") continue;
-    const t = new Date(p.created_at).getTime();
-    if (t < campStart || t > campEnd) continue;
-    buyMap.set(p.address, (buyMap.get(p.address) ?? 0) + p.points);
-  }
-
-  const eligibleBuys = eligible
-    .filter(e => (buyMap.get(e.address) ?? 0) > 0)
-    .map(e => ({ ...e, buy_volume: buyMap.get(e.address)! }));
-
-  const ebSet = new Set(eligibleBuys.map(e => e.address));
-
-  const refCounts = new Map<string, number>();
-  for (const r of referrals) {
-    if (!ebSet.has(r.referred_address)) continue;
-    const refBuyVol = buyMap.get(r.referred_address) ?? 0;
-    if (refBuyVol < config.MIN_REFERRAL_THRESHOLD) continue;
-    refCounts.set(r.referrer_address, (refCounts.get(r.referrer_address) ?? 0) + 1);
-  }
-
-  const rows = eligibleBuys.map(eb => {
-    const qr = refCounts.get(eb.address) ?? 0;
-    const multiplier = Math.min(
-      1 + (qr + eb.has_fc_bonus) * config.REFERRAL_MULTIPLIER_PER_REF,
-      config.REFERRAL_MULTIPLIER_CAP,
-    );
-    return {
-      address: eb.address,
-      buy_volume: eb.buy_volume,
-      qualified_refs: qr,
-      has_fc_bonus: eb.has_fc_bonus,
-      multiplier,
-      weighted_spend: eb.buy_volume * multiplier,
-      community_total: 0,
-    };
-  });
-
-  const total = rows.reduce((s, r) => s + r.weighted_spend, 0);
-  for (const r of rows) r.community_total = total;
-
-  return rows;
-}
-
 export function weightedSpendQuery(config: AirdropConfig): WeightedSpendQuery {
   const params: (string | number)[] = [
     config.CAMPAIGN_START.toISOString(),
@@ -124,12 +60,12 @@ weighted AS (
     COALESCE(qr.ref_count, 0) AS qualified_refs,
     eb.has_fc_bonus,
     LEAST(
-      1 + (COALESCE(qr.ref_count, 0) + eb.has_fc_bonus) * $4,
-      $5
+      1 + (COALESCE(qr.ref_count, 0) + eb.has_fc_bonus) * $4::NUMERIC,
+      $5::NUMERIC
     ) AS multiplier,
     eb.buy_volume * LEAST(
-      1 + (COALESCE(qr.ref_count, 0) + eb.has_fc_bonus) * $4,
-      $5
+      1 + (COALESCE(qr.ref_count, 0) + eb.has_fc_bonus) * $4::NUMERIC,
+      $5::NUMERIC
     ) AS weighted_spend
   FROM eligible_buys eb
   LEFT JOIN qualified_refs qr ON eb.address = qr.address

--- a/lib/airdrop/sql.ts
+++ b/lib/airdrop/sql.ts
@@ -5,6 +5,80 @@ export interface WeightedSpendQuery {
   params: (string | number)[];
 }
 
+export interface WeightedSpendRow {
+  address: string;
+  buy_volume: number;
+  qualified_refs: number;
+  has_fc_bonus: number;
+  multiplier: number;
+  weighted_spend: number;
+  community_total: number;
+}
+
+export interface Activation { address: string; activated_at: string | null; is_blacklisted: boolean; fid: number | null }
+export interface BuyPoint { address: string; action: string; points: number; created_at: string }
+export interface Referral { referrer_address: string; referred_address: string }
+
+export function computeWeightedSpend(
+  config: AirdropConfig,
+  activations: Activation[],
+  buyPoints: BuyPoint[],
+  referrals: Referral[],
+): WeightedSpendRow[] {
+  const eligible = activations
+    .filter(a => a.activated_at !== null && !a.is_blacklisted)
+    .map(a => ({ address: a.address, has_fc_bonus: a.fid !== null ? 1 : 0 }));
+
+  const eligibleSet = new Set(eligible.map(e => e.address));
+
+  const campStart = config.CAMPAIGN_START.getTime();
+  const campEnd = config.CAMPAIGN_END.getTime();
+
+  const buyMap = new Map<string, number>();
+  for (const p of buyPoints) {
+    if (p.action !== "buy") continue;
+    const t = new Date(p.created_at).getTime();
+    if (t < campStart || t > campEnd) continue;
+    buyMap.set(p.address, (buyMap.get(p.address) ?? 0) + p.points);
+  }
+
+  const eligibleBuys = eligible
+    .filter(e => (buyMap.get(e.address) ?? 0) > 0)
+    .map(e => ({ ...e, buy_volume: buyMap.get(e.address)! }));
+
+  const ebSet = new Set(eligibleBuys.map(e => e.address));
+
+  const refCounts = new Map<string, number>();
+  for (const r of referrals) {
+    if (!ebSet.has(r.referred_address)) continue;
+    const refBuyVol = buyMap.get(r.referred_address) ?? 0;
+    if (refBuyVol < config.MIN_REFERRAL_THRESHOLD) continue;
+    refCounts.set(r.referrer_address, (refCounts.get(r.referrer_address) ?? 0) + 1);
+  }
+
+  const rows = eligibleBuys.map(eb => {
+    const qr = refCounts.get(eb.address) ?? 0;
+    const multiplier = Math.min(
+      1 + (qr + eb.has_fc_bonus) * config.REFERRAL_MULTIPLIER_PER_REF,
+      config.REFERRAL_MULTIPLIER_CAP,
+    );
+    return {
+      address: eb.address,
+      buy_volume: eb.buy_volume,
+      qualified_refs: qr,
+      has_fc_bonus: eb.has_fc_bonus,
+      multiplier,
+      weighted_spend: eb.buy_volume * multiplier,
+      community_total: 0,
+    };
+  });
+
+  const total = rows.reduce((s, r) => s + r.weighted_spend, 0);
+  for (const r of rows) r.community_total = total;
+
+  return rows;
+}
+
 export function weightedSpendQuery(config: AirdropConfig): WeightedSpendQuery {
   const params: (string | number)[] = [
     config.CAMPAIGN_START.toISOString(),

--- a/lib/airdrop/sql.ts
+++ b/lib/airdrop/sql.ts
@@ -1,0 +1,75 @@
+import type { AirdropConfig } from "./config";
+
+export interface WeightedSpendQuery {
+  sql: string;
+  params: (string | number)[];
+}
+
+export function weightedSpendQuery(config: AirdropConfig): WeightedSpendQuery {
+  const params: (string | number)[] = [
+    config.CAMPAIGN_START.toISOString(),
+    config.CAMPAIGN_END.toISOString(),
+    config.MIN_REFERRAL_THRESHOLD,
+    config.REFERRAL_MULTIPLIER_PER_REF,
+    config.REFERRAL_MULTIPLIER_CAP,
+  ];
+
+  const sql = `
+WITH eligible AS (
+  SELECT
+    a.address,
+    CASE WHEN a.fid IS NOT NULL THEN 1 ELSE 0 END AS has_fc_bonus
+  FROM pl_activations a
+  WHERE a.activated_at IS NOT NULL
+    AND a.is_blacklisted = FALSE
+),
+buys AS (
+  SELECT p.address, COALESCE(SUM(p.points), 0) AS buy_volume
+  FROM pl_points p
+  WHERE p.action = 'buy'
+    AND p.created_at >= $1
+    AND p.created_at <= $2
+  GROUP BY p.address
+),
+eligible_buys AS (
+  SELECT e.address, e.has_fc_bonus, COALESCE(b.buy_volume, 0) AS buy_volume
+  FROM eligible e
+  JOIN buys b ON e.address = b.address
+),
+qualified_refs AS (
+  SELECT r.referrer_address AS address, COUNT(*) AS ref_count
+  FROM pl_referrals r
+  JOIN eligible_buys eb ON r.referred_address = eb.address
+  WHERE eb.buy_volume >= $3
+  GROUP BY r.referrer_address
+),
+weighted AS (
+  SELECT
+    eb.address,
+    eb.buy_volume,
+    COALESCE(qr.ref_count, 0) AS qualified_refs,
+    eb.has_fc_bonus,
+    LEAST(
+      1 + (COALESCE(qr.ref_count, 0) + eb.has_fc_bonus) * $4,
+      $5
+    ) AS multiplier,
+    eb.buy_volume * LEAST(
+      1 + (COALESCE(qr.ref_count, 0) + eb.has_fc_bonus) * $4,
+      $5
+    ) AS weighted_spend
+  FROM eligible_buys eb
+  LEFT JOIN qualified_refs qr ON eb.address = qr.address
+)
+SELECT
+  w.address,
+  w.buy_volume,
+  w.qualified_refs,
+  w.has_fc_bonus,
+  w.multiplier,
+  w.weighted_spend,
+  SUM(w.weighted_spend) OVER () AS community_total
+FROM weighted w
+`.trim();
+
+  return { sql, params };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink",
-  "version": "1.30.2",
+  "version": "1.30.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink",
-      "version": "1.30.2",
+      "version": "1.30.5",
       "workspaces": [
         "packages/*"
       ],
@@ -34,6 +34,7 @@
         "wagmi": "^2.19.5"
       },
       "devDependencies": {
+        "@electric-sql/pglite": "^0.4.6",
         "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
@@ -1699,6 +1700,13 @@
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
       }
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.6.tgz",
+      "integrity": "sha512-qmlmfN8UyKCee35qkV0r/MBp+Znl8FjBz7OpoglNvww3GJpw0/DLP0o1ZymvLNmcD5DTLOQdzKPtF8Hd3mdl1w==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "wagmi": "^2.19.5"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.4.6",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.30.4",
+  "version": "1.30.5",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary
- Creates `lib/airdrop/sql.ts` with `weightedSpendQuery(config)` — returns `{ sql, params }` for the weighted spend computation
- **Option A chosen** (TS SQL fragment per T0.1 locked decision): config values injected as params, no DB-side coupling to runtime mode
- SQL computes: `address, buy_volume, qualified_refs, has_fc_bonus, multiplier, weighted_spend, community_total`
- Eligibility filter built into CTEs: `activated_at IS NOT NULL AND is_blacklisted = FALSE`
- `qualified_refs` joins against same eligible cohort — referee must be activated, not blacklisted, AND have `buy_volume >= MIN_REFERRAL_THRESHOLD`
- Multiplier capped via `LEAST(1 + (refs + fc_bonus) * PER_REF, CAP)` using config params
- 10 unit tests covering params, filters, TEST vs PROD divergence, multiplier math + cap

## Config-source decision
**Option A: TS SQL fragment** — no DB schema changes, test/prod correctness automatic via parameterized config values. Per T0.1 locked decision.

## Version
1.30.4 → 1.30.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)