### PR TITLE
[#1257] Storyline banner + ref preservation + browse CTA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink",
-  "version": "1.40.1",
+  "version": "1.40.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink",
-      "version": "1.40.1",
+      "version": "1.40.2",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.40.1",
+  "version": "1.40.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/airdrop/AirdropStateMachine.tsx
+++ b/src/app/airdrop/AirdropStateMachine.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useAccount } from "wagmi";
+import Link from "next/link";
 import { CampaignHero } from "../../components/airdrop/CampaignHero";
 import { ActivationFlow } from "../../components/airdrop/ActivationFlow";
 import { ContributionPanel } from "../../components/airdrop/ContributionPanel";
@@ -107,8 +108,11 @@ export function AirdropStateMachine() {
         <CampaignHero />
         <div className="mt-8 space-y-4">
           {!isConnected ? (
-            <div className="border-border rounded border p-8 text-center">
+            <div className="border-border rounded border p-8 text-center space-y-3">
               <p className="text-muted text-sm">Connect your wallet to get started.</p>
+              <Link href="/" className="text-accent text-xs hover:underline">
+                Browse storylines &rarr;
+              </Link>
             </div>
           ) : (
             <ActivationFlow onActivated={onActivated} />

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -9,6 +9,7 @@ import { DonateWidget } from "../../../components/DonateWidget";
 import { RatingWidget } from "../../../components/RatingWidget";
 import { RatingSummary } from "../../../components/RatingSummary";
 import { ShareButtons } from "../../../components/ShareButtons";
+import { StorylineSprintBanner } from "../../../components/airdrop/StorylineSprintBanner";
 import { StoryContent } from "../../../components/StoryContent";
 import { ReadingModeWrapper } from "../../../components/ReadingModeWrapper";
 import { getTokenPrice, getCreatorEarnings, type TokenPriceInfo } from "../../../../lib/price";
@@ -238,6 +239,8 @@ export default async function StoryPage({ params }: { params: Params }) {
           <div className="mt-6">
             <ShareButtons storylineId={id} title={sl.title} />
           </div>
+
+          <StorylineSprintBanner />
         </main>
 
         {/* Sidebar — desktop only */}

--- a/src/components/airdrop/StorylineSprintBanner.tsx
+++ b/src/components/airdrop/StorylineSprintBanner.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+
+const DISMISS_KEY = "plotlink_sprint_banner_dismissed";
+
+export function StorylineSprintBanner() {
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    setDismissed(localStorage.getItem(DISMISS_KEY) === "1");
+  }, []);
+
+  if (dismissed) return null;
+
+  const handleDismiss = () => {
+    localStorage.setItem(DISMISS_KEY, "1");
+    setDismissed(true);
+  };
+
+  return (
+    <div className="border-accent/30 bg-accent/5 mt-8 flex items-center gap-3 rounded border px-4 py-3">
+      <div className="flex-1 text-xs">
+        <span className="text-accent font-bold">Buy-Back Sprint</span>
+        <span className="text-muted"> is live. Activate your wallet and earn PLOT.</span>
+      </div>
+      <Link
+        href="/airdrop"
+        className="bg-accent text-background shrink-0 rounded px-3 py-1.5 text-xs font-medium transition-opacity hover:opacity-80"
+      >
+        Join
+      </Link>
+      <button
+        onClick={handleDismiss}
+        className="text-muted hover:text-foreground shrink-0 text-sm transition-colors"
+        title="Dismiss"
+      >
+        &#x2715;
+      </button>
+    </div>
+  );
+}

--- a/src/components/airdrop/StorylineSprintBanner.tsx
+++ b/src/components/airdrop/StorylineSprintBanner.tsx
@@ -5,11 +5,22 @@ import Link from "next/link";
 
 const DISMISS_KEY = "plotlink_sprint_banner_dismissed";
 
+function formatMcap(n: number): string {
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(0)}K`;
+  return `$${n}`;
+}
+
 export function StorylineSprintBanner() {
   const [dismissed, setDismissed] = useState(true);
+  const [status, setStatus] = useState<{ timeElapsedPercent: number; currentFdv: number } | null>(null);
 
   useEffect(() => {
     setDismissed(localStorage.getItem(DISMISS_KEY) === "1");
+    fetch("/api/airdrop/status")
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { if (d) setStatus({ timeElapsedPercent: d.timeElapsedPercent, currentFdv: d.currentFdv }); })
+      .catch(() => {});
   }, []);
 
   if (dismissed) return null;
@@ -19,11 +30,15 @@ export function StorylineSprintBanner() {
     setDismissed(true);
   };
 
+  const dayNum = status ? Math.ceil(status.timeElapsedPercent / 100 * 90) || 1 : null;
+
   return (
     <div className="border-accent/30 bg-accent/5 mt-8 flex items-center gap-3 rounded border px-4 py-3">
       <div className="flex-1 text-xs">
         <span className="text-accent font-bold">Buy-Back Sprint</span>
-        <span className="text-muted"> is live. Activate your wallet and earn PLOT.</span>
+        {dayNum && status && (
+          <span className="text-muted"> · Day {dayNum}/90 · FDV {formatMcap(status.currentFdv)}</span>
+        )}
       </div>
       <Link
         href="/airdrop"


### PR DESCRIPTION
## Summary
- **StorylineSprintBanner**: dismissible bottom banner on storyline pages — "Buy-Back Sprint is live" with Join CTA to /airdrop. Dismiss stored in localStorage.
- **Ref preservation**: `ShareButtons` already appends `?ref=CODE` to share URLs (verified, no change needed)
- **Browse storylines CTA**: "Browse storylines →" link to `/` (T0.1 decision) in pre-activation state on /airdrop

## Version
1.40.1 → 1.40.2

Closes #1257

🤖 Generated with [Claude Code](https://claude.com/claude-code)