### PR TITLE
[#1306] Hero copy + rising-curve MilestoneClimb per final.html

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink",
-  "version": "1.40.5",
+  "version": "1.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink",
-      "version": "1.40.5",
+      "version": "1.41.0",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.40.5",
+  "version": "1.41.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/app/airdrop/AirdropStateMachine.tsx
+++ b/src/app/airdrop/AirdropStateMachine.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useAccount } from "wagmi";
-import Link from "next/link";
+import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { CampaignHero } from "../../components/airdrop/CampaignHero";
 import { ActivationFlow } from "../../components/airdrop/ActivationFlow";
 import { ContributionPanel } from "../../components/airdrop/ContributionPanel";
@@ -23,10 +23,7 @@ const MERKLE_CLAIM_ADDRESS = process.env.NEXT_PUBLIC_MERKLE_CLAIM_ADDRESS;
 const FINAL_BURN_TX = process.env.NEXT_PUBLIC_AIRDROP_FINAL_BURN_TX;
 const FINAL_STATE = process.env.NEXT_PUBLIC_AIRDROP_FINAL_STATE as "sub_bronze" | "zero_recipient" | undefined;
 
-function deriveState(
-  isConnected: boolean,
-  activatedAt: string | null,
-): AirdropState {
+function deriveState(isConnected: boolean, activatedAt: string | null): AirdropState {
   if (IS_PAUSED) return "paused";
   if (MERKLE_CLAIM_ADDRESS) return "settlement-normal";
   if (FINAL_BURN_TX) return "settlement-final-burn";
@@ -36,12 +33,48 @@ function deriveState(
 
 const needsFetch = !IS_PAUSED && !MERKLE_CLAIM_ADDRESS && !FINAL_BURN_TX;
 
+function HeroBlock({ isConnected, onActivate }: { isConnected: boolean; onActivate: () => void }) {
+  const { openConnectModal } = useConnectModal();
+
+  return (
+    <div className="py-10 text-center space-y-5">
+      <h1 className="font-[var(--font-display)] text-3xl leading-tight sm:text-4xl">
+        The airdrop pool<br />
+        <span className="bg-gradient-to-r from-[var(--gold-1)] to-[var(--gold-2)] bg-clip-text text-transparent">grows with us.</span><br />
+        <span className="text-[var(--burn)] italic">Or it burns.</span>
+      </h1>
+      <p className="text-[var(--muted)] text-sm">Buy storyline tokens &middot; Bring friends &middot; Push PLOT together</p>
+      {!isConnected ? (
+        <button
+          onClick={() => openConnectModal?.()}
+          className="bg-[var(--accent)] text-[var(--bg)] rounded px-6 py-2.5 text-sm font-medium transition-opacity hover:opacity-80"
+        >
+          Activate to join the Sprint
+        </button>
+      ) : (
+        <button
+          onClick={onActivate}
+          className="bg-[var(--accent)] text-[var(--bg)] rounded px-6 py-2.5 text-sm font-medium transition-opacity hover:opacity-80"
+        >
+          Activate to join the Sprint
+        </button>
+      )}
+      <p className="text-[var(--muted)] text-xs">One signature + a few clicks. ~2 min.</p>
+    </div>
+  );
+}
+
 export function AirdropStateMachine() {
   const { address, isConnected } = useAccount();
   const [fetchResult, setFetchResult] = useState<{ activatedAt: string | null; done: boolean }>({ activatedAt: null, done: !needsFetch });
+  const activationRef = useRef<HTMLDivElement>(null);
 
   const onActivated = useCallback(() => {
     setFetchResult({ activatedAt: new Date().toISOString(), done: true });
+  }, []);
+
+  const scrollToActivation = useCallback(() => {
+    activationRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   }, []);
 
   useEffect(() => {
@@ -57,14 +90,13 @@ export function AirdropStateMachine() {
 
   const activatedAt = (needsFetch && isConnected) ? fetchResult.activatedAt : null;
   const loading = needsFetch && isConnected && !fetchResult.done;
-
   const state = deriveState(isConnected, activatedAt);
 
   if (state === "paused") {
     return (
-      <div className="border-border mt-8 rounded border p-8 text-center">
-        <h2 className="text-accent mb-2 text-sm font-bold uppercase tracking-wider">Campaign Paused</h2>
-        <p className="text-muted text-sm">Campaign temporarily paused. Will resume shortly.</p>
+      <div className="border-[var(--border)] mt-8 rounded border p-8 text-center">
+        <h2 className="text-[var(--accent)] mb-2 text-sm font-bold uppercase tracking-wider">Campaign Paused</h2>
+        <p className="text-[var(--muted)] text-sm">Campaign temporarily paused. Will resume shortly.</p>
       </div>
     );
   }
@@ -73,9 +105,7 @@ export function AirdropStateMachine() {
     return (
       <>
         <CampaignHero />
-        <div className="mt-8">
-          <ClaimPanel />
-        </div>
+        <div className="mt-8"><ClaimPanel /></div>
       </>
     );
   }
@@ -84,9 +114,7 @@ export function AirdropStateMachine() {
     return (
       <>
         <CampaignHero />
-        <div className="mt-8">
-          <ClaimCard mode="final-burn" finalState={FINAL_STATE ?? null} />
-        </div>
+        <div className="mt-8"><ClaimCard mode="final-burn" finalState={FINAL_STATE ?? null} /></div>
       </>
     );
   }
@@ -95,9 +123,7 @@ export function AirdropStateMachine() {
     return (
       <>
         <CampaignHero />
-        <div className="mt-8 text-center">
-          <p className="text-muted text-sm">Loading...</p>
-        </div>
+        <div className="mt-8 text-center"><p className="text-[var(--muted)] text-sm">Loading...</p></div>
       </>
     );
   }
@@ -106,32 +132,27 @@ export function AirdropStateMachine() {
     return (
       <>
         <CampaignHero />
-        <div className="mt-8 space-y-4">
-          {!isConnected ? (
-            <div className="border-border rounded border p-8 text-center space-y-3">
-              <p className="text-muted text-sm">Connect your wallet to get started.</p>
-              <Link href="/" className="text-accent text-xs hover:underline">
-                Browse storylines &rarr;
-              </Link>
-            </div>
-          ) : (
+        <HeroBlock isConnected={isConnected} onActivate={scrollToActivation} />
+        {isConnected && (
+          <div ref={activationRef}>
             <ActivationFlow onActivated={onActivated} />
-          )}
+          </div>
+        )}
+        <div className="mt-6">
           <MilestoneClimb dimmed />
         </div>
       </>
     );
   }
 
+  // mining
   return (
     <>
       <CampaignHero />
       <div className="mt-8 space-y-4">
         <ContributionPanel />
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-          <ReferralCTA />
-          <MilestoneClimb />
-        </div>
+        <MilestoneClimb />
+        <ReferralCTA />
       </div>
     </>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,6 +14,8 @@
   --success:       oklch(45% 0.14 145);
   --burn:          oklch(50% 0.20 25);
   --dist:          oklch(45% 0.16 145);
+  --gold-1:        #FFE07A;
+  --gold-2:        #D9A847;
 
   --font-display: 'Newsreader', 'Iowan Old Style', Georgia, serif;
   --font-body:    -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;

--- a/src/components/airdrop/MilestoneClimb.tsx
+++ b/src/components/airdrop/MilestoneClimb.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useAccount } from "wagmi";
 
 interface StatusData {
   currentFdv: number;
+  latestPriceUsd: number | null;
+  poolAmount: number;
   milestones: {
     bronze: { mcap: number; pct: number; reached: boolean };
     silver: { mcap: number; pct: number; reached: boolean };
@@ -13,136 +14,155 @@ interface StatusData {
   };
 }
 
-interface ProjectionData {
-  projected_share: { bronze: number; silver: number; gold: number; diamond: number };
-}
-
 interface MilestoneClimbProps {
   dimmed?: boolean;
 }
 
-const TIERS = ["bronze", "silver", "gold", "diamond"] as const;
-const TIER_LABELS: Record<typeof TIERS[number], string> = {
-  bronze: "Bronze",
-  silver: "Silver",
-  gold: "Gold",
-  diamond: "Diamond",
-};
+const TIERS = [
+  { key: "bronze", emoji: "\u{1F949}", label: "Bronze", cx: 140, cy: 164 },
+  { key: "silver", emoji: "\u{1F948}", label: "Silver", cx: 260, cy: 125 },
+  { key: "gold", emoji: "\u{1F947}", label: "Gold", cx: 400, cy: 55 },
+  { key: "diamond", emoji: "\u{1F48E}", label: "Diamond", cx: 530, cy: 18 },
+] as const;
 
 function formatMcap(n: number): string {
-  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(0)}M`;
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `$${(n / 1_000).toFixed(0)}K`;
   return `$${n}`;
 }
 
+function formatPool(n: number): string {
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(0)}K`;
+  if (n >= 1) return `$${Math.round(n)}`;
+  return "$0";
+}
+
+function interpolateFdvX(fdv: number, milestones: StatusData["milestones"]): number {
+  const mcaps = [milestones.bronze.mcap, milestones.silver.mcap, milestones.gold.mcap, milestones.diamond.mcap];
+  const xs = [140, 260, 400, 530];
+
+  if (fdv <= 0) return 30;
+  if (fdv >= mcaps[3]) return 530;
+
+  const logFdv = Math.log10(fdv);
+  const logMin = Math.log10(mcaps[0] * 0.1);
+
+  for (let i = 0; i < mcaps.length; i++) {
+    if (fdv <= mcaps[i]) {
+      const prevX = i === 0 ? 30 : xs[i - 1];
+      const prevLog = i === 0 ? logMin : Math.log10(mcaps[i - 1]);
+      const curLog = Math.log10(mcaps[i]);
+      const t = (logFdv - prevLog) / (curLog - prevLog);
+      return prevX + t * (xs[i] - prevX);
+    }
+  }
+  return 530;
+}
+
+function interpolateFdvY(x: number): number {
+  const points = [[30, 175], [140, 164], [260, 125], [400, 55], [530, 18]];
+  for (let i = 1; i < points.length; i++) {
+    if (x <= points[i][0]) {
+      const t = (x - points[i - 1][0]) / (points[i][0] - points[i - 1][0]);
+      return points[i - 1][1] + t * (points[i][1] - points[i - 1][1]);
+    }
+  }
+  return 18;
+}
+
 export function MilestoneClimb({ dimmed }: MilestoneClimbProps) {
-  const { address, isConnected } = useAccount();
   const [status, setStatus] = useState<StatusData | null>(null);
-  const [projection, setProjection] = useState<ProjectionData | null>(null);
 
   useEffect(() => {
     fetch("/api/airdrop/status")
       .then(r => r.ok ? r.json() : null)
-      .then(d => setStatus(d))
+      .then(d => { if (d) setStatus(d); })
       .catch(() => {});
   }, []);
 
-  useEffect(() => {
-    if (!isConnected || !address || dimmed) return;
-    fetch(`/api/airdrop/projection?address=${address.toLowerCase()}`)
-      .then(r => r.ok ? r.json() : null)
-      .then(d => setProjection(d))
-      .catch(() => {});
-  }, [isConnected, address, dimmed]);
-
   if (!status) {
     return (
-      <div className="border-border rounded border p-4">
-        <h3 className="text-accent mb-1 text-xs font-bold uppercase tracking-wider">Milestone Climb</h3>
-        <p className="text-muted text-xs">Loading...</p>
+      <div className="border-[var(--border)] rounded border p-4">
+        <p className="text-[var(--muted)] text-xs">Loading milestone chart...</p>
       </div>
     );
   }
 
-  const { milestones, currentFdv } = status;
-  const tierData = TIERS.map(tier => ({
-    key: tier,
-    label: TIER_LABELS[tier],
-    mcap: milestones[tier].mcap,
-    pct: milestones[tier].pct,
-    reached: milestones[tier].reached,
-    share: projection?.projected_share[tier] ?? 0,
-  }));
+  const { milestones, currentFdv, latestPriceUsd, poolAmount } = status;
+  const plotPrice = latestPriceUsd ?? 0;
 
-  const minMcap = tierData[0].mcap;
-  const maxMcap = tierData[tierData.length - 1].mcap;
-  const logMin = Math.log10(minMcap * 0.5);
-  const logMax = Math.log10(maxMcap * 1.5);
-  const logRange = logMax - logMin;
+  const tierData = TIERS.map(t => {
+    const m = milestones[t.key as keyof typeof milestones];
+    return {
+      ...t,
+      mcap: m.mcap,
+      pct: m.pct,
+      reached: m.reached,
+      poolUsd: (poolAmount * m.pct / 100) * plotPrice,
+    };
+  });
 
-  const svgW = 300;
-  const svgH = 160;
-  const padX = 40;
-  const padY = 20;
-  const chartW = svgW - padX * 2;
-  const chartH = svgH - padY * 2;
-
-  function xPos(mcap: number) {
-    const logVal = Math.log10(Math.max(mcap, 1));
-    const normalized = Math.max(0, Math.min(1, (logVal - logMin) / logRange));
-    return padX + normalized * chartW;
-  }
-
-  const fdvX = xPos(currentFdv);
-  const lineY = padY + chartH * 0.5;
+  const fdvX = interpolateFdvX(currentFdv, milestones);
+  const fdvY = interpolateFdvY(fdvX);
 
   return (
-    <div className={`border-border rounded border p-4 ${dimmed ? "opacity-40" : ""}`}>
-      <h3 className="text-accent mb-3 text-xs font-bold uppercase tracking-wider">Milestone Climb</h3>
+    <div className={`border-[var(--border)] rounded border p-5 ${dimmed ? "opacity-50" : ""}`}>
+      <div className="relative">
+        <svg viewBox="0 0 560 200" className="w-full" style={{ maxHeight: 220 }}>
+          <defs>
+            <linearGradient id="gold-grad" x1="0" y1="1" x2="1" y2="0">
+              <stop offset="0%" stopColor="var(--gold-1)" />
+              <stop offset="100%" stopColor="var(--gold-2)" />
+            </linearGradient>
+            <linearGradient id="gold-area-grad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--gold-1)" stopOpacity="0.25" />
+              <stop offset="100%" stopColor="var(--gold-1)" stopOpacity="0.03" />
+            </linearGradient>
+          </defs>
 
-      <svg viewBox={`0 0 ${svgW} ${svgH}`} className="w-full" style={{ maxHeight: 180 }}>
-        {/* Baseline */}
-        <line x1={padX} y1={lineY} x2={svgW - padX} y2={lineY} stroke="var(--border)" strokeWidth={1} />
+          <path
+            d="M30,175 C80,172 140,165 200,148 C260,125 340,85 420,50 C460,35 500,22 540,15 L540,180 L30,180 Z"
+            fill="url(#gold-area-grad)"
+          />
+          <path
+            d="M30,175 C80,172 140,165 200,148 C260,125 340,85 420,50 C460,35 500,22 540,15"
+            fill="none"
+            stroke="url(#gold-grad)"
+            strokeWidth="2.5"
+          />
 
-        {/* Tier nodes */}
-        {tierData.map(t => {
-          const cx = xPos(t.mcap);
-          return (
+          {tierData.map(t => (
             <g key={t.key}>
-              <line x1={cx} y1={lineY - 8} x2={cx} y2={lineY + 8} stroke="var(--border)" strokeWidth={1} strokeDasharray="2,2" />
-              <circle
-                cx={cx}
-                cy={lineY}
-                r={6}
-                fill={t.reached ? "var(--accent)" : "var(--bg)"}
-                stroke={t.reached ? "var(--accent)" : "var(--border)"}
-                strokeWidth={1.5}
-              />
-              <text x={cx} y={lineY - 14} textAnchor="middle" fill="var(--muted)" fontSize={8}>
-                {t.label}
-              </text>
-              <text x={cx} y={lineY + 22} textAnchor="middle" fill="var(--muted)" fontSize={7}>
-                {formatMcap(t.mcap)}
-              </text>
-              {!dimmed && t.share > 0 && (
-                <text x={cx} y={lineY + 34} textAnchor="middle" fill="var(--accent)" fontSize={7}>
-                  {Math.round(t.share).toLocaleString()} PLOT
-                </text>
-              )}
+              <line x1={t.cx} y1={t.cy} x2={t.cx} y2={180} stroke="var(--border)" strokeWidth="1" strokeDasharray="3,3" />
+              <circle cx={t.cx} cy={t.cy} r={t.reached ? 8 : 6} fill={t.reached ? "var(--gold-2)" : "var(--bg)"} stroke="var(--gold-2)" strokeWidth="1.5" />
+              <text x={t.cx} y={t.cy - 14} textAnchor="middle" fontSize="14">{t.emoji}</text>
             </g>
-          );
-        })}
+          ))}
 
-        {/* Current FDV marker */}
-        <line x1={fdvX} y1={lineY - 16} x2={fdvX} y2={lineY + 16} stroke="var(--accent)" strokeWidth={1.5} />
-        <polygon
-          points={`${fdvX - 4},${lineY - 18} ${fdvX + 4},${lineY - 18} ${fdvX},${lineY - 12}`}
-          fill="var(--accent)"
-        />
-        <text x={fdvX} y={lineY + 46} textAnchor="middle" fill="var(--accent)" fontSize={8} fontWeight="bold">
-          {formatMcap(currentFdv)}
-        </text>
-      </svg>
+          <circle cx={fdvX} cy={fdvY} r="5" fill="var(--accent)" opacity="0.9">
+            <animate attributeName="r" values="4;7;4" dur="2s" repeatCount="indefinite" />
+            <animate attributeName="opacity" values="0.9;0.4;0.9" dur="2s" repeatCount="indefinite" />
+          </circle>
+        </svg>
+
+        <div
+          className="absolute text-[10px] font-bold text-[var(--accent)]"
+          style={{ left: `${(fdvX / 560) * 100}%`, top: "0", transform: "translateX(-50%)" }}
+        >
+          TODAY {formatMcap(currentFdv)}
+        </div>
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {tierData.map(t => (
+          <div key={t.key} className="space-y-0.5">
+            <div className="text-[var(--fg)] text-xs font-medium">{t.emoji} {t.label}</div>
+            <div className="text-[var(--muted)] font-mono text-[10px]">{formatMcap(t.mcap)}</div>
+            <div className="text-[var(--muted)] text-[10px]">&rarr; ~{formatPool(t.poolUsd)} pool</div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Visual redesign to match `z-design/plotlink-airdrop-final.html`:

### Hero block (pre-activation)
- 3-line headline: "The airdrop pool / **grows with us.** (gold gradient) / *Or it burns.* (italic burn red)"
- Sub: "Buy storyline tokens · Bring friends · Push PLOT together"
- CTA: "Activate to join the Sprint" — connects wallet (if disconnected) or scrolls to ActivationFlow
- Fine print: "One signature + a few clicks. ~2 min."

### MilestoneClimb rising curve
- SVG `viewBox="0 0 560 200"` with Bezier path matching spec
- Gold area-fill gradient (`gold-1 → gold-2`)
- 4 emoji tier circles at spec positions (Bronze 164, Silver 125, Gold 55, Diamond 18)
- Dashed droplines from tier circles to baseline
- Pulsing dot at real `currentFdv` x-position (log-interpolated)
- "TODAY $X" label at pulse-dot position

### Labels grid
- 4-column grid below chart: emoji + tier name + mcap + pool USD
- Pool size = `poolAmount × tier.pct/100 × latestPriceUsd` — all from `/api/airdrop/status`

### No mocks
All values from `/api/airdrop/status` real response. No hardcoded "$420K" or "$2K pool".

## CSS additions
`--gold-1: #FFE07A` + `--gold-2: #D9A847` in globals.css

## Version
1.40.5 → 1.41.0 (feature)

Closes #1306

🤖 Generated with [Claude Code](https://claude.com/claude-code)