### PR TITLE
[#1269] Fix og:url on story pages + OG image cache headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink",
-  "version": "1.40.2",
+  "version": "1.40.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink",
-      "version": "1.40.2",
+      "version": "1.40.3",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.40.2",
+  "version": "1.40.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/story/[storylineId]/og/route.tsx
+++ b/src/app/story/[storylineId]/og/route.tsx
@@ -197,6 +197,9 @@ export async function GET(
       width: 1200,
       height: 630,
       fonts,
+      headers: {
+        "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+      },
     },
   );
 }

--- a/src/app/story/[storylineId]/page.tsx
+++ b/src/app/story/[storylineId]/page.tsx
@@ -105,6 +105,7 @@ export async function generateMetadata({
     title: `${sl.title} — PlotLink`,
     description,
     openGraph: {
+      url: storyUrl,
       title: sl.title,
       description,
       images: [{ url: ogImageUrl, width: 1200, height: 630 }],


### PR DESCRIPTION
## Summary
- **Fix**: Add `url: storyUrl` to `openGraph` metadata in story page `generateMetadata` — fixes missing `og:url` that caused broken previews in social validators
- **Cache**: Add `Cache-Control: public, s-maxage=3600, stale-while-revalidate=86400` to OG image route to reduce cold-start timeouts
- **Verified**: `storyUrl` is canonical (no `?ref=` query params), awaits already parallelized via `Promise.all`, `metadataBase` uses `NEXT_PUBLIC_APP_URL`

## OG tag checklist
- og:url → `https://plotlink.xyz/story/{id}` (no ref param)
- og:image → `https://plotlink.xyz/story/{id}/og` (200 + image/png)
- og:image:width: 1200, og:image:height: 630
- twitter:card: summary_large_image
- metadataBase: `NEXT_PUBLIC_APP_URL` (production = `https://plotlink.xyz`)

## Version
1.40.2 → 1.40.3

Closes #1269

🤖 Generated with [Claude Code](https://claude.com/claude-code)