### PR TITLE
[#1244] Add /activation-status endpoint (public read)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink",
-  "version": "1.32.1",
+  "version": "1.32.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink",
-      "version": "1.32.1",
+      "version": "1.32.2",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.32.1",
+  "version": "1.32.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/api/airdrop/activation-status/route.test.ts
+++ b/src/app/api/airdrop/activation-status/route.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+
+const mockSingle = vi.fn();
+
+vi.mock("../../../../../lib/supabase", () => ({
+  createServerClient: () => ({
+    from: () => ({
+      select: () => ({ eq: () => ({ single: mockSingle }) }),
+    }),
+  }),
+}));
+
+import { GET } from "./route";
+
+function makeReq(address?: string) {
+  const url = address
+    ? `http://localhost/api/airdrop/activation-status?address=${address}`
+    : "http://localhost/api/airdrop/activation-status";
+  return new Request(url);
+}
+
+describe("GET /api/airdrop/activation-status", () => {
+  it("returns 4 fields for activated wallet", async () => {
+    mockSingle.mockResolvedValue({
+      data: {
+        x_handle_confirmed_at: "2026-07-01",
+        x_follow_at: "2026-07-02",
+        fc_verified_at: "2026-07-03",
+        activated_at: "2026-07-02",
+      },
+    });
+    const res = await GET(makeReq("0xabc"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.x_handle_confirmed_at).toBe("2026-07-01");
+    expect(data.activated_at).toBe("2026-07-02");
+  });
+
+  it("returns all-null for non-existent address", async () => {
+    mockSingle.mockResolvedValue({ data: null });
+    const res = await GET(makeReq("0xnonexistent"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({
+      x_handle_confirmed_at: null,
+      x_follow_at: null,
+      fc_verified_at: null,
+      activated_at: null,
+    });
+  });
+
+  it("includes Cache-Control: no-store header", async () => {
+    mockSingle.mockResolvedValue({ data: null });
+    const res = await GET(makeReq("0xabc"));
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("returns 400 when address is missing", async () => {
+    const res = await GET(makeReq());
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/airdrop/activation-status/route.ts
+++ b/src/app/api/airdrop/activation-status/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { createServerClient } from "../../../../../lib/supabase";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const address = searchParams.get("address")?.toLowerCase();
+
+  if (!address) {
+    return NextResponse.json({ error: "address parameter required" }, { status: 400 });
+  }
+
+  const supabase = createServerClient();
+  if (!supabase) {
+    return NextResponse.json({ error: "Supabase not configured" }, { status: 500 });
+  }
+
+  const { data } = await supabase
+    .from("pl_activations")
+    .select("x_handle_confirmed_at, x_follow_at, fc_verified_at, activated_at")
+    .eq("address", address)
+    .single();
+
+  return NextResponse.json(
+    {
+      x_handle_confirmed_at: data?.x_handle_confirmed_at ?? null,
+      x_follow_at: data?.x_follow_at ?? null,
+      fc_verified_at: data?.fc_verified_at ?? null,
+      activated_at: data?.activated_at ?? null,
+    },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}


### PR DESCRIPTION
## Summary
- `GET /api/airdrop/activation-status?address=X` — public read, no auth
- Returns `{ x_handle_confirmed_at, x_follow_at, fc_verified_at, activated_at }`
- All-null for non-existent address (not 404)
- `Cache-Control: no-store` for refresh-resume safety (R20 mitigation)
- No write side effects
- 4 tests: activated wallet, non-existent address, cache header, missing param

## Version
1.32.1 → 1.32.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)