### PR TITLE
[#1250] Replace /airdrop with 3-state machine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink",
-  "version": "1.34.1",
+  "version": "1.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink",
-      "version": "1.34.1",
+      "version": "1.35.0",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.34.1",
+  "version": "1.35.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/airdrop/AirdropStateMachine.tsx
+++ b/src/app/airdrop/AirdropStateMachine.tsx
@@ -8,6 +8,7 @@ import { ContributionPanel } from "../../components/airdrop/ContributionPanel";
 import { ReferralCTA } from "../../components/airdrop/ReferralCTA";
 import { MilestoneClimb } from "../../components/airdrop/MilestoneClimb";
 import { ClaimCard } from "../../components/airdrop/ClaimCard";
+import { ClaimPanel } from "../../components/airdrop/ClaimPanel";
 
 type AirdropState =
   | "paused"
@@ -16,26 +17,19 @@ type AirdropState =
   | "settlement-normal"
   | "settlement-final-burn";
 
+const IS_PAUSED = process.env.NEXT_PUBLIC_AIRDROP_PAUSED === "1";
+const MERKLE_CLAIM_ADDRESS = process.env.NEXT_PUBLIC_MERKLE_CLAIM_ADDRESS;
+const FINAL_BURN_TX = process.env.NEXT_PUBLIC_AIRDROP_FINAL_BURN_TX;
+const FINAL_STATE = process.env.NEXT_PUBLIC_AIRDROP_FINAL_STATE as "sub_bronze" | "zero_recipient" | undefined;
+
 function deriveState(
   isConnected: boolean,
   activatedAt: string | null,
 ): AirdropState {
-  if (process.env.NEXT_PUBLIC_AIRDROP_PAUSED === "1") {
-    return "paused";
-  }
-
-  if (process.env.NEXT_PUBLIC_MERKLE_CLAIM_ADDRESS) {
-    return "settlement-normal";
-  }
-
-  if (process.env.NEXT_PUBLIC_AIRDROP_FINAL_BURN_TX) {
-    return "settlement-final-burn";
-  }
-
-  if (!isConnected || !activatedAt) {
-    return "pre-activation";
-  }
-
+  if (IS_PAUSED) return "paused";
+  if (MERKLE_CLAIM_ADDRESS) return "settlement-normal";
+  if (FINAL_BURN_TX) return "settlement-final-burn";
+  if (!isConnected || !activatedAt) return "pre-activation";
   return "mining";
 }
 
@@ -45,6 +39,11 @@ export function AirdropStateMachine() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    if (IS_PAUSED || MERKLE_CLAIM_ADDRESS || FINAL_BURN_TX) {
+      setLoading(false);
+      return;
+    }
+
     if (!isConnected || !address) {
       setActivatedAt(null);
       setLoading(false);
@@ -63,12 +62,10 @@ export function AirdropStateMachine() {
 
   if (state === "paused") {
     return (
-      <>
-        <CampaignHero />
-        <div className="border-border mt-8 rounded border p-8 text-center">
-          <p className="text-muted text-sm">Campaign temporarily paused. Will resume shortly.</p>
-        </div>
-      </>
+      <div className="border-border mt-8 rounded border p-8 text-center">
+        <h2 className="text-accent mb-2 text-sm font-bold uppercase tracking-wider">Campaign Paused</h2>
+        <p className="text-muted text-sm">Campaign temporarily paused. Will resume shortly.</p>
+      </div>
     );
   }
 
@@ -77,19 +74,29 @@ export function AirdropStateMachine() {
       <>
         <CampaignHero />
         <div className="mt-8">
-          <ClaimCard mode="normal" />
+          <ClaimPanel />
         </div>
       </>
     );
   }
 
   if (state === "settlement-final-burn") {
-    const finalState = (process.env.NEXT_PUBLIC_AIRDROP_FINAL_STATE as "sub_bronze" | "zero_recipient" | undefined) ?? null;
     return (
       <>
         <CampaignHero />
         <div className="mt-8">
-          <ClaimCard mode="final-burn" finalState={finalState} />
+          <ClaimCard mode="final-burn" finalState={FINAL_STATE ?? null} />
+        </div>
+      </>
+    );
+  }
+
+  if (loading) {
+    return (
+      <>
+        <CampaignHero />
+        <div className="mt-8 text-center">
+          <p className="text-muted text-sm">Loading...</p>
         </div>
       </>
     );
@@ -107,18 +114,6 @@ export function AirdropStateMachine() {
           ) : (
             <ActivationFlow />
           )}
-        </div>
-      </>
-    );
-  }
-
-  // mining state
-  if (loading) {
-    return (
-      <>
-        <CampaignHero />
-        <div className="mt-8 text-center">
-          <p className="text-muted text-sm">Loading...</p>
         </div>
       </>
     );

--- a/src/app/airdrop/AirdropStateMachine.tsx
+++ b/src/app/airdrop/AirdropStateMachine.tsx
@@ -37,24 +37,21 @@ const needsFetch = !IS_PAUSED && !MERKLE_CLAIM_ADDRESS && !FINAL_BURN_TX;
 
 export function AirdropStateMachine() {
   const { address, isConnected } = useAccount();
-  const [activatedAt, setActivatedAt] = useState<string | null>(null);
-  const [loading, setLoading] = useState(needsFetch && isConnected);
+  const [fetchResult, setFetchResult] = useState<{ activatedAt: string | null; done: boolean }>({ activatedAt: null, done: !needsFetch });
 
   useEffect(() => {
-    if (!needsFetch || !isConnected || !address) {
-      setActivatedAt(null);
-      return;
-    }
+    if (!needsFetch || !isConnected || !address) return;
 
     let cancelled = false;
-    setLoading(true);
     fetch(`/api/airdrop/activation-status?address=${address.toLowerCase()}`)
       .then(res => res.json())
-      .then(data => { if (!cancelled) setActivatedAt(data.activated_at ?? null); })
-      .catch(() => { if (!cancelled) setActivatedAt(null); })
-      .finally(() => { if (!cancelled) setLoading(false); });
-    return () => { cancelled = true; };
+      .then(data => { if (!cancelled) setFetchResult({ activatedAt: data.activated_at ?? null, done: true }); })
+      .catch(() => { if (!cancelled) setFetchResult({ activatedAt: null, done: true }); });
+    return () => { cancelled = true; setFetchResult({ activatedAt: null, done: false }); };
   }, [isConnected, address]);
+
+  const activatedAt = (needsFetch && isConnected) ? fetchResult.activatedAt : null;
+  const loading = needsFetch && isConnected && !fetchResult.done;
 
   const state = deriveState(isConnected, activatedAt);
 

--- a/src/app/airdrop/AirdropStateMachine.tsx
+++ b/src/app/airdrop/AirdropStateMachine.tsx
@@ -33,29 +33,27 @@ function deriveState(
   return "mining";
 }
 
+const needsFetch = !IS_PAUSED && !MERKLE_CLAIM_ADDRESS && !FINAL_BURN_TX;
+
 export function AirdropStateMachine() {
   const { address, isConnected } = useAccount();
   const [activatedAt, setActivatedAt] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(needsFetch && isConnected);
 
   useEffect(() => {
-    if (IS_PAUSED || MERKLE_CLAIM_ADDRESS || FINAL_BURN_TX) {
-      setLoading(false);
-      return;
-    }
-
-    if (!isConnected || !address) {
+    if (!needsFetch || !isConnected || !address) {
       setActivatedAt(null);
-      setLoading(false);
       return;
     }
 
+    let cancelled = false;
     setLoading(true);
     fetch(`/api/airdrop/activation-status?address=${address.toLowerCase()}`)
       .then(res => res.json())
-      .then(data => setActivatedAt(data.activated_at ?? null))
-      .catch(() => setActivatedAt(null))
-      .finally(() => setLoading(false));
+      .then(data => { if (!cancelled) setActivatedAt(data.activated_at ?? null); })
+      .catch(() => { if (!cancelled) setActivatedAt(null); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
   }, [isConnected, address]);
 
   const state = deriveState(isConnected, activatedAt);

--- a/src/app/airdrop/AirdropStateMachine.tsx
+++ b/src/app/airdrop/AirdropStateMachine.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAccount } from "wagmi";
+import { CampaignHero } from "../../components/airdrop/CampaignHero";
+import { ActivationFlow } from "../../components/airdrop/ActivationFlow";
+import { ContributionPanel } from "../../components/airdrop/ContributionPanel";
+import { ReferralCTA } from "../../components/airdrop/ReferralCTA";
+import { MilestoneClimb } from "../../components/airdrop/MilestoneClimb";
+import { ClaimCard } from "../../components/airdrop/ClaimCard";
+
+type AirdropState =
+  | "paused"
+  | "pre-activation"
+  | "mining"
+  | "settlement-normal"
+  | "settlement-final-burn";
+
+function deriveState(
+  isConnected: boolean,
+  activatedAt: string | null,
+): AirdropState {
+  if (process.env.NEXT_PUBLIC_AIRDROP_PAUSED === "1") {
+    return "paused";
+  }
+
+  if (process.env.NEXT_PUBLIC_MERKLE_CLAIM_ADDRESS) {
+    return "settlement-normal";
+  }
+
+  if (process.env.NEXT_PUBLIC_AIRDROP_FINAL_BURN_TX) {
+    return "settlement-final-burn";
+  }
+
+  if (!isConnected || !activatedAt) {
+    return "pre-activation";
+  }
+
+  return "mining";
+}
+
+export function AirdropStateMachine() {
+  const { address, isConnected } = useAccount();
+  const [activatedAt, setActivatedAt] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!isConnected || !address) {
+      setActivatedAt(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    fetch(`/api/airdrop/activation-status?address=${address.toLowerCase()}`)
+      .then(res => res.json())
+      .then(data => setActivatedAt(data.activated_at ?? null))
+      .catch(() => setActivatedAt(null))
+      .finally(() => setLoading(false));
+  }, [isConnected, address]);
+
+  const state = deriveState(isConnected, activatedAt);
+
+  if (state === "paused") {
+    return (
+      <>
+        <CampaignHero />
+        <div className="border-border mt-8 rounded border p-8 text-center">
+          <p className="text-muted text-sm">Campaign temporarily paused. Will resume shortly.</p>
+        </div>
+      </>
+    );
+  }
+
+  if (state === "settlement-normal") {
+    return (
+      <>
+        <CampaignHero />
+        <div className="mt-8">
+          <ClaimCard mode="normal" />
+        </div>
+      </>
+    );
+  }
+
+  if (state === "settlement-final-burn") {
+    const finalState = (process.env.NEXT_PUBLIC_AIRDROP_FINAL_STATE as "sub_bronze" | "zero_recipient" | undefined) ?? null;
+    return (
+      <>
+        <CampaignHero />
+        <div className="mt-8">
+          <ClaimCard mode="final-burn" finalState={finalState} />
+        </div>
+      </>
+    );
+  }
+
+  if (state === "pre-activation") {
+    return (
+      <>
+        <CampaignHero />
+        <div className="mt-8">
+          {!isConnected ? (
+            <div className="border-border rounded border p-8 text-center">
+              <p className="text-muted text-sm">Connect your wallet to get started.</p>
+            </div>
+          ) : (
+            <ActivationFlow />
+          )}
+        </div>
+      </>
+    );
+  }
+
+  // mining state
+  if (loading) {
+    return (
+      <>
+        <CampaignHero />
+        <div className="mt-8 text-center">
+          <p className="text-muted text-sm">Loading...</p>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <CampaignHero />
+      <div className="mt-8 space-y-4">
+        <ContributionPanel />
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <ReferralCTA />
+          <MilestoneClimb />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/airdrop/page.tsx
+++ b/src/app/airdrop/page.tsx
@@ -1,37 +1,15 @@
 import type { Metadata } from "next";
-import { CampaignHero } from "../../components/airdrop/CampaignHero";
-import { UserPoints } from "../../components/airdrop/UserPoints";
-import { ClaimPanel } from "../../components/airdrop/ClaimPanel";
-import { Leaderboard } from "../../components/airdrop/Leaderboard";
-import { WeeklySnapshots } from "../../components/airdrop/WeeklySnapshots";
-import { getAirdropConfig } from "../../../lib/airdrop/config";
+import { AirdropStateMachine } from "./AirdropStateMachine";
 
 export const metadata: Metadata = {
-  title: "PLOT Big or Nothing Airdrop | PlotLink",
-  description: "Earn PL points through trading, writing, and referrals.",
+  title: "PlotLink Buy-Back Sprint | PlotLink",
+  description: "Activate, trade, and earn your share of the PLOT airdrop pool.",
 };
 
 export default function AirdropPage() {
-  const campaignEnded = new Date() > getAirdropConfig().CAMPAIGN_END;
-
   return (
     <main className="mx-auto max-w-[var(--page-max)] px-6 py-8 pb-24 lg:pb-8">
-      {/* Hero spans full width */}
-      <CampaignHero />
-
-      {/* 2-column grid below hero */}
-      <div className="mt-8 grid grid-cols-1 gap-4 lg:grid-cols-[1fr_340px]">
-        {/* Left column: user-specific */}
-        <div className="min-w-0 space-y-6">
-          {campaignEnded ? <ClaimPanel /> : <UserPoints />}
-        </div>
-
-        {/* Right column: global sections */}
-        <div className="space-y-6">
-          <Leaderboard />
-          <WeeklySnapshots />
-        </div>
-      </div>
+      <AirdropStateMachine />
     </main>
   );
 }

--- a/src/components/airdrop/ActivationFlow.tsx
+++ b/src/components/airdrop/ActivationFlow.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export function ActivationFlow() {
+  return (
+    <div className="border-border rounded border p-6">
+      <h2 className="text-accent mb-2 text-sm font-bold uppercase tracking-wider">Activate Your Wallet</h2>
+      <p className="text-muted text-xs">Connect your X account and follow PlotLink to activate.</p>
+    </div>
+  );
+}

--- a/src/components/airdrop/ClaimCard.tsx
+++ b/src/components/airdrop/ClaimCard.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+interface ClaimCardProps {
+  mode: "normal" | "final-burn";
+  finalState?: "sub_bronze" | "zero_recipient" | null;
+}
+
+export function ClaimCard({ mode, finalState }: ClaimCardProps) {
+  if (mode === "final-burn") {
+    const message = finalState === "sub_bronze"
+      ? "Campaign ended below Bronze milestone. All tokens burned."
+      : finalState === "zero_recipient"
+        ? "No eligible recipients. All tokens burned."
+        : "Campaign ended. Watch for Season 2.";
+
+    return (
+      <div className="border-border rounded border p-6">
+        <h2 className="text-accent mb-2 text-sm font-bold uppercase tracking-wider">Campaign Complete</h2>
+        <p className="text-muted text-xs">{message}</p>
+        {process.env.NEXT_PUBLIC_AIRDROP_FINAL_BURN_TX && (
+          <a
+            href={`https://basescan.org/tx/${process.env.NEXT_PUBLIC_AIRDROP_FINAL_BURN_TX}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent mt-2 inline-block text-xs underline"
+          >
+            View burn transaction
+          </a>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-border rounded border p-6">
+      <h2 className="text-accent mb-2 text-sm font-bold uppercase tracking-wider">Claim Your PLOT</h2>
+      <p className="text-muted text-xs">The campaign has ended. Claim your share below.</p>
+    </div>
+  );
+}

--- a/src/components/airdrop/ContributionPanel.tsx
+++ b/src/components/airdrop/ContributionPanel.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export function ContributionPanel() {
+  return (
+    <div className="border-border rounded border p-6">
+      <h2 className="text-accent mb-2 text-sm font-bold uppercase tracking-wider">Your Contribution</h2>
+      <p className="text-muted text-xs">Buy PLOT tokens to earn your share of the airdrop pool.</p>
+    </div>
+  );
+}

--- a/src/components/airdrop/MilestoneClimb.tsx
+++ b/src/components/airdrop/MilestoneClimb.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export function MilestoneClimb() {
+  return (
+    <div className="border-border rounded border p-4">
+      <h3 className="text-accent mb-1 text-xs font-bold uppercase tracking-wider">Milestone Climb</h3>
+      <p className="text-muted text-xs">Track community progress toward milestone tiers.</p>
+    </div>
+  );
+}

--- a/src/components/airdrop/ReferralCTA.tsx
+++ b/src/components/airdrop/ReferralCTA.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export function ReferralCTA() {
+  return (
+    <div className="border-border rounded border p-4">
+      <h3 className="text-accent mb-1 text-xs font-bold uppercase tracking-wider">Invite Friends</h3>
+      <p className="text-muted text-xs">Share your referral link to boost your multiplier.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Replaces v1's 2-column grid with a 3-state machine:

- **Paused**: `NEXT_PUBLIC_AIRDROP_PAUSED=1` → maintenance message (highest precedence)
- **Pre-activation**: not connected or not activated → hero + "Connect wallet" / ActivationFlow
- **Mining**: activated + campaign active → ContributionPanel + ReferralCTA + MilestoneClimb
- **Settlement-Normal**: `NEXT_PUBLIC_MERKLE_CLAIM_ADDRESS` set → ClaimCard with claim button
- **Settlement-FinalBurn**: `NEXT_PUBLIC_AIRDROP_FINAL_BURN_TX` set → ClaimCard with burn tx link

State derived from env vars + wallet connection + `/api/airdrop/activation-status` API.

## New components (stubs for T3.2-T3.8)
- `ActivationFlow.tsx`, `ContributionPanel.tsx`, `ReferralCTA.tsx`, `MilestoneClimb.tsx`, `ClaimCard.tsx`

## Removed from layout
- `Leaderboard`, `WeeklySnapshots` (v1 components)

## Version
1.34.1 → 1.35.0 (feature)

Closes #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)