### PR TITLE
[#1304] Add TWAP minimum samples validation

### DIFF
--- a/docs/airdrop-contracts.md
+++ b/docs/airdrop-contracts.md
@@ -43,3 +43,15 @@ forge script contracts/script/DeployMerkleClaim.s.sol \
   --broadcast \
   --private-key $DEPLOYER_PRIVATE_KEY
 ```
+
+## Settlement (finalize)
+
+```bash
+npx tsx scripts/airdrop-finalize.ts [--dry-run]
+```
+
+Emergency override for partial TWAP data (<5 daily price samples):
+
+```bash
+AIRDROP_FINALIZE_ALLOW_PARTIAL_TWAP=1 npx tsx scripts/airdrop-finalize.ts
+```

--- a/lib/airdrop/twap.test.ts
+++ b/lib/airdrop/twap.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { validateTwapSamples } from "./twap";
+
+describe("validateTwapSamples", () => {
+  it("rejects 0 samples", () => {
+    const result = validateTwapSamples(0, false);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("No daily price entries");
+  });
+
+  it("rejects 1 sample without override", () => {
+    const result = validateTwapSamples(1, false);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("requires >=5");
+  });
+
+  it("rejects 4 samples without override", () => {
+    const result = validateTwapSamples(4, false);
+    expect(result.ok).toBe(false);
+  });
+
+  it("allows 1 sample with override", () => {
+    const result = validateTwapSamples(1, true);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.warning).toBeDefined();
+  });
+
+  it("allows 5 samples with warning", () => {
+    const result = validateTwapSamples(5, false);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.warning).toContain("5 samples");
+  });
+
+  it("allows 6 samples with warning", () => {
+    const result = validateTwapSamples(6, false);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.warning).toContain("6 samples");
+  });
+
+  it("allows 7 samples cleanly (no warning)", () => {
+    const result = validateTwapSamples(7, false);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.warning).toBeUndefined();
+  });
+});

--- a/lib/airdrop/twap.ts
+++ b/lib/airdrop/twap.ts
@@ -1,0 +1,27 @@
+export const EXPECTED_SAMPLES = 7;
+export const MINIMUM_SAMPLES = 5;
+export const OVERRIDE_ENV = "AIRDROP_FINALIZE_ALLOW_PARTIAL_TWAP";
+
+export function validateTwapSamples(
+  count: number,
+  overrideEnabled: boolean,
+): { ok: true; warning?: string } | { ok: false; error: string } {
+  if (count === 0) {
+    return { ok: false, error: "No daily price entries found for TWAP window" };
+  }
+  if (count < MINIMUM_SAMPLES && !overrideEnabled) {
+    return {
+      ok: false,
+      error:
+        `TWAP requires >=${MINIMUM_SAMPLES} daily samples, got ${count}. ` +
+        `Investigate pl_daily_prices cron coverage OR set ${OVERRIDE_ENV}=1 to proceed with partial data.`,
+    };
+  }
+  if (count < EXPECTED_SAMPLES) {
+    return {
+      ok: true,
+      warning: `TWAP using ${count} samples (expected ${EXPECTED_SAMPLES}). Verify pl_daily_prices cron coverage.`,
+    };
+  }
+  return { ok: true };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink",
-  "version": "1.41.0",
+  "version": "1.41.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink",
-      "version": "1.41.0",
+      "version": "1.41.1",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink",
-  "version": "1.41.0",
+  "version": "1.41.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/scripts/airdrop-finalize.ts
+++ b/scripts/airdrop-finalize.ts
@@ -47,6 +47,20 @@ async function computeTwap(): Promise<number> {
   if (error) throw new Error(`Failed to fetch daily prices: ${error.message}`);
   if (!data || data.length === 0) throw new Error("No daily price entries found for TWAP window");
 
+  const EXPECTED_SAMPLES = 7;
+  const MINIMUM_SAMPLES = 5;
+  const OVERRIDE_ENV = "AIRDROP_FINALIZE_ALLOW_PARTIAL_TWAP";
+
+  if (data.length < MINIMUM_SAMPLES && process.env[OVERRIDE_ENV] !== "1") {
+    throw new Error(
+      `TWAP requires >=${MINIMUM_SAMPLES} daily samples, got ${data.length}. ` +
+      `Investigate pl_daily_prices cron coverage OR set ${OVERRIDE_ENV}=1 to proceed with partial data.`,
+    );
+  }
+  if (data.length < EXPECTED_SAMPLES) {
+    console.warn(`Warning: TWAP using ${data.length} samples (expected ${EXPECTED_SAMPLES}). Verify pl_daily_prices cron coverage.`);
+  }
+
   const sum = data.reduce((acc, row) => acc + Number(row.mcap_usd), 0);
   const twap = sum / data.length;
   console.log(`TWAP (${data.length} days): $${twap.toLocaleString()}`);

--- a/scripts/airdrop-finalize.ts
+++ b/scripts/airdrop-finalize.ts
@@ -20,6 +20,7 @@ import { StandardMerkleTree } from "@openzeppelin/merkle-tree";
 import { writeFileSync } from "fs";
 import { getAirdropConfig } from "../lib/airdrop/config";
 import { weightedSpendQuery } from "../lib/airdrop/sql";
+import { validateTwapSamples, OVERRIDE_ENV } from "../lib/airdrop/twap";
 
 const dryRun = process.argv.includes("--dry-run");
 
@@ -45,21 +46,13 @@ async function computeTwap(): Promise<number> {
     .lte("recorded_at", endDate.toISOString().slice(0, 10));
 
   if (error) throw new Error(`Failed to fetch daily prices: ${error.message}`);
-  if (!data || data.length === 0) throw new Error("No daily price entries found for TWAP window");
 
-  const EXPECTED_SAMPLES = 7;
-  const MINIMUM_SAMPLES = 5;
-  const OVERRIDE_ENV = "AIRDROP_FINALIZE_ALLOW_PARTIAL_TWAP";
-
-  if (data.length < MINIMUM_SAMPLES && process.env[OVERRIDE_ENV] !== "1") {
-    throw new Error(
-      `TWAP requires >=${MINIMUM_SAMPLES} daily samples, got ${data.length}. ` +
-      `Investigate pl_daily_prices cron coverage OR set ${OVERRIDE_ENV}=1 to proceed with partial data.`,
-    );
-  }
-  if (data.length < EXPECTED_SAMPLES) {
-    console.warn(`Warning: TWAP using ${data.length} samples (expected ${EXPECTED_SAMPLES}). Verify pl_daily_prices cron coverage.`);
-  }
+  const validation = validateTwapSamples(
+    data?.length ?? 0,
+    process.env[OVERRIDE_ENV] === "1",
+  );
+  if (!validation.ok) throw new Error(validation.error);
+  if (validation.warning) console.warn(`Warning: ${validation.warning}`);
 
   const sum = data.reduce((acc, row) => acc + Number(row.mcap_usd), 0);
   const twap = sum / data.length;


### PR DESCRIPTION
## Summary
- Finalize script now requires >=5 daily price samples for 7-day TWAP calculation
- <5 samples → throws with clear error message (no silent single-sample TWAP)
- 5-6 samples → warns but proceeds (defensible TWAP)
- 7 samples → clean (expected)
- Emergency override: `AIRDROP_FINALIZE_ALLOW_PARTIAL_TWAP=1` env var for operator to proceed with partial data

## Version
1.41.0 → 1.41.1

Closes #1304

🤖 Generated with [Claude Code](https://claude.com/claude-code)