### PR TITLE
[#1270] Redesign story OG image to match StoryCard design

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink",
-  "version": "1.40.3",
+  "version": "1.40.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink",
-      "version": "1.40.3",
+      "version": "1.40.4",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.40.3",
+  "version": "1.40.4",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/story/[storylineId]/og/route.tsx
+++ b/src/app/story/[storylineId]/og/route.tsx
@@ -8,6 +8,7 @@ import { formatPrice } from "../../../../../lib/format";
 import { truncateAddress } from "../../../../../lib/utils";
 import { getPlotUsdPrice, formatUsdValue } from "../../../../../lib/usd-price";
 import { getCoverUrl } from "../../../../../lib/cover";
+import { getStoryStatus } from "../../../../../lib/story-status";
 
 export const runtime = "nodejs";
 
@@ -67,7 +68,8 @@ export async function GET(
   const titleDisplay = sl.title.length > 60 ? `${sl.title.slice(0, 57)}...` : sl.title;
   const isAi = sl.writer_type === 1;
   const authorName = isAi ? "P7 AI Writer" : (fcProfile ? `@${fcProfile.username}` : truncateAddress(sl.writer_address));
-  const status = sl.sunset ? "Complete" : "Ongoing";
+  const storyStatus = getStoryStatus(sl);
+  const statusLabel = storyStatus === "completed" ? "Complete" : storyStatus === "active" ? "Ongoing" : null;
   const coverUrl = getCoverUrl(sl.cover_cid);
   const variants: FallbackVariant[] = ["A", "B", "C", "D"];
   const variant = variants[((id * 2654435761) >>> 0) % 4];
@@ -95,11 +97,11 @@ export async function GET(
     letterSpacing: "0.08em",
   });
 
-  const badges = (
-    <div style={{ display: "flex", flexWrap: "wrap", gap: "6px", marginBottom: "12px" }}>
+  const badgeElements = (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: "6px" }}>
       {sl.genre && <span style={badgeStyle(BADGE_COLORS.genre)}>{sl.genre}</span>}
       {isAi && <span style={badgeStyle(BADGE_COLORS.ai)}>AI Writer</span>}
-      <span style={badgeStyle(BADGE_COLORS.status)}>{status}</span>
+      {statusLabel && <span style={badgeStyle(BADGE_COLORS.status)}>{statusLabel}</span>}
       {sl.content_type === "cartoon" && <span style={badgeStyle(BADGE_COLORS.cartoon)}>Cartoon</span>}
       {sl.is_nsfw && <span style={badgeStyle(BADGE_COLORS.nsfw)}>18+</span>}
     </div>
@@ -109,18 +111,14 @@ export async function GET(
     <div style={{ width: "460px", height: "100%", display: "flex", position: "relative", overflow: "hidden" }}>
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img src={coverUrl} alt="" style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", objectFit: "cover" }} />
-      <div style={{ position: "absolute", top: "16px", left: "16px", display: "flex", flexWrap: "wrap", gap: "6px" }}>
-        {sl.genre && <span style={badgeStyle(BADGE_COLORS.genre)}>{sl.genre}</span>}
-        {isAi && <span style={badgeStyle(BADGE_COLORS.ai)}>AI Writer</span>}
-        <span style={badgeStyle(BADGE_COLORS.status)}>{status}</span>
+      <div style={{ position: "absolute", top: "16px", left: "16px", display: "flex" }}>
+        {badgeElements}
       </div>
     </div>
   ) : (
     <div style={{ width: "460px", height: "100%", display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center", background: FALLBACK_HEX[variant].bg, position: "relative" }}>
-      <div style={{ position: "absolute", top: "16px", left: "16px", display: "flex", flexWrap: "wrap", gap: "6px" }}>
-        {sl.genre && <span style={badgeStyle(BADGE_COLORS.genre)}>{sl.genre}</span>}
-        {isAi && <span style={badgeStyle(BADGE_COLORS.ai)}>AI Writer</span>}
-        <span style={badgeStyle(BADGE_COLORS.status)}>{status}</span>
+      <div style={{ position: "absolute", top: "16px", left: "16px", display: "flex" }}>
+        {badgeElements}
       </div>
       <div style={{ width: "50px", height: "1px", background: "rgba(0,0,0,0.15)", display: "flex" }} />
       <div style={{ fontSize: "28px", fontWeight: 500, color: "#4a4038", marginTop: "16px", textAlign: "center", padding: "0 32px", display: "flex", maxWidth: "400px" }}>
@@ -136,7 +134,7 @@ export async function GET(
         {coverSection}
 
         <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "center", padding: "48px 48px 48px 40px" }}>
-          {coverUrl && badges}
+          {!coverUrl && <div style={{ marginBottom: "12px", display: "flex" }}>{badgeElements}</div>}
 
           <div style={{ fontSize: titleDisplay.length > 35 ? "32px" : "38px", fontWeight: 500, color: "#1a1a1a", lineHeight: 1.25, display: "flex", marginBottom: "12px" }}>
             {titleDisplay}

--- a/src/app/story/[storylineId]/og/route.tsx
+++ b/src/app/story/[storylineId]/og/route.tsx
@@ -4,7 +4,6 @@ import { createServerClient, type Storyline } from "../../../../../lib/supabase"
 import { getTokenTVL } from "../../../../../lib/price";
 import { getFarcasterProfile } from "../../../../../lib/actions";
 import { RESERVE_LABEL, STORY_FACTORY } from "../../../../../lib/contracts/constants";
-import { formatPrice } from "../../../../../lib/format";
 import { truncateAddress } from "../../../../../lib/utils";
 import { getPlotUsdPrice, formatUsdValue } from "../../../../../lib/usd-price";
 import { getCoverUrl } from "../../../../../lib/cover";
@@ -134,7 +133,6 @@ export async function GET(
         {coverSection}
 
         <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "center", padding: "48px 48px 48px 40px" }}>
-          {!coverUrl && <div style={{ marginBottom: "12px", display: "flex" }}>{badgeElements}</div>}
 
           <div style={{ fontSize: titleDisplay.length > 35 ? "32px" : "38px", fontWeight: 500, color: "#1a1a1a", lineHeight: 1.25, display: "flex", marginBottom: "12px" }}>
             {titleDisplay}

--- a/src/app/story/[storylineId]/og/route.tsx
+++ b/src/app/story/[storylineId]/og/route.tsx
@@ -11,21 +11,31 @@ import { getCoverUrl } from "../../../../../lib/cover";
 
 export const runtime = "nodejs";
 
+// oklch → hex translations for Satori (oklch not supported)
+const FALLBACK_HEX = {
+  A: { bg: "linear-gradient(160deg, #ede5d9 0%, #e4d9cc 100%)", accent: "rgba(180,140,110,0.15)" },
+  B: { bg: "linear-gradient(170deg, #dce8df 0%, #cddcd4 100%)", accent: "rgba(100,160,130,0.12)" },
+  C: { bg: "linear-gradient(180deg, #e0dce8 0%, #d3cde0 100%)", accent: "rgba(130,110,170,0.10)" },
+  D: { bg: "linear-gradient(175deg, #ede5d9 0%, #e2d5c5 100%)", accent: "rgba(180,140,100,0.12)" },
+} as const;
+type FallbackVariant = keyof typeof FALLBACK_HEX;
+
+const BADGE_COLORS = {
+  genre: { bg: "rgba(0,0,0,0.55)", text: "rgba(255,255,255,0.9)" },
+  ai: { bg: "rgba(90,50,160,0.7)", text: "rgba(255,255,255,0.9)" },
+  status: { bg: "rgba(0,0,0,0.45)", text: "rgba(255,255,255,0.85)" },
+  nsfw: { bg: "rgba(200,50,50,0.7)", text: "rgba(255,255,255,0.9)" },
+  cartoon: { bg: "rgba(50,120,180,0.6)", text: "rgba(255,255,255,0.9)" },
+};
+
 async function loadFont(): Promise<ArrayBuffer | null> {
   try {
-    const res = await fetch(
-      "https://fonts.googleapis.com/css2?family=Newsreader:wght@500&display=swap",
-    );
+    const res = await fetch("https://fonts.googleapis.com/css2?family=Newsreader:wght@500&display=swap");
     const css = await res.text();
-    const match =
-      css.match(/src:\s*url\(([^)]+)\)\s*format\(['"]truetype['"]\)/) ??
-      css.match(/src:\s*url\(([^)]+)\)\s*format\(['"]woff['"]\)/);
+    const match = css.match(/src:\s*url\(([^)]+)\)\s*format\(['"]truetype['"]\)/) ?? css.match(/src:\s*url\(([^)]+)\)\s*format\(['"]woff['"]\)/);
     if (!match?.[1]) return null;
-    const fontRes = await fetch(match[1]);
-    return fontRes.arrayBuffer();
-  } catch {
-    return null;
-  }
+    return (await fetch(match[1])).arrayBuffer();
+  } catch { return null; }
 }
 
 export async function GET(
@@ -34,162 +44,122 @@ export async function GET(
 ) {
   const { storylineId } = await params;
   const id = Number(storylineId);
-
-  if (isNaN(id) || id <= 0) {
-    return new Response("Invalid storyline ID", { status: 400 });
-  }
+  if (isNaN(id) || id <= 0) return new Response("Invalid storyline ID", { status: 400 });
 
   const supabase = createServerClient();
-  if (!supabase) {
-    return new Response("Database unavailable", { status: 503 });
-  }
+  if (!supabase) return new Response("Database unavailable", { status: 503 });
 
   const { data: storyline } = await supabase
-    .from("storylines")
-    .select("*")
-    .eq("storyline_id", id)
-    .eq("hidden", false)
-    .eq("contract_address", STORY_FACTORY.toLowerCase())
-    .single();
+    .from("storylines").select("*")
+    .eq("storyline_id", id).eq("hidden", false)
+    .eq("contract_address", STORY_FACTORY.toLowerCase()).single();
 
-  if (!storyline) {
-    return new Response("Storyline not found", { status: 404 });
-  }
-
+  if (!storyline) return new Response("Storyline not found", { status: 404 });
   const sl = storyline as Storyline;
 
-  const [tvlInfo, plotUsd, farcasterProfile, fontData] = await Promise.all([
+  const [tvlInfo, plotUsd, fcProfile, fontData] = await Promise.all([
     sl.token_address ? getTokenTVL(sl.token_address as Address) : null,
     getPlotUsdPrice(),
     getFarcasterProfile(sl.writer_address).catch(() => null),
     loadFont(),
   ]);
 
-  const reserveLabel = RESERVE_LABEL;
-  const authorName = farcasterProfile
-    ? `@${farcasterProfile.username}`
-    : truncateAddress(sl.writer_address);
-  const plotLabel = `${sl.plot_count} ${sl.plot_count === 1 ? "plot" : "plots"}`;
-  const titleDisplay =
-    sl.title.length > 50 ? `${sl.title.slice(0, 47)}...` : sl.title;
-
-  // TVL display with USD
-  let tvlDisplay: string | null = null;
-  if (tvlInfo) {
-    const tvlNum = parseFloat(tvlInfo.tvl);
-    tvlDisplay = `TVL: ${formatPrice(tvlInfo.tvl)} ${reserveLabel}`;
-    if (plotUsd && tvlNum > 0) {
-      tvlDisplay += ` (${formatUsdValue(tvlNum * plotUsd)})`;
-    }
-  }
-
-  type FallbackVariant = "A" | "B" | "C" | "D";
+  const titleDisplay = sl.title.length > 60 ? `${sl.title.slice(0, 57)}...` : sl.title;
+  const isAi = sl.writer_type === 1;
+  const authorName = isAi ? "P7 AI Writer" : (fcProfile ? `@${fcProfile.username}` : truncateAddress(sl.writer_address));
+  const status = sl.sunset ? "Complete" : "Ongoing";
+  const coverUrl = getCoverUrl(sl.cover_cid);
   const variants: FallbackVariant[] = ["A", "B", "C", "D"];
   const variant = variants[((id * 2654435761) >>> 0) % 4];
 
-  const FALLBACK_BG: Record<FallbackVariant, string> = {
-    A: "radial-gradient(ellipse at 30% 20%, #3a2e24, #261f19)",
-    B: "repeating-linear-gradient(135deg, #2a2420 0px, #2a2420 8px, #332c26 8px, #332c26 16px)",
-    C: "conic-gradient(from 180deg at 50% 50%, #2e3540, #2a2420, #2e3540)",
-    D: "#302820",
-  };
+  let tvlUsd = "";
+  let tvlPlot = "";
+  if (tvlInfo) {
+    const tvlNum = parseFloat(tvlInfo.tvl);
+    if (plotUsd && tvlNum > 0) tvlUsd = formatUsdValue(tvlNum * plotUsd);
+    const k = tvlNum >= 1000 ? `${(tvlNum / 1000).toFixed(1)}k` : tvlNum.toFixed(1);
+    tvlPlot = `${k} ${RESERVE_LABEL}`;
+  }
 
-  const coverUrl = getCoverUrl(sl.cover_cid);
+  const fonts = fontData ? [{ name: "Newsreader", data: fontData, weight: 500 as const }] : [];
 
-  const fonts = fontData
-    ? [{ name: "Newsreader", data: fontData, weight: 500 as const }]
-    : [];
+  const badgeStyle = (colors: { bg: string; text: string }) => ({
+    display: "flex" as const,
+    fontSize: "11px",
+    fontWeight: 600,
+    color: colors.text,
+    backgroundColor: colors.bg,
+    borderRadius: "4px",
+    padding: "3px 8px",
+    textTransform: "uppercase" as const,
+    letterSpacing: "0.08em",
+  });
 
-  const cardContent = coverUrl ? (
-    <div
-      style={{
-        width: "380px",
-        height: "520px",
-        display: "flex",
-        flexDirection: "column",
-        borderRadius: "12px",
-        position: "relative",
-        overflow: "hidden",
-      }}
-    >
+  const badges = (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: "6px", marginBottom: "12px" }}>
+      {sl.genre && <span style={badgeStyle(BADGE_COLORS.genre)}>{sl.genre}</span>}
+      {isAi && <span style={badgeStyle(BADGE_COLORS.ai)}>AI Writer</span>}
+      <span style={badgeStyle(BADGE_COLORS.status)}>{status}</span>
+      {sl.content_type === "cartoon" && <span style={badgeStyle(BADGE_COLORS.cartoon)}>Cartoon</span>}
+      {sl.is_nsfw && <span style={badgeStyle(BADGE_COLORS.nsfw)}>18+</span>}
+    </div>
+  );
+
+  const coverSection = coverUrl ? (
+    <div style={{ width: "460px", height: "100%", display: "flex", position: "relative", overflow: "hidden" }}>
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img src={coverUrl} alt="" style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", objectFit: "cover" }} />
-      <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, background: "linear-gradient(to bottom, transparent, rgba(250,248,245,0.85))", padding: "60px 28px 28px", display: "flex", flexDirection: "column", gap: "6px" }}>
-        {sl.genre && (
-          <div style={{ display: "flex", fontSize: "11px", color: "#6a5e50", textTransform: "uppercase", letterSpacing: "0.1em" }}>{sl.genre}</div>
-        )}
-        <div style={{ fontSize: titleDisplay.length > 30 ? "28px" : "34px", fontWeight: 500, color: "#1a1a1a", lineHeight: 1.25, display: "flex" }}>{titleDisplay}</div>
-        <div style={{ display: "flex", fontSize: "14px", color: "#8a7e70" }}>{plotLabel}</div>
-        {tvlDisplay && (
-          <div style={{ display: "flex", fontWeight: 500, color: "#b05c3a", fontSize: "14px" }}>{tvlDisplay}</div>
-        )}
+      <div style={{ position: "absolute", top: "16px", left: "16px", display: "flex", flexWrap: "wrap", gap: "6px" }}>
+        {sl.genre && <span style={badgeStyle(BADGE_COLORS.genre)}>{sl.genre}</span>}
+        {isAi && <span style={badgeStyle(BADGE_COLORS.ai)}>AI Writer</span>}
+        <span style={badgeStyle(BADGE_COLORS.status)}>{status}</span>
       </div>
     </div>
   ) : (
-    <div
-      style={{
-        width: "380px",
-        height: "520px",
-        display: "flex",
-        flexDirection: "column",
-        background: FALLBACK_BG[variant],
-        borderRadius: "12px",
-        border: "1px solid #3a332c",
-        position: "relative",
-        overflow: "hidden",
-      }}
-    >
-      <div style={{ display: "flex", height: "3px", background: "linear-gradient(90deg, #b05c3a, #b05c3a80, transparent)" }} />
-      <div style={{ display: "flex", padding: "28px 28px 0" }}>
-        {sl.genre ? (
-          <div style={{ display: "flex", fontSize: "12px", color: "#b05c3a", backgroundColor: "rgba(176, 92, 58, 0.12)", borderRadius: "4px", padding: "4px 12px", textTransform: "uppercase", letterSpacing: "0.12em", fontWeight: 500 }}>{sl.genre}</div>
-        ) : (
-          <div style={{ display: "flex" }} />
-        )}
+    <div style={{ width: "460px", height: "100%", display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center", background: FALLBACK_HEX[variant].bg, position: "relative" }}>
+      <div style={{ position: "absolute", top: "16px", left: "16px", display: "flex", flexWrap: "wrap", gap: "6px" }}>
+        {sl.genre && <span style={badgeStyle(BADGE_COLORS.genre)}>{sl.genre}</span>}
+        {isAi && <span style={badgeStyle(BADGE_COLORS.ai)}>AI Writer</span>}
+        <span style={badgeStyle(BADGE_COLORS.status)}>{status}</span>
       </div>
-      <div style={{ display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center", flex: 1, padding: "0 32px", textAlign: "center" }}>
-        <div style={{ width: "40px", height: "1px", background: "rgba(176, 92, 58, 0.4)", marginBottom: "20px", display: "flex" }} />
-        <div style={{ fontSize: titleDisplay.length > 30 ? "30px" : "36px", fontWeight: 500, color: "#ede4d6", lineHeight: 1.3, display: "flex", textAlign: "center", justifyContent: "center", maxWidth: "340px" }}>{titleDisplay}</div>
-        <div style={{ width: "40px", height: "1px", background: "rgba(176, 92, 58, 0.4)", marginTop: "20px", display: "flex" }} />
+      <div style={{ width: "50px", height: "1px", background: "rgba(0,0,0,0.15)", display: "flex" }} />
+      <div style={{ fontSize: "28px", fontWeight: 500, color: "#4a4038", marginTop: "16px", textAlign: "center", padding: "0 32px", display: "flex", maxWidth: "400px" }}>
+        {titleDisplay}
       </div>
-      <div style={{ display: "flex", flexDirection: "column", gap: "6px", padding: "0 28px 28px", fontSize: "14px", color: "#8a7e70" }}>
-        <div style={{ display: "flex" }}>{plotLabel}</div>
-        {tvlDisplay && (
-          <div style={{ display: "flex", fontWeight: 500, color: "#b05c3a" }}>{tvlDisplay}</div>
-        )}
-      </div>
+      <div style={{ width: "50px", height: "1px", background: "rgba(0,0,0,0.15)", marginTop: "16px", display: "flex" }} />
     </div>
   );
 
   return new ImageResponse(
     (
-      <div
-        style={{
-          width: "100%",
-          height: "100%",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-          backgroundColor: "#faf8f5",
-          fontFamily: fontData ? "Newsreader" : "Georgia, serif",
-        }}
-      >
-        {cardContent}
+      <div style={{ width: "100%", height: "100%", display: "flex", backgroundColor: "#faf8f5", fontFamily: fontData ? "Newsreader" : "Georgia, serif" }}>
+        {coverSection}
 
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            width: "380px",
-            marginTop: "20px",
-            fontSize: "15px",
-            color: "#6a5e50",
-          }}
-        >
-          <div style={{ display: "flex" }}>by {authorName}</div>
-          <div style={{ display: "flex", color: "#4a4038" }}>plotlink.xyz</div>
+        <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "center", padding: "48px 48px 48px 40px" }}>
+          {coverUrl && badges}
+
+          <div style={{ fontSize: titleDisplay.length > 35 ? "32px" : "38px", fontWeight: 500, color: "#1a1a1a", lineHeight: 1.25, display: "flex", marginBottom: "12px" }}>
+            {titleDisplay}
+          </div>
+
+          <div style={{ display: "flex", fontSize: "16px", color: "#8a7e70", marginBottom: "20px" }}>
+            by {authorName}
+          </div>
+
+          <div style={{ display: "flex", fontSize: "14px", color: "#8a7e70", marginBottom: "8px" }}>
+            {sl.plot_count} {sl.plot_count === 1 ? "plot" : "plots"}
+          </div>
+
+          {tvlUsd && (
+            <div style={{ display: "flex", alignItems: "baseline", gap: "6px", fontSize: "16px" }}>
+              <span style={{ color: "#c04030", fontWeight: 600 }}>TVL: {tvlUsd}</span>
+              {tvlPlot && <span style={{ color: "#8a7e70", fontSize: "13px" }}>({tvlPlot})</span>}
+            </div>
+          )}
+
+          <div style={{ display: "flex", marginTop: "auto", fontSize: "13px", color: "#a09080" }}>
+            plotlink.xyz
+          </div>
         </div>
       </div>
     ),
@@ -197,9 +167,7 @@ export async function GET(
       width: 1200,
       height: 630,
       fonts,
-      headers: {
-        "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
-      },
+      headers: { "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400" },
     },
   );
 }


### PR DESCRIPTION
## Summary
Full redesign of story OG image to match StoryCard thumbnail aesthetic:

- **Layout**: Horizontal 1200x630 — cover (460px left) + info panel (right)
- **Badges**: genre, AI Writer, Ongoing/Complete, Cartoon, 18+ — oklch→hex color translations
- **Cover**: portrait image on left, or FALLBACK_STYLES A/B/C/D gradient (ported to hex from StoryCard)
- **TVL**: matches StoryCardTVL format — red `TVL: $X.XX` + muted `(Y.Yk PLOT)`
- **Author**: "P7 AI Writer" for AI-written, @username or truncated address for user-written (text-only prefix, safest for Satori)
- **Watermark**: `plotlink.xyz` bottom-right

### Satori constraints
All inline styles, `display: flex` on every container, no oklch/backdrop-blur/Tailwind/line-clamp. JS-side text truncation.

### Performance
Parallelized fetches (cover + TVL + FC + font) via Promise.all. Cache headers preserved from T7.1.

## Version
1.40.3 → 1.40.4

Closes #1270

🤖 Generated with [Claude Code](https://claude.com/claude-code)